### PR TITLE
remove info icon for standard delegation

### DIFF
--- a/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
+++ b/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
@@ -111,8 +111,7 @@ export function DelegateDialog({
           >
             <VStack className={styles.amount_container}>
               <HStack alignItems="items-center" gap={1}>
-                Your total delegatable votes{" "}
-                <InfoIcon size={12} className="opacity-50" />
+                Your total delegatable votes
               </HStack>
               <AdvancedDelegationDisplayAmount amount={votingPower} />
             </VStack>


### PR DESCRIPTION
Removing the info icon for standard delegation. Following the old page pattern, also I think it does not make sense to have this icon with standard delegation.

Here is the preview link: https://agora-next-k675d77o0-voteagora.vercel.app/

This would solve this bug: https://linear.app/agora-app/issue/AGORA-1574/myprofile-delegate-pop-up-is-displayed-after-the-phrase-your-total

Info icon for advanced delegation is being solved here: https://github.com/voteagora/agora-next/pull/110
<img width="531" alt="Screenshot 2024-02-05 at 18 41 15" src="https://github.com/voteagora/agora-next/assets/29060919/a2a62569-9f25-4067-b08b-01dea3784237">
