### PR TITLE
Ferrodri/agora 1687 citizens with most voting power are not sorted correctly

### DIFF
--- a/src/app/api/common/citizens/getCitizens.ts
+++ b/src/app/api/common/citizens/getCitizens.ts
@@ -32,7 +32,7 @@ export async function getCitizensForNamespace({
       if (sort === "shuffle") {
         return prisma.$queryRawUnsafe<citizen[]>(
           `
-          SELECT address_metadata.address, address_metadata.metadata,
+          SELECT address_metadata.address, address_metadata.metadata, delegate.voting_power
           FROM agora.address_metadata address_metadata
           LEFT JOIN ${namespace + ".delegates"
           } delegate ON LOWER(address_metadata.address) = LOWER(delegate.delegate)

--- a/src/app/api/common/citizens/getCitizens.ts
+++ b/src/app/api/common/citizens/getCitizens.ts
@@ -32,10 +32,9 @@ export async function getCitizensForNamespace({
       if (sort === "shuffle") {
         return prisma.$queryRawUnsafe<citizen[]>(
           `
-          SELECT address_metadata.address, address_metadata.metadata, delegate.voting_power
+          SELECT address_metadata.address, address_metadata.metadata,
           FROM agora.address_metadata address_metadata
-          LEFT JOIN ${
-            namespace + ".delegates"
+          LEFT JOIN ${namespace + ".delegates"
           } delegate ON LOWER(address_metadata.address) = LOWER(delegate.delegate)
           WHERE address_metadata.kind = 'citizen' 
           AND address_metadata.dao_slug = 'OP'
@@ -52,12 +51,11 @@ export async function getCitizensForNamespace({
           `
             SELECT address_metadata.address, address_metadata.metadata, delegate.voting_power
             FROM agora.address_metadata address_metadata
-            LEFT JOIN ${
-              namespace + ".delegates"
-            } delegate ON LOWER(address_metadata.address) = LOWER(delegate.delegate)
+            LEFT JOIN ${namespace + ".delegates"
+          } delegate ON LOWER(address_metadata.address) = LOWER(delegate.delegate)
             WHERE address_metadata.kind = 'citizen' 
             AND address_metadata.dao_slug = 'OP'
-            ORDER BY delegate.voting_power DESC
+            ORDER BY COALESCE(delegate.voting_power, 0) DESC
             OFFSET $1
             LIMIT $2;
           `,

--- a/src/app/api/common/citizens/getCitizens.ts
+++ b/src/app/api/common/citizens/getCitizens.ts
@@ -55,7 +55,8 @@ export async function getCitizensForNamespace({
           } delegate ON LOWER(address_metadata.address) = LOWER(delegate.delegate)
             WHERE address_metadata.kind = 'citizen' 
             AND address_metadata.dao_slug = 'OP'
-            ORDER BY COALESCE(delegate.voting_power, 0) DESC
+            ORDER BY COALESCE(delegate.voting_power, 0) DESC,
+            address_metadata.address ASC 
             OFFSET $1
             LIMIT $2;
           `,


### PR DESCRIPTION
LGTM! https://agora-next-iafm8xp10-voteagora.vercel.app/delegates?tab=citizens&citizensOrderBy=mostVotingPower

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the query logic in `getCitizens.ts` for fetching citizen data by sorting citizens by `voting_power` in descending order and then by `address` in ascending order.

### Detailed summary
- Updated the query to order citizens by `voting_power` in descending order and `address` in ascending order.
- Used `COALESCE` to handle null values in `voting_power`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->