### PR TITLE
useSwitch network functionality done

### DIFF
--- a/src/app/Web3Provider.tsx
+++ b/src/app/Web3Provider.tsx
@@ -41,7 +41,7 @@ const config = createConfig(
 
 const Web3Provider: FC<PropsWithChildren<{}>> = ({ children }) => (
   <WagmiConfig config={config}>
-    <ConnectKitProvider>
+    <ConnectKitProvider options={{ enforceSupportedChains: false }}>
       <body className={inter.variable}>
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <BetaBanner />

--- a/src/components/Dialogs/DialogProvider/DialogProvider.tsx
+++ b/src/components/Dialogs/DialogProvider/DialogProvider.tsx
@@ -68,7 +68,9 @@ export const DialogProvider: FC<Props> = ({ children }) => {
     <DialogContext.Provider value={setCurrentDialog}>
       <Modal
         open={!!currentDialog}
-        onClose={() => setCurrentDialog(null)}
+        onClose={() =>
+          currentDialog?.type !== "SWITCH_NETWORK" && setCurrentDialog(null)
+        }
         transparent={(currentDialog as { transparent?: boolean })?.transparent}
       >
         {renderedDialog}

--- a/src/components/Dialogs/DialogProvider/dialogs.tsx
+++ b/src/components/Dialogs/DialogProvider/dialogs.tsx
@@ -1,5 +1,6 @@
 import { DialogDefinitions } from "./types";
 import { DelegateDialog } from "../DelegateDialog/DelegateDialog";
+import { SwitchNetwork } from "../SwitchNetworkDialog/SwitchNetworkDialog";
 import { CastProposalDialog } from "@/components/Proposals/ProposalCreation/CastProposalDialog";
 import {
   CastVoteDialog,
@@ -23,7 +24,8 @@ export type DialogType =
   | CastVoteDialogType
   | AdvancedDelegateDialogType
   | ApprovalCastVoteDialogType
-  | RetroPGFShareCardDialog;
+  | RetroPGFShareCardDialog
+  | SwithcNetworkDialogType;
 // | FaqDialogType
 
 export type DelegateDialogType = {
@@ -67,6 +69,13 @@ export type RetroPGFShareCardDialog = {
     displayName: string;
     id: string;
     profileImageUrl: string | null;
+  };
+};
+
+export type SwithcNetworkDialogType = {
+  type: "SWITCH_NETWORK";
+  params: {
+    chainId: number;
   };
 };
 
@@ -206,6 +215,9 @@ export const dialogs: DialogDefinitions<DialogType> = {
       />
     );
   },
+  SWITCH_NETWORK: ({ chainId }: { chainId: number }, closeDialog) => (
+    <SwitchNetwork chainId={chainId} closeDialog={closeDialog} />
+  ),
   // FAQ: () => {
   //   return <FaqDialog />;
   // },

--- a/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
+++ b/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
@@ -2,10 +2,6 @@ import { useNetwork, useSwitchNetwork } from "wagmi";
 import { Button } from "@/components/ui/button";
 import { useEffect } from "react";
 
-/**
- * Function openSwitchNetworks from connectkit should not work here since we need mainnet to resolve ENS names.
- * However, mainnet should not be allowed for other write transactions and therefore this component.
- */
 export function SwitchNetwork({
   chainId,
   closeDialog,

--- a/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
+++ b/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
@@ -1,5 +1,6 @@
-import { useSwitchNetwork } from "wagmi";
+import { useNetwork, useSwitchNetwork } from "wagmi";
 import { Button } from "@/components/ui/button";
+import { useEffect } from "react";
 
 /**
  * Function openSwitchNetworks from connectkit should not work here since we need mainnet to resolve ENS names.
@@ -12,13 +13,24 @@ export function SwitchNetwork({
   chainId: number;
   closeDialog: () => void;
 }) {
+  const chainIdMainnet = 1;
+  const { chain } = useNetwork();
   const { switchNetwork } = useSwitchNetwork();
+
+  useEffect(() => {
+    if (chain?.id !== chainIdMainnet) {
+      closeDialog();
+    }
+  }, [chain?.id, closeDialog]);
 
   return (
     <div className="flex flex-col gap-4">
+      <img src="/images/action-pending.svg" className="w-full" />
       <h1 className="text-2xl font-extrabold">Switch Networks</h1>
       <p>Wrong network detected, switch to Optimism to continue.</p>
       <Button
+        variant="outline"
+        className="font-bold"
         onClick={() => {
           switchNetwork?.(chainId);
           closeDialog();

--- a/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
+++ b/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
@@ -13,15 +13,14 @@ export function SwitchNetwork({
   chainId: number;
   closeDialog: () => void;
 }) {
-  const chainIdMainnet = 1;
   const { chain } = useNetwork();
   const { switchNetwork } = useSwitchNetwork();
 
   useEffect(() => {
-    if (chain?.id !== chainIdMainnet) {
+    if (chain?.id === chainId) {
       closeDialog();
     }
-  }, [chain?.id, closeDialog]);
+  }, [chain?.id, chainId, closeDialog]);
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
+++ b/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
@@ -1,0 +1,31 @@
+import { useSwitchNetwork } from "wagmi";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Function openSwitchNetworks from connectkit should not work here since we need mainnet to resolve ENS names.
+ * However, mainnet should not be allowed for other write transactions and therefore this component.
+ */
+export function SwitchNetwork({
+  chainId,
+  closeDialog,
+}: {
+  chainId: number;
+  closeDialog: () => void;
+}) {
+  const { switchNetwork } = useSwitchNetwork();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl font-extrabold">Switch Networks</h1>
+      <p>Wrong network detected, switch to Optimism to continue.</p>
+      <Button
+        onClick={() => {
+          switchNetwork?.(chainId);
+          closeDialog();
+        }}
+      >
+        Switch to Optimism
+      </Button>
+    </div>
+  );
+}

--- a/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
+++ b/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
@@ -30,7 +30,7 @@ export function SwitchNetwork({
       <p>Wrong network detected, switch to Optimism to continue.</p>
       <Button
         variant="outline"
-        className="font-bold"
+        className="font-bold cursor-pointer"
         onClick={() => {
           switchNetwork?.(chainId);
           closeDialog();

--- a/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
+++ b/src/components/Dialogs/SwitchNetworkDialog/SwitchNetworkDialog.tsx
@@ -30,7 +30,7 @@ export function SwitchNetwork({
       <p>Wrong network detected, switch to Optimism to continue.</p>
       <Button
         variant="outline"
-        className="font-bold cursor-pointer"
+        className="font-bold"
         onClick={() => {
           switchNetwork?.(chainId);
           closeDialog();

--- a/src/components/Header/ConnectButton.tsx
+++ b/src/components/Header/ConnectButton.tsx
@@ -2,12 +2,37 @@
 
 import { MobileConnectButton } from "./MobileConnectButton";
 import { DesktopConnectButton } from "./DesktopConnectButton";
+import { useNetwork } from "wagmi";
+import { Button } from "@/components/ui/button";
+import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
 
 export function ConnectButton() {
+  const chainIdOP = 10;
+  const { chain } = useNetwork();
+  const openDialog = useOpenDialog();
+
   return (
     <div>
-      <MobileConnectButton />
-      <DesktopConnectButton />
+      {chain?.id !== chainIdOP ? (
+        <Button
+          className="bg-red-700 hover:bg-red-600 text-xs sm:text-base p-2 sm:p-auto"
+          onClick={() =>
+            openDialog({
+              type: "SWITCH_NETWORK",
+              params: {
+                chainId: chainIdOP,
+              },
+            })
+          }
+        >
+          Wrong network
+        </Button>
+      ) : (
+        <>
+          <MobileConnectButton />
+          <DesktopConnectButton />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/Header/ConnectButton.tsx
+++ b/src/components/Header/ConnectButton.tsx
@@ -3,36 +3,33 @@
 import { MobileConnectButton } from "./MobileConnectButton";
 import { DesktopConnectButton } from "./DesktopConnectButton";
 import { useNetwork } from "wagmi";
-import { Button } from "@/components/ui/button";
 import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
+import { useEffect } from "react";
+import { useModal } from "connectkit";
 
 export function ConnectButton() {
+  const chainIdMainnet = 1;
   const chainIdOP = 10;
   const { chain } = useNetwork();
   const openDialog = useOpenDialog();
+  const { setOpen } = useModal();
+
+  useEffect(() => {
+    if (chain?.id === chainIdMainnet) {
+      setOpen(false);
+      openDialog({
+        type: "SWITCH_NETWORK",
+        params: {
+          chainId: chainIdOP,
+        },
+      });
+    }
+  }, [chain?.id, openDialog]);
 
   return (
     <div>
-      {chain?.id !== chainIdOP ? (
-        <Button
-          className="bg-red-700 hover:bg-red-600 text-xs sm:text-base p-2 sm:p-auto"
-          onClick={() =>
-            openDialog({
-              type: "SWITCH_NETWORK",
-              params: {
-                chainId: chainIdOP,
-              },
-            })
-          }
-        >
-          Wrong network
-        </Button>
-      ) : (
-        <>
-          <MobileConnectButton />
-          <DesktopConnectButton />
-        </>
-      )}
+      <MobileConnectButton />
+      <DesktopConnectButton />
     </div>
   );
 }

--- a/src/components/Header/ConnectButton.tsx
+++ b/src/components/Header/ConnectButton.tsx
@@ -5,26 +5,23 @@ import { DesktopConnectButton } from "./DesktopConnectButton";
 import { useNetwork } from "wagmi";
 import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
 import { useEffect } from "react";
-import { useModal } from "connectkit";
+import { OptimismContracts } from "@/lib/contracts/contracts";
 
 export function ConnectButton() {
-  const chainIdMainnet = 1;
-  const chainIdOP = 10;
+  const { chainId } = OptimismContracts.governor;
   const { chain } = useNetwork();
   const openDialog = useOpenDialog();
-  const { setOpen } = useModal();
 
   useEffect(() => {
-    if (chain?.id === chainIdMainnet) {
-      setOpen(false);
+    if (chain?.id && chain.id !== chainId) {
       openDialog({
         type: "SWITCH_NETWORK",
         params: {
-          chainId: chainIdOP,
+          chainId,
         },
       });
     }
-  }, [chain?.id, openDialog]);
+  }, [chain?.id, chainId, openDialog]);
 
   return (
     <div>


### PR DESCRIPTION
Preview link: https://agora-next-nogn2ql7x-voteagora.vercel.app/

This PR shows the button "Wrong Network" when user is not on OP chain:
<img width="1496" alt="Screenshot 2024-02-20 at 01 25 53" src="https://github.com/voteagora/agora-next/assets/29060919/d5c4424f-5d9b-4ebc-941a-c3cd66745d5a">
<img width="928" alt="Screenshot 2024-02-20 at 01 26 03" src="https://github.com/voteagora/agora-next/assets/29060919/3a391cda-1c6e-40a7-b85b-e88adf85b4da">

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to implement a switch network dialog feature for connecting to Optimism chain.

### Detailed summary
- Added `SwitchNetworkDialog` component for switching networks
- Updated `DialogProvider` to handle `SWITCH_NETWORK` type
- Implemented logic in `ConnectButton` to prompt network switch
- Defined `SwithcNetworkDialogType` in `dialogs.tsx`
- Utilized `useSwitchNetwork` and `useNetwork` hooks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->