### PR TITLE
fix approval proposal results for V6 governor

### DIFF
--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OptionResultsPanel/OptionResultsPanel.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OptionResultsPanel/OptionResultsPanel.tsx
@@ -29,7 +29,9 @@ export default function OptionsResultsPanel({
   const options = proposalResults.options;
 
   const totalVotingPower =
-    BigInt(proposalResults.for) + BigInt(proposalResults.abstain);
+    BigInt(proposalResults.for) +
+    BigInt(proposalResults.abstain) +
+    BigInt(proposalResults.against);
 
   const thresholdPosition = (() => {
     if (proposalSettings.criteria === "THRESHOLD") {


### PR DESCRIPTION
Before
![CleanShot 2024-03-21 at 20 19 30@2x](https://github.com/voteagora/agora-next/assets/20438019/ed16ca33-aa57-48f7-8502-e1be15bc416b)
After
![CleanShot 2024-03-21 at 20 19 53@2x](https://github.com/voteagora/agora-next/assets/20438019/11c573a8-24ac-449a-9e0a-1c483eee1f2f)


<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the parsing and handling of proposal results, including adding support for `against` votes and incorporating `startBlock` in the calculations.

### Detailed summary
- Added support for `against` votes in proposal results parsing.
- Included `startBlock` in proposal data processing.
- Introduced `Tenant` and `TENANT_NAMESPACES` for namespace and contract management.
- Updated calculations for `totalVotingPower` and `thresholdPosition`.
- Improved handling of proposal data and results in `OptionResultsPanel`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->