### PR TITLE
Fix: "When I switch wallets the ens image from the old wallet is not removed"

### DIFF
--- a/src/components/shared/ENSAvatar.jsx
+++ b/src/components/shared/ENSAvatar.jsx
@@ -45,7 +45,11 @@ export default function ENSAvatar({ ensName, className = "" }) {
     if (data) {
       setAvatar(data);
     }
-  }, [data]);
+    // Set the default avatar when wallet is change from a ensName wallet to a non ensName wallet
+    if (!data && !ensName) {
+      setAvatar(altAvatar);
+    }
+  }, [altAvatar, data, ensName]);
 
   return (
     <div className={`${styles.ens_avatar} ${className}`}>


### PR DESCRIPTION
Here is the preview link: https://agora-next-omtf1vp6t-voteagora.vercel.app/