### PR TITLE
Fix authority chains snaps -- use ordinal

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,10 +195,10 @@ view OptimismVoterStats {
 }
 
 view OptimismDelegatees {
-  delegator    String   @unique
+  delegator    String  @unique
   delegatee    String
   block_number BigInt
-  balance      Decimal  @db.Decimal
+  balance      Decimal @db.Decimal
 
   @@map("delegatees")
   @@schema("optimism")
@@ -346,7 +346,9 @@ view subdelegations_snaps {
   block_number         BigInt?
   balance              String?
   balance_block_number BigInt?
-  contract             String? @db.VarChar(42)
+  contract             String?  @db.VarChar(42)
+  ordinal              Decimal? @db.Decimal
+  balance_ordinal      Decimal? @db.Decimal
 
   @@ignore
   @@schema("optimism")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -317,6 +317,7 @@ view advanced_voting_power_raw_snaps {
   block_number        BigInt?
   proxy               String?
   contract            String?  @db.VarChar(42)
+  ordinal             Decimal? @db.Decimal
 
   @@ignore
   @@schema("optimism")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,6 +168,7 @@ view OptimismAuthorityChainsSnaps {
   balance_block_number BigInt
   allowance            Decimal  @db.Decimal
   contract             String?  @db.VarChar(42)
+  balance_ordinal      Decimal? @db.Decimal
 
   @@map("authority_chains_snaps")
   @@schema("optimism")
@@ -197,7 +198,9 @@ view subdelegations_snaps {
   block_number         BigInt?
   balance              String?
   balance_block_number BigInt?
-  contract             String? @db.VarChar(42)
+  contract             String?  @db.VarChar(42)
+  ordinal              Decimal? @db.Decimal
+  balance_ordinal      Decimal? @db.Decimal
 
   @@ignore
   @@schema("optimism")
@@ -299,6 +302,7 @@ view direct_chains_snaps {
   balance_block_number BigInt?
   allowance            Decimal? @db.Decimal
   contract             String?  @db.VarChar(42)
+  balance_ordinal      Decimal? @db.Decimal
 
   @@ignore
   @@schema("optimism")
@@ -345,6 +349,7 @@ view authority_chains_snaps_wrapper {
   balance_block_number BigInt?
   allowance            Decimal? @db.Decimal
   contract             String?  @db.VarChar(42)
+  balance_ordinal      Decimal? @db.Decimal
 
   @@ignore
   @@schema("optimism")
@@ -394,7 +399,8 @@ view subdelegation_events {
   from                String?
   subdelegation_rules String?
   block_number        BigInt?
-  contract            String? @db.VarChar(42)
+  contract            String?  @db.VarChar(42)
+  ordinal             Decimal? @db.Decimal
 
   @@ignore
   @@schema("optimism")
@@ -413,6 +419,7 @@ enum DaoSlug {
 
 enum Chain {
   optimism_mainnet @map("optimism-mainnet")
+  ethereum_mainnet @map("ethereum-mainnet")
 
   @@map("chain")
   @@schema("config")

--- a/src/app/api/common/authority-chains/getAuthorityChains.ts
+++ b/src/app/api/common/authority-chains/getAuthorityChains.ts
@@ -25,7 +25,7 @@ export async function getAuthorityChainsForNamespace({
     FROM ${namespace + ".authority_chains_snaps"} ac
     CROSS JOIN LATERAL (
       SELECT
-        MAX(balance_block_number) AS max_block_number
+        MAX(balance_ordinal) AS max_ordinal
       FROM ${namespace + ".authority_chains_snaps"}
       WHERE chain = ac.chain
         AND delegate = $1
@@ -34,7 +34,7 @@ export async function getAuthorityChainsForNamespace({
     ) AS max_blocks
     WHERE ac.delegate = $1
       AND ac.contract = $2
-      AND ac.balance_block_number = max_blocks.max_block_number
+      AND ac.balance_ordinal = max_blocks.max_ordinal
       AND ac.balance > 0
       AND ac.allowance > 0;
     `,

--- a/src/app/api/common/voting-power/getVotingPower.ts
+++ b/src/app/api/common/voting-power/getVotingPower.ts
@@ -100,7 +100,7 @@ async function getVotingPowerForProposalByAddress({
         WHERE chain_str=s.chain_str 
           AND contract = $2
           AND block_number <= $3
-        ORDER BY block_number DESC
+        ORDER BY ordinal DESC
         LIMIT 1
       ) AS a ON TRUE
     ) t


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update sorting criteria and introduce a new `balance_ordinal` field for better data organization.

### Detailed summary
- Updated sorting criteria from `block_number` to `ordinal` in queries
- Introducing `balance_ordinal` field in relevant database tables for improved data management

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->