### PR TITLE
Fix: "hover over the grey area of this bar to be able to see the exact number of people who abstained"

### DIFF
--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.jsx
@@ -11,7 +11,7 @@ import { TokenAmountDisplay, generateBarsForVote } from "@/lib/utils";
 export default function ProposalVotesBar({ proposal }) {
   return (
     <div>
-      <TooltipProvider>
+      <TooltipProvider delayDuration={10}>
         <Tooltip>
           <TooltipTrigger asChild>
             <HStack

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/proposalVotesBar.module.scss
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/proposalVotesBar.module.scss
@@ -1,7 +1,7 @@
 @import "@/styles/variables.scss";
 
 .vote_bar_ticks {
-  cursor: pointer;
+  cursor: help;
   .for {
     background: #06ab34;
     border-radius: $border-radius-full;

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/proposalVotesBar.module.scss
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/proposalVotesBar.module.scss
@@ -1,6 +1,7 @@
 @import "@/styles/variables.scss";
 
 .vote_bar_ticks {
+  cursor: pointer;
   .for {
     background: #06ab34;
     border-radius: $border-radius-full;


### PR DESCRIPTION
Here is the preview link: https://agora-next-9xx0rqhcv-voteagora.vercel.app/proposals/47253113366919812831791422571513347073374828501432502648295761953879525315523

It was working but there was a default delay of 700ms that's why it looked like it was not working.

Here is a screenshot
<img width="555" alt="Screenshot 2024-03-22 at 01 04 40" src="https://github.com/voteagora/agora-next/assets/29060919/18b22e87-2efa-438c-ae99-5db13b50d688">

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a `cursor: help` style to the `.vote_bar_ticks` class and update the `TooltipProvider` component in `ProposalVotesBar.jsx` with a `delayDuration` prop.

### Detailed summary
- Added `cursor: help` style to `.vote_bar_ticks` class
- Updated `TooltipProvider` in `ProposalVotesBar.jsx` with `delayDuration={10}` prop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->