### PR TITLE
Add missing vote cast ghost views for etherfi & ens

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -811,6 +811,70 @@ view etherfi_authority_chains {
   @@schema("etherfi")
 }
 
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view ens_vote_cast_events {
+  transaction_hash String?  @db.VarChar
+  proposal_id      String?
+  voter            String?
+  support          String?
+  weight           Decimal? @db.Decimal
+  reason           String?
+  block_number     BigInt?
+  params           String?
+
+  @@map("vote_cast_events")
+  @@ignore
+  @@schema("ens")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view ens_vote_cast_with_params_events {
+  transaction_hash String?  @db.VarChar
+  proposal_id      String?
+  voter            String?
+  support          String?
+  weight           Decimal? @db.Decimal
+  reason           String?
+  block_number     BigInt?
+  params           String?
+
+  @@map("vote_cast_with_params_events")
+  @@ignore
+  @@schema("ens")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view etherfi_vote_cast_events {
+  transaction_hash String?  @db.VarChar
+  proposal_id      String?
+  voter            String?
+  support          String?
+  weight           Decimal? @db.Decimal
+  reason           String?
+  block_number     BigInt?
+  params           String?
+
+  @@map("vote_cast_events")
+  @@ignore
+  @@schema("etherfi")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view etherfi_vote_cast_with_params_events {
+  transaction_hash String?  @db.VarChar
+  proposal_id      String?
+  voter            String?
+  support          String?
+  weight           Decimal? @db.Decimal
+  reason           String?
+  block_number     BigInt?
+  params           String?
+
+  @@map("vote_cast_with_params_events")
+  @@ignore
+  @@schema("etherfi")
+}
+
 enum DaoSlug {
   OP
   ENS


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds views `ens_vote_cast_events`, `ens_vote_cast_with_params_events`, `etherfi_vote_cast_events`, and `etherfi_vote_cast_with_params_events` with specific fields and mappings for handling data in Prisma Client.

### Detailed summary
- Added views for handling specific event data in Prisma Client
- Fields include `transaction_hash`, `proposal_id`, `voter`, `support`, `weight`, `reason`, `block_number`, and `params`
- Views are mapped to corresponding tables and schemas for proper data handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->