### PR TITLE
Ferrodri/agora 1654 add current governance stage to the proposals page

### DIFF
--- a/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
+++ b/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
@@ -50,10 +50,19 @@ function parseICS(icsData: string) {
                     (currentEvent as Event)["DTEND;VALUE=DATE"]
                 );
                 if (isCurrentEvent(startDate, endDate)) {
-                    console.log('currentEvent', currentEvent);
+                    const day = endDate.getDate();
+                    const suffix = (day >= 11 && day <= 13) ? 'th' : ['st', 'nd', 'rd'][day % 10 - 1] || 'th';
+
+                    const options: Intl.DateTimeFormatOptions = {
+                        month: "long",
+                        day: "numeric"
+                    };
+
+                    const _endDate = new Intl.DateTimeFormat("en-US", options).format(endDate);
+
                     event = {
                         title: (currentEvent as Event).SUMMARY.trim(),
-                        endDate,
+                        endDate: _endDate.replace(/\d+/, (day + suffix)),
                         reviewPeriod: (currentEvent as Event).SUMMARY.includes("Review Period")
                     };
                     currentEvent = {};

--- a/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
+++ b/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
@@ -50,9 +50,11 @@ function parseICS(icsData: string) {
                     (currentEvent as Event)["DTEND;VALUE=DATE"]
                 );
                 if (isCurrentEvent(startDate, endDate)) {
+                    console.log('currentEvent', currentEvent);
                     event = {
                         title: (currentEvent as Event).SUMMARY.trim(),
-                        endDate
+                        endDate,
+                        reviewPeriod: (currentEvent as Event).SUMMARY.includes("Review Period")
                     };
                     currentEvent = {};
                     break;

--- a/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
+++ b/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
@@ -8,17 +8,17 @@ const parseICSDates = (_startDate: string, _endDate: string) => {
     const startDateTrim = _startDate.trim();
     const endDateTrim = _endDate.trim();
 
-    const startDate = new Date(
+    const startDate = new Date(Date.UTC(
         parseInt(startDateTrim.substring(0, 4), 10), // Year
         parseInt(startDateTrim.substring(4, 6), 10) - 1, // Month
         parseInt(startDateTrim.substring(6, 8), 10) // Day
-    );
+    ));
 
-    const endDate = new Date(
+    const endDate = new Date(Date.UTC(
         parseInt(endDateTrim.substring(0, 4), 10), // Year
         parseInt(endDateTrim.substring(4, 6), 10) - 1, // Month
         parseInt(endDateTrim.substring(6, 8), 10) // Day
-    );
+    ));
 
     return {
         startDate,
@@ -50,6 +50,8 @@ function parseICS(icsData: string) {
                     (currentEvent as Event)["DTEND;VALUE=DATE"]
                 );
                 if (isCurrentEvent(startDate, endDate)) {
+                    // Calendar ends one day later that it is supposed to
+                    endDate.setDate(endDate.getDate() - 1);
                     const day = endDate.getDate();
                     const suffix = (day >= 11 && day <= 13) ? 'th' : ['st', 'nd', 'rd'][day % 10 - 1] || 'th';
 
@@ -58,11 +60,11 @@ function parseICS(icsData: string) {
                         day: "numeric"
                     };
 
-                    const _endDate = new Intl.DateTimeFormat("en-US", options).format(endDate);
+                    const formattedEndDate = new Intl.DateTimeFormat("en-US", options).format(endDate);
 
                     event = {
                         title: (currentEvent as Event).SUMMARY.trim(),
-                        endDate: _endDate.replace(/\d+/, (day + suffix)),
+                        endDate: formattedEndDate.replace(/\d+/, (day + suffix)),
                         reviewPeriod: (currentEvent as Event).SUMMARY.includes("Review Period")
                     };
                     currentEvent = {};

--- a/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
+++ b/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
@@ -50,8 +50,16 @@ function parseICS(icsData: string) {
                     (currentEvent as Event)["DTEND;VALUE=DATE"]
                 );
                 if (isCurrentEvent(startDate, endDate)) {
-                    // Calendar ends one day later that it is supposed to
-                    endDate.setDate(endDate.getDate() - 1);
+                    const reviewPeriod = (currentEvent as Event).SUMMARY.includes("Review Period");
+                    if (!reviewPeriod) {
+                        /**
+                         * On voting period we should display the last day (the day voting ends). On review period we 
+                         * should display the next day (the day voting starts).
+                         * 
+                         * Calendar provides one day extra
+                         */
+                        endDate.setDate(endDate.getDate() - 1);
+                    }
                     const day = endDate.getDate();
                     const suffix = (day >= 11 && day <= 13) ? 'th' : ['st', 'nd', 'rd'][day % 10 - 1] || 'th';
 

--- a/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
+++ b/src/app/api/common/governanceCalendar/getGovernanceCalendar.ts
@@ -1,0 +1,83 @@
+type Event = {
+    SUMMARY: string;
+    ["DTSTART;VALUE=DATE"]: string;
+    ["DTEND;VALUE=DATE"]: string;
+};
+
+const parseICSDates = (_startDate: string, _endDate: string) => {
+    const startDateTrim = _startDate.trim();
+    const endDateTrim = _endDate.trim();
+
+    const startDate = new Date(
+        parseInt(startDateTrim.substring(0, 4), 10), // Year
+        parseInt(startDateTrim.substring(4, 6), 10) - 1, // Month
+        parseInt(startDateTrim.substring(6, 8), 10) // Day
+    );
+
+    const endDate = new Date(
+        parseInt(endDateTrim.substring(0, 4), 10), // Year
+        parseInt(endDateTrim.substring(4, 6), 10) - 1, // Month
+        parseInt(endDateTrim.substring(6, 8), 10) // Day
+    );
+
+    return {
+        startDate,
+        endDate,
+    };
+};
+
+const isCurrentEvent = (startDate: Date, endDate: Date) => {
+    const now = new Date();
+    return now >= startDate && now <= endDate;
+};
+
+function parseICS(icsData: string) {
+    const lines = icsData.split("\n");
+    let event;
+    let currentEvent: Event | object = {};
+
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].startsWith("BEGIN:VEVENT")) {
+            currentEvent = {};
+        } else if (lines[i].startsWith("END:VEVENT")) {
+            /**
+             * Check if today's date is between events date and it has the text "Voting Cycle", we only need one event,
+             * so in case we find it there is no need to loop more
+             */
+            if ((currentEvent as Event).SUMMARY.includes("Voting Cycle")) {
+                const { startDate, endDate } = parseICSDates(
+                    (currentEvent as Event)["DTSTART;VALUE=DATE"],
+                    (currentEvent as Event)["DTEND;VALUE=DATE"]
+                );
+                if (isCurrentEvent(startDate, endDate)) {
+                    event = {
+                        title: (currentEvent as Event).SUMMARY.trim(),
+                        endDate
+                    };
+                    currentEvent = {};
+                    break;
+                } else {
+                    currentEvent = {};
+                }
+            } else {
+                currentEvent = {};
+            }
+        } else if (currentEvent) {
+            const [key, value] = lines[i].split(":");
+            (currentEvent as Event)[key as keyof Event] = value;
+        }
+    }
+
+    return event;
+}
+
+export async function getGovernanceCalendar() {
+    const response = await fetch(
+        `https://calendar.google.com/calendar/ical/c_fnmtguh6noo6qgbni2gperid4k%40group.calendar.google.com/public/basic.ics`,
+        {
+            method: "GET"
+        }
+    );
+    const calendarICS = await response.text();
+    return parseICS(calendarICS);
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -2,6 +2,7 @@ import { getMetrics } from "@/app/api/common/metrics/getMetrics";
 import { getNeedsMyVoteProposals } from "@/app/api/common/proposals/getNeedsMyVoteProposals";
 import { getProposals } from "@/app/api/common/proposals/getProposals";
 import { getVotableSupply } from "@/app/api/common/votableSupply/getVotableSupply";
+import { getGovernanceCalendar } from "@/app/api/common/governanceCalendar/getGovernanceCalendar";
 import Hero from "@/components/Hero/Hero";
 import { PageDivider } from "@/components/Layout/PageDivider";
 import { VStack } from "@/components/Layout/Stack";
@@ -33,6 +34,12 @@ async function fetchVotableSupply() {
   return getVotableSupply();
 }
 
+async function fetchGovernanceCalendar() {
+  "use server";
+
+  return getGovernanceCalendar();
+}
+
 export async function generateMetadata({}, parent) {
   const preview = `/api/images/og/proposals`;
   const title = "Optimism Agora";
@@ -54,6 +61,7 @@ export async function generateMetadata({}, parent) {
 }
 
 export default async function Home() {
+  const governanceCalendar = await fetchGovernanceCalendar();
   const relevalntProposals = await fetchProposals(
     proposalsFilterOptions.relevant.filter
   );
@@ -80,6 +88,7 @@ export default async function Home() {
           "use server";
           return getProposals({ filter, page });
         }}
+        governanceCalendar={governanceCalendar}
         votableSupply={votableSupply}
       />
     </VStack>

--- a/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
+++ b/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
@@ -3,9 +3,11 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 export default function CurrentGovernanceStage({
   title,
   endDate,
+  reviewPeriod,
 }: {
   title: string;
   endDate: Date;
+  reviewPeriod: boolean;
 }) {
   const currentDate = new Date();
   const differenceInMilliseconds = endDate.getTime() - currentDate.getTime();
@@ -21,7 +23,7 @@ export default function CurrentGovernanceStage({
         </div>
         <span className="hidden sm:block">&nbsp;·&nbsp;</span>
         <span>
-          Voting ends in around {differenceInDays}{" "}
+          Voting {reviewPeriod ? "starts" : "ends"} in around {differenceInDays}{" "}
           {differenceInDays === 1 ? "day" : "days"}
         </span>
       </div>

--- a/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
+++ b/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
@@ -20,7 +20,7 @@ export default function CurrentGovernanceStage({
           <span>{title}</span>
         </div>
         <span className="hidden sm:block">&nbsp;·&nbsp;</span>
-        <span>Voting ends in around {differenceInDays + 1} days</span>
+        <span>Voting ends in around {differenceInDays} days</span>
       </div>
       <a
         href="https://calendar.google.com/calendar/embed?src=c_fnmtguh6noo6qgbni2gperid4k%40group.calendar.google.com"

--- a/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
+++ b/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
@@ -6,14 +6,9 @@ export default function CurrentGovernanceStage({
   reviewPeriod,
 }: {
   title: string;
-  endDate: Date;
+  endDate: string;
   reviewPeriod: boolean;
 }) {
-  const currentDate = new Date();
-  const differenceInMilliseconds = endDate.getTime() - currentDate.getTime();
-  const differenceInDays = Math.floor(
-    differenceInMilliseconds / (1000 * 60 * 60 * 24)
-  );
   return (
     <div className="flex items-center justify-between bg-gray-fa text-gray-700 text-xs px-6 pt-2 pb-6 -mb-5 border border-gray-300 border-b-0 rounded-tl-2xl rounded-tr-2xl">
       <div className="flex flex-col sm:flex-row">
@@ -23,8 +18,7 @@ export default function CurrentGovernanceStage({
         </div>
         <span className="hidden sm:block">&nbsp;·&nbsp;</span>
         <span>
-          Voting {reviewPeriod ? "starts" : "ends"} in around {differenceInDays}{" "}
-          {differenceInDays === 1 ? "day" : "days"}
+          Voting {reviewPeriod ? "starts" : "ends"} on {endDate}
         </span>
       </div>
       <a

--- a/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
+++ b/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
@@ -20,7 +20,10 @@ export default function CurrentGovernanceStage({
           <span>{title}</span>
         </div>
         <span className="hidden sm:block">&nbsp;·&nbsp;</span>
-        <span>Voting ends in around {differenceInDays} days</span>
+        <span>
+          Voting ends in around {differenceInDays}{" "}
+          {differenceInDays === 1 ? "day" : "days"}
+        </span>
       </div>
       <a
         href="https://calendar.google.com/calendar/embed?src=c_fnmtguh6noo6qgbni2gperid4k%40group.calendar.google.com"

--- a/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
+++ b/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
@@ -1,9 +1,14 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 
-export default function CurrentGovernanceStage() {
+export default function CurrentGovernanceStage({
+  title,
+  endDate,
+}: {
+  title: string;
+  endDate: Date;
+}) {
   const currentDate = new Date();
-  const targetDate = new Date(currentDate.getFullYear(), 2, 5, 21, 47);
-  const differenceInMilliseconds = targetDate.getTime() - currentDate.getTime();
+  const differenceInMilliseconds = endDate.getTime() - currentDate.getTime();
   const differenceInDays = Math.floor(
     differenceInMilliseconds / (1000 * 60 * 60 * 24)
   );
@@ -12,7 +17,7 @@ export default function CurrentGovernanceStage() {
       <div className="flex flex-col sm:flex-row">
         <div className="flex">
           <span className="hidden sm:block">Currently in&nbsp;</span>
-          <span>Voting Cycle #19 Voting Period</span>
+          <span>{title}</span>
         </div>
         <span className="hidden sm:block">&nbsp;·&nbsp;</span>
         <span>Voting ends in around {differenceInDays + 1} days</span>

--- a/src/components/Proposals/ProposalsList/ProposalsList.jsx
+++ b/src/components/Proposals/ProposalsList/ProposalsList.jsx
@@ -59,6 +59,7 @@ export default function ProposalsList({
         <CurrentGovernanceStage
           title={governanceCalendar.title}
           endDate={governanceCalendar.endDate}
+          reviewPeriod={governanceCalendar.reviewPeriod}
         />
       )}
       <VStack className={styles.proposals_table_container}>

--- a/src/components/Proposals/ProposalsList/ProposalsList.jsx
+++ b/src/components/Proposals/ProposalsList/ProposalsList.jsx
@@ -17,6 +17,7 @@ export default function ProposalsList({
   initAllProposals,
   fetchProposals,
   votableSupply,
+  governanceCalendar,
 }) {
   const filter = useSearchParams().get("filter") || "relevant";
   const fetching = useRef(false);
@@ -54,7 +55,12 @@ export default function ProposalsList({
         </div>
       </div>
 
-      <CurrentGovernanceStage />
+      {governanceCalendar && (
+        <CurrentGovernanceStage
+          title={governanceCalendar.title}
+          endDate={governanceCalendar.endDate}
+        />
+      )}
       <VStack className={styles.proposals_table_container}>
         <div className={styles.proposals_table}>
           <InfiniteScroll


### PR DESCRIPTION
Here is the preview link: https://agora-next-8n06xjzv6-voteagora.vercel.app/
<img width="1446" alt="Screenshot 2024-03-06 at 20 19 55" src="https://github.com/voteagora/agora-next/assets/29060919/23603daf-0ac3-4bab-86be-f6f29d171d5f">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `governanceCalendar` feature to display current governance stage details in the proposals list.

### Detailed summary
- Added `governanceCalendar` object to fetch and display governance stage details
- Updated `ProposalsList` component to render `CurrentGovernanceStage` with calendar data
- Added functions to fetch and parse governance calendar data from an external source

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->