### PR TITLE
Restrict dynamo statements storage to optimism

### DIFF
--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -4,6 +4,7 @@ import prisma from "@/app/lib/prisma";
 import { makeDynamoClient } from "@/app/lib/dynamodb";
 import { addressOrEnsNameWrap } from "../utils/ensName";
 import Tenant from "@/lib/tenant/tenant";
+import { DaoSlug } from "@prisma/client";
 
 export const getDelegateStatement = (addressOrENSName: string) =>
   addressOrEnsNameWrap(getDelegateStatementForAddress, addressOrENSName);
@@ -20,7 +21,9 @@ async function getDelegateStatementForAddress({
     .catch((error) => console.error(error));
   return postgreqsqlData
     ? postgreqsqlData
-    : await getDelegateStatementForAddressDynamo(address);
+    : slug === DaoSlug.OP // Only fetch from Dynamo for optimism
+    ? await getDelegateStatementForAddressDynamo(address)
+    : null;
 }
 
 async function getDelegateStatementForAddressDynamo(address: string) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a conditional check based on `DaoSlug` value to determine whether to fetch data from DynamoDB or return null.

### Detailed summary
- Introduced `DaoSlug` import from `@prisma/client`
- Added conditional check to fetch data from DynamoDB based on `DaoSlug` value

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->