### PR TITLE
Hardcode governance dates to start

### DIFF
--- a/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
+++ b/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
@@ -2,7 +2,7 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 
 export default function CurrentGovernanceStage() {
   const currentDate = new Date();
-  const targetDate = new Date(currentDate.getFullYear(), 2, 6);
+  const targetDate = new Date(currentDate.getFullYear(), 2, 6, 19);
   const differenceInMilliseconds = targetDate.getTime() - currentDate.getTime();
   const differenceInDays = Math.floor(
     differenceInMilliseconds / (1000 * 60 * 60 * 24)

--- a/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
+++ b/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
@@ -1,0 +1,31 @@
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
+
+export default function CurrentGovernanceStage() {
+  const currentDate = new Date();
+  const targetDate = new Date(currentDate.getFullYear(), 2, 6);
+  const differenceInMilliseconds = targetDate.getTime() - currentDate.getTime();
+  const differenceInDays = Math.floor(
+    differenceInMilliseconds / (1000 * 60 * 60 * 24)
+  );
+  return (
+    <div className="flex items-center justify-between bg-gray-fa text-gray-700 text-xs px-6 pt-2 pb-6 -mb-5 border border-gray-300 border-b-0 rounded-tl-2xl rounded-tr-2xl">
+      <div className="flex flex-col sm:flex-row">
+        <div className="flex">
+          <span className="hidden sm:block">Currently in&nbsp;</span>
+          <span>Voting Cycle #19 Voting Period</span>
+        </div>
+        <span className="hidden sm:block">&nbsp;·&nbsp;</span>
+        <span>Voting ends in around {differenceInDays + 1} days</span>
+      </div>
+      <a
+        href="https://calendar.google.com/calendar/embed?src=c_fnmtguh6noo6qgbni2gperid4k%40group.calendar.google.com"
+        target="_blank"
+        rel="noreferrer noopener"
+        className="flex items-center"
+      >
+        <p>View calendar</p>
+        <ArrowTopRightOnSquareIcon className="w-4 h-4 ml-1 sm:ml-2" />
+      </a>
+    </div>
+  );
+}

--- a/src/components/Proposals/ProposalsList/ProposalsList.jsx
+++ b/src/components/Proposals/ProposalsList/ProposalsList.jsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import InfiniteScroll from "react-infinite-scroller";
 import Proposal from "../Proposal/Proposal";
 import styles from "./proposalLists.module.scss";
+import CurrentGovernanceStage from "@/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage";
 
 export default function ProposalsList({
   initialProposals,
@@ -45,6 +46,7 @@ export default function ProposalsList({
         </div>
       </div>
 
+      <CurrentGovernanceStage />
       <VStack className={styles.proposals_table_container}>
         <div className={styles.proposals_table}>
           <InfiniteScroll

--- a/src/components/Proposals/ProposalsList/proposalLists.module.scss
+++ b/src/components/Proposals/ProposalsList/proposalLists.module.scss
@@ -4,6 +4,7 @@
   max-width: $max-width-6xl;
 
   .proposals_table_container {
+    background: white;
     border: 1px solid $gray-300;
     border-radius: $border-radius-xl;
     box-shadow: $box-shadow-newDefault;


### PR DESCRIPTION
Hi @yitongzhang I currently hardcoded this since the voting period starts tomorrow.

<img width="434" alt="Screenshot 2024-02-28 at 21 55 49" src="https://github.com/voteagora/agora-next/assets/29060919/f75426c1-e8e1-44d1-8524-8a018970b766">
<img width="1420" alt="Screenshot 2024-02-28 at 21 55 34" src="https://github.com/voteagora/agora-next/assets/29060919/16f44d34-ddaf-4aac-a36e-5bae5a14b506">

Let me know if it is what you were looking for and we can get it merged for tomorrow. This is the preview link: https://agora-next-an9wu96uz-voteagora.vercel.app/

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new component `CurrentGovernanceStage` to display voting cycle information and countdown.

### Detailed summary
- Added `CurrentGovernanceStage` component
- Displays current voting cycle and countdown
- Includes a link to view calendar

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->