### PR TITLE
Bugfix: Creating Optimistic proposals 

### DIFF
--- a/src/components/Proposals/ProposalCreation/ProposalTypeRow.tsx
+++ b/src/components/Proposals/ProposalCreation/ProposalTypeRow.tsx
@@ -22,9 +22,9 @@ function ProposalTypeRow({
   proposalSettingsList: any[];
 }) {
   const { proposalType, proposalSettings } = form.state;
-  const optimisticProposalSettingsIndex = proposalSettingsList.findIndex(
+  const optimisticProposalSettingsIndex = proposalSettingsList.find(
     (item) => item.name === "Optimistic"
-  );
+  ).proposal_type_id;
   const infoText = () => {
     switch (proposalType) {
       case "Basic":

--- a/src/lib/contracts/contracts.ts
+++ b/src/lib/contracts/contracts.ts
@@ -5,4 +5,4 @@ export const approvalModuleAddress =
   "0xdd0229D72a414DC821DEc66f3Cc4eF6dB2C7b7df" as `0x${string}`;
 
 export const optimisticModuleAddress =
-  "0x27964c5f4F389B8399036e1076d84c6984576C33";
+  "0x27964c5f4F389B8399036e1076d84c6984576C33" as `0x${string}`;


### PR DESCRIPTION
A quick fix for the wrong proposal type

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `optimisticModuleAddress` constant and refactor the `optimisticProposalSettingsIndex` logic in the `ProposalTypeRow.tsx` file.

### Detailed summary
- Updated `optimisticModuleAddress` constant format
- Refactored `optimisticProposalSettingsIndex` logic to use `find` instead of `findIndex`
- Changed `findIndex` logic to access `proposal_type_id` directly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->