### PR TITLE
Ferrodri/agora 1688 display exact date in proposals

### DIFF
--- a/src/components/Proposals/NeedsMyVoteProposalsList/NeedsMyVoteProposalsList.jsx
+++ b/src/components/Proposals/NeedsMyVoteProposalsList/NeedsMyVoteProposalsList.jsx
@@ -31,8 +31,6 @@ export default function NeedsMyVoteProposalsList({
     getProposals();
   }, [getProposals, address]);
 
-  console.log(proposals);
-
   return (
     <>
       {isConnected && proposals.length > 0 && (

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -5,16 +5,25 @@ export default function ProposalTimeStatus({
   proposalStatus,
   proposalEndTime,
 }) {
+  const options = {
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    timeZoneName: "short",
+  };
+
+  const activeProposalEndTime = new Intl.DateTimeFormat(
+    "en-US",
+    options
+  ).format(proposalEndTime);
+
   switch (proposalStatus) {
     case "PENDING":
       return <HStack gap={1}>Voting</HStack>;
 
     case "ACTIVE":
-      return (
-        <HStack gap={1}>
-          Ends in {formatDistanceToNowStrict(proposalEndTime)}
-        </HStack>
-      );
+      return <HStack gap={1}>Ends {activeProposalEndTime}</HStack>;
 
     case "CANCELLED":
       return <HStack gap={1}></HStack>;

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -1,3 +1,6 @@
+// Use client for local timezone
+"use client";
+
 import { HStack } from "@/components/Layout/Stack";
 import { formatDistanceToNowStrict } from "date-fns";
 
@@ -11,8 +14,8 @@ export default function ProposalTimeStatus({
     hour: "numeric",
     minute: "numeric",
     timeZoneName: "short",
-    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   };
+
   console.log(
     "Intl.DateTimeFormat().resolvedOptions().timeZone: ",
     Intl.DateTimeFormat().resolvedOptions().timeZone

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -16,11 +16,6 @@ export default function ProposalTimeStatus({
     timeZoneName: "short",
   };
 
-  console.log(
-    "Intl.DateTimeFormat().resolvedOptions().timeZone: ",
-    Intl.DateTimeFormat().resolvedOptions().timeZone
-  );
-
   const activeProposalEndTime = new Intl.DateTimeFormat(
     "en-US",
     options

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -11,7 +11,7 @@ export default function ProposalTimeStatus({
     hour: "numeric",
     minute: "numeric",
     timeZoneName: "short",
-    timeZone: "UTC",
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   };
 
   const activeProposalEndTime = new Intl.DateTimeFormat(

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -11,11 +11,13 @@ export default function ProposalTimeStatus({
     hour: "numeric",
     minute: "numeric",
     timeZoneName: "short",
+    timeZone: "UTC",
   };
 
-  const activeProposalEndTime = new Intl.DateTimeFormat("UTC", options).format(
-    proposalEndTime
-  );
+  const activeProposalEndTime = new Intl.DateTimeFormat(
+    "en-US",
+    options
+  ).format(proposalEndTime);
 
   switch (proposalStatus) {
     case "PENDING":

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -13,6 +13,10 @@ export default function ProposalTimeStatus({
     timeZoneName: "short",
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   };
+  console.log(
+    "Intl.DateTimeFormat().resolvedOptions().timeZone: ",
+    Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
 
   const activeProposalEndTime = new Intl.DateTimeFormat(
     "en-US",

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -13,10 +13,9 @@ export default function ProposalTimeStatus({
     timeZoneName: "short",
   };
 
-  const activeProposalEndTime = new Intl.DateTimeFormat(
-    "en-US",
-    options
-  ).format(proposalEndTime);
+  const activeProposalEndTime = new Intl.DateTimeFormat("UTC", options).format(
+    proposalEndTime
+  );
 
   switch (proposalStatus) {
     case "PENDING":

--- a/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
+++ b/src/components/Proposals/Proposal/ProposalTimeStatus.jsx
@@ -1,4 +1,4 @@
-// Use client for local timezone
+// Use client for local timezone instead of server timezone
 "use client";
 
 import { HStack } from "@/components/Layout/Stack";

--- a/src/components/Proposals/Proposal/proposal.module.scss
+++ b/src/components/Proposals/Proposal/proposal.module.scss
@@ -28,7 +28,7 @@
   }
 }
 .cell_status {
-  width: 15%;
+  width: 20%;
   align-items: flex-start;
   justify-content: center;
   @media (max-width: $screen-sm) {
@@ -36,7 +36,7 @@
   }
 }
 .cell_result {
-  width: 30%;
+  width: 25%;
   align-items: flex-end;
   justify-content: center;
   @media (max-width: $screen-sm) {


### PR DESCRIPTION
Preview link: https://agora-next-p1cxxdwxr-voteagora.vercel.app/

Some screenshots
<img width="1250" alt="Screenshot 2024-03-05 at 21 10 42" src="https://github.com/voteagora/agora-next/assets/29060919/3f722aae-7ee3-44f8-b4d9-d681e885396b">
<img width="1425" alt="Screenshot 2024-03-05 at 21 10 52" src="https://github.com/voteagora/agora-next/assets/29060919/0318967d-0b5a-4ad3-bb24-3fbc12012929">
<img width="1347" alt="Screenshot 2024-03-05 at 21 11 07" src="https://github.com/voteagora/agora-next/assets/29060919/9707448c-3c78-4bf7-a742-3ede8fccc2e6">

LGTM!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the width of certain cells in the NeedsMyVoteProposalsList component and updates the display of proposal end times in the ProposalTimeStatus component.

### Detailed summary
- Increased width of cells in NeedsMyVoteProposalsList
- Improved display of proposal end times in ProposalTimeStatus

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->