### PR TITLE
Twitter Metadata Hotfix

### DIFF
--- a/src/app/delegates/[addressOrENSName]/page.tsx
+++ b/src/app/delegates/[addressOrENSName]/page.tsx
@@ -51,16 +51,22 @@ export async function generateMetadata(
   const preview = `/api/images/og/delegate?${imgParams.join(
     "&"
   )}&address=${address}&votes=${votes}`;
+  const title = `${address} on Agora`;
+  const description = `See what ${address} believes and how they vote on Optimism governance.`;
 
   return {
-    title: `${address} on Agora`,
-    description: `See what ${address} believes and how they vote on Optimism governance.`,
+    title: title,
+    description: description,
     openGraph: {
-      images: [preview],
+      images: preview,
     },
     other: {
-      "fc:frame": "vNext",
-      "fc:frame:image": preview,
+      ["twitter:card"]: "summary_large_image",
+      ["twitter:title"]: title,
+      ["twitter:description"]: description,
+      ["twitter:image"]: preview,
+      ["fc:frame"]: "vNext",
+      ["fc:frame:image"]: preview,
     },
   };
 }

--- a/src/app/delegates/page.jsx
+++ b/src/app/delegates/page.jsx
@@ -37,14 +37,20 @@ async function fetchDelegators(address) {
 
 export async function generateMetadata({}, parent) {
   const preview = `/api/images/og/delegates`;
+  const title = "Voter on Agora";
+  const description = "Delegate your voting power to a trusted representative";
 
   return {
-    title: "Voter on Agora",
-    description: "See which voters are active on Optimism governance.",
+    title: title,
+    description: description,
     openGraph: {
-      images: [preview],
+      images: preview,
     },
     other: {
+      ["twitter:card"]: "summary_large_image",
+      ["twitter:title"]: title,
+      ["twitter:description"]: description,
+      ["twitter:image"]: preview,
       ["fc:frame"]: "vNext",
       ["fc:frame:image"]: preview,
     },

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -39,14 +39,20 @@ async function fetchVotableSupply() {
 
 export async function generateMetadata({}, parent) {
   const preview = `/api/images/og/proposals`;
+  const title = "Optimism Agora";
+  const description = "Home of token house governance and RPGF";
 
   return {
-    title: "Optimism Agora",
-    description: "Home of token house governance and RPGF",
+    title: title,
+    description: description,
     openGraph: {
-      images: [preview],
+      images: preview,
     },
     other: {
+      ["twitter:card"]: "summary_large_image",
+      ["twitter:title"]: title,
+      ["twitter:description"]: description,
+      ["twitter:image"]: preview,
       ["fc:frame"]: "vNext",
       ["fc:frame:image"]: preview,
     },

--- a/src/app/proposals/[proposal_id]/page.jsx
+++ b/src/app/proposals/[proposal_id]/page.jsx
@@ -25,11 +25,15 @@ export async function generateMetadata({ params }, parent) {
 
   return {
     title: title,
-    description: cleanString(proposal.description),
+    description: description,
     openGraph: {
-      images: [preview],
+      images: preview,
     },
     other: {
+      ["twitter:card"]: "summary_large_image",
+      ["twitter:title"]: title,
+      ["twitter:description"]: description,
+      ["twitter:image"]: preview,
       ["fc:frame"]: "vNext",
       ["fc:frame:image"]: preview,
     },

--- a/src/app/retropgf/3/summary/page.tsx
+++ b/src/app/retropgf/3/summary/page.tsx
@@ -6,15 +6,21 @@ import Link from "next/link";
 
 export async function generateMetadata() {
   const preview = `/api/images/og/proposals`;
+  const title = "Agora - Optimism's RetroPGF Round 3 Summary";
+  const description =
+    "See which of your favourite projects were allocated in Optimism's RetroPGF Round 3.";
 
   return {
-    title: "Agora - Optimism's RetroPGF Round 3 Summary",
-    description:
-      "See which of your favourite projects were allocated in Optimism's RetroPGF Round 3.",
+    title: title,
+    description: description,
     openGraph: {
-      images: [preview],
+      images: preview,
     },
     other: {
+      ["twitter:card"]: "summary_large_image",
+      ["twitter:title"]: title,
+      ["twitter:description"]: description,
+      ["twitter:image"]: preview,
       ["fc:frame"]: "vNext",
       ["fc:frame:image"]: preview,
     },


### PR DESCRIPTION
I somehow completely spaced adding Twitter previews to the original metadata PR. 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the title and description metadata for various pages in the application. 

### Detailed summary:
- Updates the title and description metadata for the proposals page.
- Updates the title and description metadata for the home page.
- Updates the title and description metadata for the delegates page.
- Updates the title and description metadata for the delegate details page.
- Updates the title and description metadata for the RetroPGF summary page.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->