### PR TITLE
Ferrodri/agora 1615 sometimes these two timestamps are out of sync

### DIFF
--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -5,7 +5,6 @@ export default function ProposalTimeStatus({
   proposalStatus,
   proposalEndTime,
 }) {
-  // TODO: frh -> WIP approval proposal dates are the same, check standard and add proposal times to optimistic
   switch (proposalStatus) {
     case "PENDING":
       return <HStack gap={1}>Voting</HStack>;

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -5,6 +5,7 @@ export default function ProposalTimeStatus({
   proposalStatus,
   proposalEndTime,
 }) {
+  // TODO: frh -> WIP approval proposal dates are the same, check standard and add proposal times to optimistic
   switch (proposalStatus) {
     case "PENDING":
       return <HStack gap={1}>Voting</HStack>;

--- a/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
@@ -11,11 +11,12 @@ import CastVoteInput from "@/components/Votes/CastVoteInput/CastVoteInput";
 import { getDelegate } from "@/app/api/delegates/getDelegates";
 import { getDelegateStatement } from "@/app/api/delegateStatement/getDelegateStatement";
 import { getVotableSupply } from "@/app/api/votableSupply/getVotableSupply";
-import { cn, formatNumber } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils";
 import { disapprovalThreshold } from "@/lib/constants";
 import { getCurrentDelegators } from "@/app/api/delegations/getDelegations";
 import OpManagerDeleteProposal from "./OpManagerDeleteProposal";
 import { formatUnits } from "ethers";
+import ProposalTimeStatus from "@/components/Proposals/Proposal/ProposalTimeStatus";
 
 async function fetchProposalVotes(proposal_id, page = 1) {
   "use server";
@@ -107,9 +108,7 @@ export default async function OPProposalPage({ proposal }) {
           <VStack gap={4} className={styles.proposal_actions_panel}>
             <div>
               <div className={styles.proposal_header}>Proposal votes</div>
-              <div
-                className={cn(styles.proposal_votes_summary_container, "!py-4")}
-              >
+              <div className={styles.proposal_votes_summary_container}>
                 {proposal.status === "CANCELLED" ? (
                   <p className="text-red-negative">
                     This proposal has been cancelled
@@ -134,6 +133,12 @@ export default async function OPProposalPage({ proposal }) {
                     </p>
                   </div>
                 )}
+                <HStack className="bg-gray-fa border-t -mx-4 px-4 py-2 text-gray-4f rounded-b-md justify-end font-medium">
+                  <ProposalTimeStatus
+                    proposalStatus={proposal.status}
+                    proposalEndTime={proposal.end_time}
+                  />
+                </HStack>
               </div>
             </div>
             {/* Show the scrolling list of votes for the proposal */}

--- a/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalPage.module.scss
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalPage.module.scss
@@ -28,7 +28,7 @@
   }
 
   .proposal_votes_summary_container {
-    padding: $spacing-2 $spacing-4 $spacing-3 $spacing-4;
+    padding: $spacing-4 $spacing-4 0 $spacing-4;
     border-radius: $border-radius-md;
     font-weight: $font-weight-bold;
     flex-shrink: 0;
@@ -36,6 +36,9 @@
     border: 1px solid $gray-300;
     margin: 0 $spacing-4;
     box-shadow: $box-shadow-newDefault;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
   }
 
   .proposal_actions_panel {

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -5,7 +5,6 @@ import ProposalVotesBar from "../ProposalVotesBar/ProposalVotesBar";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import { ParsedProposalResults } from "@/lib/proposalUtils";
-import { formatDistanceToNowStrict } from "date-fns";
 
 export default function ProposalVotesSummary({
   proposal,
@@ -82,22 +81,10 @@ export default function ProposalVotesSummary({
             )}
           </div>
           <div>
-            {proposal.end_time && proposal.status === "ACTIVE" && (
-              <HStack gap={1}>
-                <p>{`Ends in ${formatDistanceToNowStrict(
-                  proposal.end_time
-                )} at ${proposal.end_time.toLocaleTimeString("en-US")}`}</p>
-              </HStack>
-            )}
-            {proposal.end_time &&
-              proposal.status !== "PENDING" &&
-              proposal.status !== "ACTIVE" && (
-                <HStack gap={1}>
-                  <p>{`Ended ${formatDistanceToNowStrict(
-                    proposal.end_time
-                  )} ago on ${proposal.end_time.toLocaleDateString()}`}</p>
-                </HStack>
-              )}
+            <ProposalTimeStatus
+              proposalStatus={proposal.status}
+              proposalEndTime={proposal.end_time}
+            />
           </div>
         </HStack>
       </VStack>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -95,7 +95,7 @@ export default function ProposalVotesSummary({
                 <HStack gap={1}>
                   <p>{`Ended ${formatDistanceToNowStrict(
                     proposal.end_time
-                  )} ago on ${proposal.end_time}`}</p>
+                  )} ago on ${proposal.end_time.toLocaleDateString()}`}</p>
                 </HStack>
               )}
           </div>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -95,7 +95,7 @@ export default function ProposalVotesSummary({
                 <HStack gap={1}>
                   <p>{`Ended ${formatDistanceToNowStrict(
                     proposal.end_time
-                  )} ago on ${proposal.end_time.toLocaleDateString()}`}</p>
+                  )} ago on ${proposal.end_time}`}</p>
                 </HStack>
               )}
           </div>


### PR DESCRIPTION
Preview link: https://agora-next-ib05hvx1n-voteagora.vercel.app/

- Now all timestamps from home page and proposals page are the same (synced).
- I did add the time to optimistic proposals since it was not there on the proposals page.
<img width="473" alt="Screenshot 2024-02-20 at 12 40 56" src="https://github.com/voteagora/agora-next/assets/29060919/46adfdf6-13c4-4097-9fde-adca3cfcd78b">


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the styling and structure of the Proposal Page component.

### Detailed summary
- Updated padding and added flex properties in `proposal_votes_summary_container` in SCSS.
- Refactored time display logic in `ProposalVotesSummary.tsx`.
- Added `ProposalTimeStatus` component for time status display.
- Removed unused imports in `OPProposalOptimisticPage.jsx`.
- Added `ProposalTimeStatus` component in `OPProposalOptimisticPage.jsx` for time status display.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->