### PR TITLE
Ferrodri/agora 1602 not possible to see how many votes were casted on approval

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -62,9 +62,9 @@ const nextConfig = {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     return config;
   },
-  experimental: {
-      instrumentationHook: true,
-  },
+  // experimental: {
+  //     instrumentationHook: true,
+  // },
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -62,9 +62,9 @@ const nextConfig = {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     return config;
   },
-  // experimental: {
-  //     instrumentationHook: true,
-  // },
+  experimental: {
+    instrumentationHook: true,
+  },
 };
 
 module.exports = nextConfig;

--- a/src/app/lib/logging.ts
+++ b/src/app/lib/logging.ts
@@ -16,12 +16,12 @@ const time_this = async <T>(
     throw error;
   } finally {
     const end = performance.now();
-    console.log(
-      util.inspect(
-        { ...log_fields, time: end - start },
-        { showHidden: false, depth: null, colors: !log_emission }
-      )
-    );
+    // console.log(
+    //   util.inspect(
+    //     { ...log_fields, time: end - start },
+    //     { showHidden: false, depth: null, colors: !log_emission }
+    //   )
+    // );
   }
 };
 
@@ -36,12 +36,12 @@ const time_this_sync = <T>(
     throw error;
   } finally {
     const end = performance.now();
-    console.log(
-      util.inspect(
-        { ...log_fields, time: end - start },
-        { showHidden: false, depth: null, colors: !log_emission }
-      )
-    );
+    // console.log(
+    //   util.inspect(
+    //     { ...log_fields, time: end - start },
+    //     { showHidden: false, depth: null, colors: !log_emission }
+    //   )
+    // );
   }
 };
 

--- a/src/app/lib/logging.ts
+++ b/src/app/lib/logging.ts
@@ -16,12 +16,12 @@ const time_this = async <T>(
     throw error;
   } finally {
     const end = performance.now();
-    // console.log(
-    //   util.inspect(
-    //     { ...log_fields, time: end - start },
-    //     { showHidden: false, depth: null, colors: !log_emission }
-    //   )
-    // );
+    console.log(
+      util.inspect(
+        { ...log_fields, time: end - start },
+        { showHidden: false, depth: null, colors: !log_emission }
+      )
+    );
   }
 };
 
@@ -36,12 +36,12 @@ const time_this_sync = <T>(
     throw error;
   } finally {
     const end = performance.now();
-    // console.log(
-    //   util.inspect(
-    //     { ...log_fields, time: end - start },
-    //     { showHidden: false, depth: null, colors: !log_emission }
-    //   )
-    // );
+    console.log(
+      util.inspect(
+        { ...log_fields, time: end - start },
+        { showHidden: false, depth: null, colors: !log_emission }
+      )
+    );
   }
 };
 

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalProposalCriteria/ApprovalProposalCriteria.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalProposalCriteria/ApprovalProposalCriteria.jsx
@@ -11,23 +11,33 @@ export default function ApprovalProposalCriteria({ proposal }) {
 
   return (
     <VStack className="p-4 pb-2 border-t border-gray-200">
-      <HStack
-        justifyContent="justify-between"
-        className="text-xs font-semibold text-gray-700"
-      >
-        <div>
-          QUORUM{" "}
-          <TokenAmountDisplay
-            amount={proposal.quorum}
-            decimals={18}
-            currency="OP"
-          />
-        </div>
-      </HStack>
-      <ProposalStatusDetail
-        proposalStatus={proposal.status}
-        proposalEndTime={proposal.end_time}
-      />
+      <div className="px-4 border border-gray-300 rounded-md">
+        <HStack
+          justifyContent="justify-between"
+          className="text-xs font-semibold text-gray-700 py-2"
+        >
+          <div>
+            Quorum{" "}
+            <TokenAmountDisplay
+              amount={proposal.quorum}
+              decimals={token.decimals}
+              currency={token.symbol}
+            />
+          </div>
+          <div>
+            Current{" "}
+            <TokenAmountDisplay
+              amount={proposalResults.for}
+              decimals={token.decimals}
+              currency={token.symbol}
+            />
+          </div>
+        </HStack>
+        <ProposalStatusDetail
+          proposalStatus={proposal.status}
+          proposalEndTime={proposal.end_time}
+        />
+      </div>
       <div className="pt-2 text-xs font-semibold text-gray-700">
         {/* {totalVotingPower.toString()} */}
         {proposalSettings.criteria === "TOP_CHOICES" && (

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalProposalCriteria/ApprovalProposalCriteria.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalProposalCriteria/ApprovalProposalCriteria.jsx
@@ -1,14 +1,13 @@
 import { HStack, VStack } from "@/components/Layout/Stack";
-import ProposalTimeStatus from "@/components/Proposals/Proposal/ProposalTimeStatus";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
+import ProposalStatusDetail from "@/components/Proposals/ProposalStatus/ProposalStatusDetail";
+import Tenant from "@/lib/tenant/tenant";
 
 export default function ApprovalProposalCriteria({ proposal }) {
+  const { token } = Tenant.current();
   const proposalData = proposal.proposalData;
   const proposalResults = proposal.proposalResults;
   const proposalSettings = proposalData.proposalSettings;
-
-  const totalVotingPower =
-    BigInt(proposalResults.for) + BigInt(proposalResults.abstain);
 
   return (
     <VStack className="p-4 pb-2 border-t border-gray-200">
@@ -24,11 +23,11 @@ export default function ApprovalProposalCriteria({ proposal }) {
             currency="OP"
           />
         </div>
-        <ProposalTimeStatus
-          proposalStatus={proposal.status}
-          proposalEndTime={proposal.end_time}
-        />
       </HStack>
+      <ProposalStatusDetail
+        proposalStatus={proposal.status}
+        proposalEndTime={proposal.end_time}
+      />
       <div className="pt-2 text-xs font-semibold text-gray-700">
         {/* {totalVotingPower.toString()} */}
         {proposalSettings.criteria === "TOP_CHOICES" && (
@@ -45,15 +44,15 @@ export default function ApprovalProposalCriteria({ proposal }) {
             threshold of{" "}
             <TokenAmountDisplay
               amount={proposalSettings.criteriaValue}
-              decimals={18}
-              currency="OP"
+              decimals={token.decimals}
+              currency={token.symbol}
             />{" "}
             votes will be executed in order from most to least popular, until
             the total budget of{" "}
             <TokenAmountDisplay
               amount={proposalSettings.budgetAmount}
-              decimals={18}
-              currency="OP"
+              decimals={token.decimals}
+              currency={token.symbol}
             />{" "}
             runs out. Voters can select up to {proposalSettings.maxApprovals}{" "}
             options. If the quorum is not met, no options will be executed.

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -1,10 +1,10 @@
 import { VStack, HStack } from "@/components/Layout/Stack";
 import styles from "./proposalVotesSummary.module.scss";
-import ProposalTimeStatus from "@/components/Proposals/Proposal/ProposalTimeStatus";
 import ProposalVotesBar from "../ProposalVotesBar/ProposalVotesBar";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import { ParsedProposalResults } from "@/lib/proposalUtils";
+import ProposalStatusDetail from "@/components/Proposals/ProposalStatus/ProposalStatusDetail";
 
 export default function ProposalVotesSummary({
   proposal,
@@ -58,35 +58,10 @@ export default function ProposalVotesSummary({
             )}
           </>
         </HStack>
-        <HStack
-          justifyContent="justify-between"
-          alignItems="items-center"
-          className="bg-gray-fa border-t -mx-4 px-4 py-2 text-gray-4f rounded-b-md"
-        >
-          <div>
-            {proposal.status === "ACTIVE" && (
-              <p className="text-blue-600 bg-sky-200 rounded-sm px-1 py-0.5 font-semibold">
-                ACTIVE
-              </p>
-            )}
-            {proposal.status === "SUCCEEDED" && (
-              <p className="text-green-600 bg-green-200 rounded-sm px-1 py-0.5 font-semibold">
-                SUCCEEDED
-              </p>
-            )}
-            {proposal.status === "DEFEATED" && (
-              <p className="text-red-600 bg-red-200 rounded-sm px-1 py-0.5 font-semibold">
-                DEFEATED
-              </p>
-            )}
-          </div>
-          <div>
-            <ProposalTimeStatus
-              proposalStatus={proposal.status}
-              proposalEndTime={proposal.end_time}
-            />
-          </div>
-        </HStack>
+        <ProposalStatusDetail
+          proposalEndTime={proposal.end_time}
+          proposalStatus={proposal.status}
+        />
       </VStack>
     </VStack>
   );

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -5,12 +5,14 @@ import { Proposal } from "@/app/api/common/proposals/proposal";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import { ParsedProposalResults } from "@/lib/proposalUtils";
 import ProposalStatusDetail from "@/components/Proposals/ProposalStatus/ProposalStatusDetail";
+import Tenant from "@/lib/tenant/tenant";
 
 export default function ProposalVotesSummary({
   proposal,
 }: {
   proposal: Proposal;
 }) {
+  const { token } = Tenant.current();
   const results =
     proposal.proposalResults as ParsedProposalResults["STANDARD"]["kind"];
   return (
@@ -20,16 +22,16 @@ export default function ProposalVotesSummary({
           FOR{" "}
           <TokenAmountDisplay
             amount={results.for}
-            decimals={18}
-            currency={"OP"}
+            decimals={token.decimals}
+            currency={token.symbol}
           />
         </div>
         <div className="gl_votes_against">
           AGAINST{" "}
           <TokenAmountDisplay
             amount={results.against}
-            decimals={18}
-            currency={"OP"}
+            decimals={token.decimals}
+            currency={token.symbol}
           />
         </div>
       </HStack>
@@ -42,8 +44,8 @@ export default function ProposalVotesSummary({
                 Quorum{" "}
                 <TokenAmountDisplay
                   amount={proposal.quorum}
-                  decimals={18}
-                  currency={"OP"}
+                  decimals={token.decimals}
+                  currency={token.symbol}
                 />
               </div>
             )}

--- a/src/components/Proposals/ProposalStatus/ProposalStatusDetail.tsx
+++ b/src/components/Proposals/ProposalStatus/ProposalStatusDetail.tsx
@@ -1,0 +1,43 @@
+import { HStack } from "@/components/Layout/Stack";
+import ProposalTimeStatus from "@/components/Proposals/Proposal/ProposalTimeStatus";
+import { type ProposalStatus } from "@/lib/proposalUtils";
+
+export default function ProposalStatusDetail({
+  proposalStatus,
+  proposalEndTime,
+}: {
+  proposalStatus: ProposalStatus | null;
+  proposalEndTime: Date | null;
+}) {
+  return (
+    <HStack
+      justifyContent="justify-between"
+      alignItems="items-center"
+      className="bg-gray-fa border-t -mx-4 px-4 py-2 text-gray-4f rounded-b-md text-xs"
+    >
+      <div>
+        {proposalStatus === "ACTIVE" && (
+          <p className="text-blue-600 bg-sky-200 rounded-sm px-1 py-0.5 font-semibold">
+            ACTIVE
+          </p>
+        )}
+        {proposalStatus === "SUCCEEDED" && (
+          <p className="text-green-600 bg-green-200 rounded-sm px-1 py-0.5 font-semibold">
+            SUCCEEDED
+          </p>
+        )}
+        {proposalStatus === "DEFEATED" && (
+          <p className="text-red-600 bg-red-200 rounded-sm px-1 py-0.5 font-semibold">
+            DEFEATED
+          </p>
+        )}
+      </div>
+      <div>
+        <ProposalTimeStatus
+          proposalStatus={proposalStatus}
+          proposalEndTime={proposalEndTime}
+        />
+      </div>
+    </HStack>
+  );
+}


### PR DESCRIPTION
Here is the preview link: https://agora-next-bgbhr371n-voteagora.vercel.app/

A couple of screenshots: 
<img width="471" alt="Screenshot 2024-03-22 at 13 36 05" src="https://github.com/voteagora/agora-next/assets/29060919/5cfaf6a2-23a6-46b2-a31e-37a1b74c6265">
<img width="513" alt="Screenshot 2024-03-22 at 14 01 09" src="https://github.com/voteagora/agora-next/assets/29060919/d86093ec-21e2-492d-94cb-080e1a98a227">


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor components related to proposal status and time display.

### Detailed summary
- Added `ProposalStatusDetail` component to display proposal status and time
- Removed `ProposalTimeStatus` import from multiple components
- Updated components to use `ProposalStatusDetail` for status and time display

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->