### PR TITLE
Add tx hash explorer url to every vote

### DIFF
--- a/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalVotesList.tsx
+++ b/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalVotesList.tsx
@@ -9,6 +9,7 @@ import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import Image from "next/image";
 import { useAccount } from "wagmi";
 import { Vote } from "@/app/api/common/votes/vote";
+import BlockScanUrls from "@/components/shared/BlockScanUrl";
 
 type Props = {
   initialProposalVotes: {
@@ -124,7 +125,14 @@ export default function ApprovalProposalVotesList({
 
 function SingleVote({ vote }: { vote: Vote }) {
   const { address } = useAccount();
-  const { address: voterAddress, params, support, reason, weight } = vote;
+  const {
+    address: voterAddress,
+    params,
+    support,
+    reason,
+    weight,
+    transactionHash,
+  } = vote;
 
   return (
     <VStack className={""}>
@@ -166,6 +174,10 @@ function SingleVote({ vote }: { vote: Vote }) {
           </p>
         </div>
       )}
+      <BlockScanUrls
+        hash1={transactionHash}
+        text="View vote on block explorer"
+      />
     </VStack>
   );
 }

--- a/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalVotesList.tsx
+++ b/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalVotesList.tsx
@@ -133,6 +133,7 @@ function SingleVote({ vote }: { vote: Vote }) {
     weight,
     transactionHash,
   } = vote;
+  const [hash1, hash2] = transactionHash.split("|");
 
   return (
     <VStack className={""}>
@@ -174,10 +175,7 @@ function SingleVote({ vote }: { vote: Vote }) {
           </p>
         </div>
       )}
-      <BlockScanUrls
-        hash1={transactionHash}
-        text="View vote on block explorer"
-      />
+      <BlockScanUrls hash1={hash1} hash2={hash2} />
     </VStack>
   );
 }

--- a/src/components/shared/BlockScanUrl.tsx
+++ b/src/components/shared/BlockScanUrl.tsx
@@ -4,11 +4,9 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 export default function BlockScanUrls({
   hash1,
   hash2,
-  text,
 }: {
   hash1: string | undefined;
   hash2?: string | undefined;
-  text?: string | undefined;
 }) {
   return (
     <div className="pt-4 text-xs text-gray-4f">
@@ -40,7 +38,7 @@ export default function BlockScanUrls({
           rel="noreferrer noopener"
           className="flex flex-row items-center justify-between w-full hover:underline"
         >
-          <p>{text || "View transaction on block explorer"}</p>
+          <p>View transaction on block explorer</p>
           <ArrowTopRightOnSquareIcon className="w-4 h-4 ml-2" />
         </a>
       )}

--- a/src/components/shared/BlockScanUrl.tsx
+++ b/src/components/shared/BlockScanUrl.tsx
@@ -4,9 +4,11 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 export default function BlockScanUrls({
   hash1,
   hash2,
+  text,
 }: {
   hash1: string | undefined;
   hash2?: string | undefined;
+  text?: string | undefined;
 }) {
   return (
     <div className="pt-4 text-xs text-gray-4f">
@@ -38,7 +40,7 @@ export default function BlockScanUrls({
           rel="noreferrer noopener"
           className="flex flex-row items-center justify-between w-full hover:underline"
         >
-          <p>View transaction on block explorer</p>
+          <p>{text || "View transaction on block explorer"}</p>
           <ArrowTopRightOnSquareIcon className="w-4 h-4 ml-2" />
         </a>
       )}


### PR DESCRIPTION
Hi @yitongzhang , could you please take a look at adding the block explorer URL to every vote? From the issues/requests I have been handling from the community, this would be useful and help them easily find the tx they/others have done + the events. Honestly, for me, it will also be better since it will improve my productivity when looking for specific cases.

If this looks reasonable, I think we could also add a URL somewhere near the proposal that links to the proposal creation transaction.

Thank you!
<img width="492" alt="Screenshot 2024-02-15 at 13 46 33" src="https://github.com/voteagora/agora-next/assets/29060919/785f6f76-e30c-487e-9a98-b9b439ad4f6c">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new component `BlockScanUrls` to the `ApprovalProposalVotesList` component. 

### Detailed summary
- Added import statement for `BlockScanUrls` component
- Destructured `transactionHash` from the `vote` object
- Split `transactionHash` into `hash1` and `hash2`
- Rendered `BlockScanUrls` component with `hash1` and `hash2` as props

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->