### PR TITLE
fix budgetTokensSpent and budgetAmount to have the same format in wei

### DIFF
--- a/src/components/Proposals/ProposalCreation/AddTransactionsDetails.tsx
+++ b/src/components/Proposals/ProposalCreation/AddTransactionsDetails.tsx
@@ -10,6 +10,7 @@ import InputBox from "@/components/shared/InputBox";
 import styles from "./styles.module.scss";
 import { MultiButtons } from "@/components/shared/MultiButtons";
 import SimulateTransaction from "@/components/shared/SimulateTransaction";
+import { formatEther, parseUnits } from "viem";
 
 export default function AddTransactionsDetails({
   form,
@@ -31,7 +32,7 @@ export default function AddTransactionsDetails({
                 target: "",
                 value: 0,
                 calldata: "",
-                transferAmount: 0,
+                transferAmount: 0n,
                 transferTo: "",
               },
             ],
@@ -118,11 +119,13 @@ export default function AddTransactionsDetails({
                     </label>
                     <InputBox
                       placeholder={"3 000 000 OP"}
-                      value={transaction.transferAmount}
+                      value={formatEther(transaction.transferAmount)}
                       type="number"
                       onChange={(next) =>
                         form.onChange.options(
-                          update(index, { transferAmount: next })
+                          update(index, {
+                            transferAmount: parseUnits(next, 18),
+                          })
                         )
                       }
                       required

--- a/src/components/Proposals/ProposalCreation/CreateProposalForm.tsx
+++ b/src/components/Proposals/ProposalCreation/CreateProposalForm.tsx
@@ -34,7 +34,7 @@ export type Transaction = {
   target: string;
   value: number;
   calldata: string;
-  transferAmount: number;
+  transferAmount: bigint;
   transferTo: string;
 };
 

--- a/src/components/Proposals/ProposalCreation/SubmitButton.tsx
+++ b/src/components/Proposals/ProposalCreation/SubmitButton.tsx
@@ -265,7 +265,7 @@ function getInputData(form: Form): {
   return { governorFunction, inputData, error };
 }
 
-function encodeTransfer(to: string, amount: number): string {
+function encodeTransfer(to: string, amount: bigint): string {
   return (
     "0xa9059cbb" +
     abiCoder


### PR DESCRIPTION
Preview link: https://agora-next-qj4miydna-voteagora.vercel.app/

Following this bug https://linear.app/agora-app/issue/AGORA-1600/bug-incorrect-budgettokensspent-in-approval-voting-options