### PR TITLE
Small button UI fix

### DIFF
--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.module.scss
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.module.scss
@@ -23,7 +23,7 @@
 .proposal_votes_container {
   position: sticky;
   top: $spacing-20;
-  max-height: calc(100vh - 188px);
+  max-height: calc(100vh - 162px);
   flex-shrink: 0;
   width: $max-width-sm;
   background-color: $white;

--- a/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalPage.module.scss
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalPage.module.scss
@@ -12,7 +12,7 @@
 .proposal_votes_container {
   position: sticky;
   top: $spacing-20;
-  max-height: calc(100vh - 188px);
+  max-height: calc(100vh - 162px);
   flex-shrink: 0;
   width: $max-width-sm;
   background-color: $white;


### PR DESCRIPTION
Hi @yitongzhang here is the preview link: https://agora-next-qf4mnhbej-voteagora.vercel.app/

Before 
![image](https://github.com/voteagora/agora-next/assets/29060919/f48fc5da-aa37-4795-9d56-7c9528ff4c51)

Now (it will be the same when cast vote is displayed too)
<img width="474" alt="Screenshot 2024-02-17 at 11 51 40" src="https://github.com/voteagora/agora-next/assets/29060919/1d5677a3-8801-4b06-a3bd-a62af7ffc084">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR reduces the `max-height` of elements in `OPProposalPage` and `OPProposalApprovalPage` modules to improve layout consistency.

### Detailed summary
- Reduced `max-height` from `calc(100vh - 188px)` to `calc(100vh - 162px)` for better layout consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->