### PR TITLE
[WIP] 🛠️ Allow concurrent execution of delegate query

### DIFF
--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -158,7 +158,7 @@ export async function getDelegateForNamespace({
 
   const [delegate, votableSupply, delegateStatement, quorum, _isCitizen] =
     await Promise.all([
-      (await delegateQuery)?.[0] || undefined,
+      delegateQuery.then(result => result?.[0] || undefined),
       prisma[`${namespace}VotableSupply`].findFirst({}),
       getDelegateStatement({ addressOrENSName }),
       getCurrentQuorum(),


### PR DESCRIPTION
~~TODO: test locally~~ Tested on preview branch for correctness manually
~~TODO: instrument dynamo calls~~ this will come as a separate PR/ workitem
~~TODO: measure impact~~ Screenshot supplied. Seems that this has an effect from the before and after, but further optimizations are probably needed; there are queries taking ~6s as reported from our prisma logging middleware

![image](https://github.com/voteagora/agora-next/assets/13227294/a3a07675-402e-4cb8-b4cd-885bd35ddc00)
^ marked improvement according to vercel speed insights

![image](https://github.com/voteagora/agora-next/assets/13227294/83d1c75a-d02c-478d-8f4a-705d4b41c733)

![image](https://github.com/voteagora/agora-next/assets/13227294/074cecbb-11ce-466b-9862-01cd2c679cd0)

^ one particular query is taking ~6s to complete for the same delegate on prod and preview, we should tackle this one next.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `getDelegates` function to use `delegateQuery` with a `then` method instead of `await`, improving code readability and efficiency.

### Detailed summary
- Refactored `delegateQuery` usage to use `then` method for better readability
- Improved code efficiency by using `delegateQuery.then` instead of `await`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->