### PR TITLE
fix Div of past votes in delegates/address page not clickable

### DIFF
--- a/src/components/Delegates/DelegateVotes/DelegateVotes.jsx
+++ b/src/components/Delegates/DelegateVotes/DelegateVotes.jsx
@@ -80,16 +80,14 @@ export default function DelegateVotes({ fetchDelegateVotes }) {
         {delegateVotes.map(
           (vote) =>
             vote && (
-              <VoteDetailsContainer key={vote.transactionHash}>
+              <VoteDetailsContainer
+                key={vote.transactionHash}
+                proposalId={vote.proposal_id}
+              >
                 <div className={styles.details_container}>
                   <VStack className={styles.details_sub}>
                     <HStack gap={1} className={styles.vote_type}>
-                      <a
-                        href={`/proposals/${vote.proposal_id}`}
-                        title={`Prop ${vote.proposal_id}`}
-                      >
-                        Prop {shortAddress(vote.proposal_id)}
-                      </a>
+                      Prop {shortAddress(vote.proposal_id)}
                       <>
                         {vote.proposalValue != 0n ? (
                           <> asking {formatNumber(vote.proposalValue)} ETH</>

--- a/src/components/Delegates/DelegateVotes/DelegateVotesDetailsContainer.jsx
+++ b/src/components/Delegates/DelegateVotes/DelegateVotesDetailsContainer.jsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { VStack } from "@/components/Layout/Stack";
 import styles from "./delegateVotes.module.scss";
+import Link from "next/link";
 
-function VoteDetailsContainer({ children }) {
+function VoteDetailsContainer({ children, proposalId }) {
   return (
-    <VStack gap={3} className={styles.vote_details_container}>
-      {children}
-    </VStack>
+    <Link href={`/proposals/${proposalId}`} title={`Prop ${proposalId}`}>
+      <VStack gap={3} className={styles.vote_details_container}>
+        {children}
+      </VStack>
+    </Link>
   );
 }
 


### PR DESCRIPTION
Here is the preview link @yitongzhang: https://agora-next-45flogu6j-voteagora.vercel.app/

This is a small change, before only the title was clickable, now the whole div
<img width="951" alt="Screenshot 2024-03-21 at 15 02 18" src="https://github.com/voteagora/agora-next/assets/29060919/88aea650-5dec-4ea2-b1cf-a3133babcc9a">
<img width="1039" alt="Screenshot 2024-03-21 at 15 02 41" src="https://github.com/voteagora/agora-next/assets/29060919/2120d1f5-e1e3-48a7-b817-a527694b45b3">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a link to each proposal in DelegateVotesDetailsContainer and updates DelegateVotes to display proposalId.

### Detailed summary
- Added `Link` component to wrap proposal links in `DelegateVotesDetailsContainer`
- Updated `VoteDetailsContainer` to accept `proposalId`
- Updated `DelegateVotes` to pass `proposalId` to `VoteDetailsContainer`
- Removed unnecessary anchor tag in `DelegateVotes` for proposal link

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->