### PR TITLE
Unify prisma schemas

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -750,7 +750,7 @@ view ens_delegates_wrapper {
   delegate          String?
   num_of_delegators Decimal? @db.Decimal
   direct_vp         Decimal? @db.Decimal
-  advanced_vp       String?
+  advanced_vp       Decimal? @db.Decimal
   voting_power      Decimal? @db.Decimal
 
   @@map("delegates_wrapper")
@@ -788,7 +788,7 @@ view etherfi_delegates_wrapper {
   delegate          String?
   num_of_delegators Decimal? @db.Decimal
   direct_vp         Decimal? @db.Decimal
-  advanced_vp       String?
+  advanced_vp       Decimal? @db.Decimal
   voting_power      Decimal? @db.Decimal
 
   @@map("delegates_wrapper")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,13 +120,13 @@ view OptimismDelegates {
 
 view OptimismProposals {
   proposal_id        String       @unique
-  contract           String?      @db.VarChar(42)
+  contract           String       @db.VarChar(42)
   proposer           String
   description        String?
-  ordinal            Decimal?     @db.Decimal
-  created_block      BigInt
+  ordinal            Decimal      @db.Decimal
+  created_block      BigInt?
   start_block        String
-  end_block          String
+  end_block          String?
   cancelled_block    BigInt?
   executed_block     BigInt?
   proposal_data      Json?
@@ -240,11 +240,11 @@ view ensDelegatees {
 }
 
 view ensDelegates {
-  delegate          String  @unique
-  num_of_delegators Decimal @db.Decimal
-  direct_vp         Decimal @db.Decimal
-  advanced_vp       String
-  voting_power      Decimal @db.Decimal
+  delegate          String   @unique
+  num_of_delegators Decimal? @db.Decimal
+  direct_vp         Decimal? @db.Decimal
+  advanced_vp       String?
+  voting_power      Decimal? @db.Decimal
 
   @@map("delegates")
   @@schema("ens")
@@ -252,7 +252,7 @@ view ensDelegates {
 
 view ensProposals {
   proposal_id        String       @unique
-  contract           String       @db.VarChar(42)
+  contract           String       @db.VarChar
   proposer           String
   description        String?
   ordinal            Decimal      @db.Decimal
@@ -293,18 +293,18 @@ view ensVoterStats {
 }
 
 view ensVotes {
-  transaction_hash String        @unique @db.VarChar(66)
+  transaction_hash String       @unique @db.VarChar(66)
   proposal_id      String
   voter            String
   support          String
-  weight           Decimal       @db.Decimal
+  weight           Decimal      @db.Decimal
   reason           String?
   block_number     BigInt
   params           String?
   start_block      String?
   description      String?
-  proposal_data    Json?
-  proposal_type    ProposalType?
+  proposal_data    Json
+  proposal_type    ProposalType
 
   @@map("votes")
   @@schema("ens")
@@ -382,11 +382,11 @@ view etherfiDelegatees {
 }
 
 view etherfiDelegates {
-  delegate          String  @unique
-  num_of_delegators Decimal @db.Decimal
-  direct_vp         Decimal @db.Decimal
-  advanced_vp       String
-  voting_power      Decimal @db.Decimal
+  delegate          String   @unique
+  num_of_delegators Decimal? @db.Decimal
+  direct_vp         Decimal? @db.Decimal
+  advanced_vp       String?
+  voting_power      Decimal? @db.Decimal
 
   @@map("delegates")
   @@schema("etherfi")
@@ -420,13 +420,13 @@ view etherfiVotingPowerSnaps {
 
 view etherfiProposals {
   proposal_id        String       @unique
-  contract           String?      @db.VarChar
+  contract           String       @db.VarChar
   proposer           String
   description        String?
-  ordinal            Decimal?     @db.Decimal
-  created_block      BigInt
+  ordinal            Decimal      @db.Decimal
+  created_block      BigInt?
   start_block        String
-  end_block          String
+  end_block          String?
   cancelled_block    BigInt?
   executed_block     BigInt?
   proposal_data      Json?
@@ -734,7 +734,7 @@ view ens_delegates_wrapper {
 /// This view or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 view ens_proposals_wrapper {
   proposal_id        String?
-  contract           String?       @db.VarChar(42)
+  contract           String?       @db.VarChar
   proposer           String?
   description        String?
   ordinal            Decimal?      @db.Decimal

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -243,7 +243,7 @@ view ensDelegates {
   delegate          String   @unique
   num_of_delegators Decimal? @db.Decimal
   direct_vp         Decimal? @db.Decimal
-  advanced_vp       String?
+  advanced_vp       Decimal? @db.Decimal
   voting_power      Decimal? @db.Decimal
 
   @@map("delegates")
@@ -399,7 +399,7 @@ view etherfiDelegates {
   delegate          String   @unique
   num_of_delegators Decimal? @db.Decimal
   direct_vp         Decimal? @db.Decimal
-  advanced_vp       String?
+  advanced_vp       Decimal? @db.Decimal
   voting_power      Decimal? @db.Decimal
 
   @@map("delegates")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -264,7 +264,7 @@ view ensProposals {
   proposal_data      Json?
   proposal_data_raw  String?
   proposal_type      ProposalType
-  proposal_type_data String?
+  proposal_type_data Json?
   proposal_results   Json?
 
   @@map("proposals")
@@ -371,6 +371,20 @@ view ensAuthorityChainsSnaps {
   @@schema("ens")
 }
 
+view ensProposalTypes {
+  id                 String @unique
+  contract           String @db.VarChar
+  block_number       BigInt
+  proposal_type_id   String
+  quorum             String
+  approval_threshold String
+  name               String
+  inputs             Json
+
+  @@map("proposal_types")
+  @@schema("ens")
+}
+
 view etherfiDelegatees {
   delegator    String  @unique
   delegatee    String
@@ -432,7 +446,7 @@ view etherfiProposals {
   proposal_data      Json?
   proposal_data_raw  String?
   proposal_type      ProposalType
-  proposal_type_data String?
+  proposal_type_data Json?
   proposal_results   Json?
 
   @@map("proposals")
@@ -510,6 +524,20 @@ view etherfiAuthorityChainsSnaps {
   balance_ordinal      Decimal? @db.Decimal
 
   @@map("authority_chains_snaps")
+  @@schema("etherfi")
+}
+
+view etherfiProposalTypes {
+  id                 String @unique
+  contract           String @db.VarChar
+  block_number       BigInt
+  proposal_type_id   String
+  quorum             String
+  approval_threshold String
+  name               String
+  inputs             Json
+
+  @@map("proposal_types")
   @@schema("etherfi")
 }
 
@@ -746,7 +774,7 @@ view ens_proposals_wrapper {
   proposal_data      Json?
   proposal_data_raw  String?
   proposal_type      ProposalType?
-  proposal_type_data String?
+  proposal_type_data Json?
   proposal_results   Json?
 
   @@map("proposals_wrapper")

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -78,7 +78,7 @@ async function getDelegates({
   );
 
   const _delegates = await Promise.all(
-    delegates.map(async (delegate: DelegatePayload) => {
+    delegates.map(async (delegate) => {
       return {
         citizen: await fetchIsCitizen(delegate.delegate),
         statement: await fetchDelegateStatement(delegate.delegate),
@@ -88,7 +88,7 @@ async function getDelegates({
 
   return {
     meta,
-    delegates: delegates.map((delegate: DelegatePayload, index: number) => ({
+    delegates: delegates.map((delegate, index) => ({
       address: delegate.delegate,
       votingPower: delegate.voting_power?.toFixed(0),
       citizen: _delegates[index].citizen.length > 0,

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -9,11 +9,7 @@ import prisma from "@/app/lib/prisma";
 import { cache } from "react";
 import { isAddress } from "viem";
 import { resolveENSName } from "@/app/lib/ENSUtils";
-import {
-  type Delegate,
-  type DelegatePayload,
-  type DelegatesGetPayload,
-} from "./delegate";
+import { type Delegate, type DelegatesGetPayload } from "./delegate";
 import { fetchIsCitizen } from "../citizens/isCitizen";
 import Tenant from "@/lib/tenant/tenant";
 import { fetchDelegateStatement } from "@/app/api/common/delegateStatement/getDelegateStatement";

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -64,7 +64,7 @@ async function getDelegates({
             take
           );
         default:
-          return (prisma as any)[`${namespace}Delegates`].findMany({
+          return prisma[`${namespace}Delegates`].findMany({
             skip,
             take,
             orderBy: {

--- a/src/app/api/common/delegations/delegation.d.ts
+++ b/src/app/api/common/delegations/delegation.d.ts
@@ -10,11 +10,3 @@ export type Delegation = {
   type: "DIRECT" | "ADVANCED";
   amount: "FULL" | "PARTIAL";
 };
-
-export type AdvancedDelegationPayload = {
-  block_number: number;
-  delegated_amount: number;
-  delegated_share: number;
-  from: number;
-  to: string;
-};

--- a/src/app/api/common/delegations/getDelegations.ts
+++ b/src/app/api/common/delegations/getDelegations.ts
@@ -1,4 +1,4 @@
-import { type AdvancedDelegationPayload, type Delegation } from "./delegation";
+import { type Delegation } from "./delegation";
 import { getHumanBlockTime } from "@/lib/blockTimes";
 import { cache } from "react";
 import prisma from "@/app/lib/prisma";

--- a/src/app/api/common/delegations/getDelegations.ts
+++ b/src/app/api/common/delegations/getDelegations.ts
@@ -21,7 +21,7 @@ async function getCurrentDelegateesForAddress({
 }): Promise<Delegation[]> {
   const { namespace, contracts } = Tenant.current();
 
-  const advancedDelegatees = await (prisma as any)[
+  const advancedDelegatees = await prisma[
     `${namespace}AdvancedDelegatees`
   ].findMany({
     where: {
@@ -101,21 +101,19 @@ async function getCurrentDelegateesForAddress({
     //       },
     //     ]
     //   : []),
-    ...advancedDelegatees.map(
-      (advancedDelegatee: AdvancedDelegationPayload) => ({
-        from: advancedDelegatee.from,
-        to: advancedDelegatee.to,
-        allowance: advancedDelegatee.delegated_amount.toFixed(0),
-        timestamp: latestBlock
-          ? getHumanBlockTime(advancedDelegatee.block_number, latestBlock)
-          : null,
-        type: "ADVANCED",
-        amount:
-          Number(advancedDelegatee.delegated_share.toFixed(3)) >= 1
-            ? "FULL"
-            : "PARTIAL",
-      })
-    ),
+    ...advancedDelegatees.map((advancedDelegatee) => ({
+      from: advancedDelegatee.from,
+      to: advancedDelegatee.to,
+      allowance: advancedDelegatee.delegated_amount.toFixed(0),
+      timestamp: latestBlock
+        ? getHumanBlockTime(advancedDelegatee.block_number, latestBlock)
+        : null,
+      type: "ADVANCED",
+      amount:
+        Number(advancedDelegatee.delegated_share.toFixed(3)) >= 1
+          ? "FULL"
+          : "PARTIAL",
+    })),
   ] as Delegation[];
 }
 
@@ -133,9 +131,7 @@ async function getCurrentDelegatorsForAddress({
 }) {
   const { namespace, contracts } = Tenant.current();
 
-  const advancedDelegators = (prisma as any)[
-    `${namespace}AdvancedDelegatees`
-  ].findMany({
+  const advancedDelegators = prisma[`${namespace}AdvancedDelegatees`].findMany({
     where: {
       to: address.toLowerCase(),
       delegated_amount: { gt: 0 },
@@ -201,21 +197,19 @@ async function getCurrentDelegatorsForAddress({
     //   amount: "FULL",
     // })),
 
-    ...(await advancedDelegators).map(
-      (advancedDelegator: AdvancedDelegationPayload) => ({
-        from: advancedDelegator.from,
-        to: advancedDelegator.to,
-        allowance: advancedDelegator.delegated_amount.toFixed(0),
-        timestamp: latestBlock
-          ? getHumanBlockTime(advancedDelegator.block_number, latestBlock)
-          : null,
-        type: "ADVANCED",
-        amount:
-          Number(advancedDelegator.delegated_share.toFixed(3)) === 1
-            ? "FULL"
-            : "PARTIAL",
-      })
-    ),
+    ...(await advancedDelegators).map((advancedDelegator) => ({
+      from: advancedDelegator.from,
+      to: advancedDelegator.to,
+      allowance: advancedDelegator.delegated_amount.toFixed(0),
+      timestamp: latestBlock
+        ? getHumanBlockTime(advancedDelegator.block_number, latestBlock)
+        : null,
+      type: "ADVANCED",
+      amount:
+        Number(advancedDelegator.delegated_share.toFixed(3)) === 1
+          ? "FULL"
+          : "PARTIAL",
+    })),
   ] as Delegation[];
 }
 
@@ -234,7 +228,7 @@ const getDirectDelegateeForAddress = async ({
   const { namespace } = Tenant.current();
   const [proxyAddress, delegatee] = await Promise.all([
     getProxyAddress(address),
-    (prisma as any)[`${namespace}Delegatees`].findFirst({
+    prisma[`${namespace}Delegatees`].findFirst({
       where: { delegator: address.toLowerCase() },
     }),
   ]);
@@ -275,4 +269,4 @@ async function getAllDelegatorsInChainsForAddress({
 export const fetchCurrentDelegatees = cache(getCurrentDelegatees);
 export const fetchCurrentDelegators = cache(getCurrentDelegators);
 export const fetchDirectDelegatee = cache(getDirectDelegatee);
-export const fetchAllDelegatorsInChains = cache(getAllDelegatorsInChains); 
+export const fetchAllDelegatorsInChains = cache(getAllDelegatorsInChains);

--- a/src/app/api/common/metrics/getMetrics.ts
+++ b/src/app/api/common/metrics/getMetrics.ts
@@ -5,7 +5,7 @@ import { cache } from "react";
 async function getMetrics() {
   const { namespace, contracts } = Tenant.current();
   const totalSupply = await contracts.token.contract.totalSupply();
-  const votableSupply = await (prisma as any)[`${namespace}VotableSupply`].findFirst({});
+  const votableSupply = await prisma[`${namespace}VotableSupply`].findFirst({});
 
   return {
     votableSupply: votableSupply?.votable_supply || "0",

--- a/src/app/api/common/proposals/getProposals.ts
+++ b/src/app/api/common/proposals/getProposals.ts
@@ -25,7 +25,7 @@ async function getProposals({
   const { meta, data: proposals } = await paginateResult(
     (skip: number, take: number) => {
       if (filter === "relevant") {
-        return (prisma as any)[`${namespace}Proposals`].findMany({
+        return prisma[`${namespace}Proposals`].findMany({
           take,
           skip,
           orderBy: {
@@ -37,7 +37,7 @@ async function getProposals({
           },
         });
       } else {
-        return (prisma as any)[`${namespace}Proposals`].findMany({
+        return prisma[`${namespace}Proposals`].findMany({
           take,
           skip,
           orderBy: {
@@ -76,7 +76,7 @@ async function getProposals({
 
 async function getProposal(proposal_id: string) {
   const { namespace } = Tenant.current();
-  const proposal = await (prisma as any)[`${namespace}Proposals`].findFirst({
+  const proposal = await prisma[`${namespace}Proposals`].findFirst({
     where: { proposal_id },
   });
 
@@ -99,7 +99,7 @@ async function getProposal(proposal_id: string) {
 async function getProposalTypes() {
   const { namespace, contracts } = Tenant.current();
 
-  return (prisma as any)[`${namespace}ProposalTypes`].findMany({
+  return prisma[`${namespace}ProposalTypes`].findMany({
     where: {
       contract: contracts.proposalTypesConfigurator!.address,
     },

--- a/src/app/api/common/quorum/getQuorum.ts
+++ b/src/app/api/common/quorum/getQuorum.ts
@@ -21,7 +21,7 @@ async function getQuorumForProposal(proposal: ProposalPayload) {
 
       // If no quorum is set, calculate it based on votable supply
       if (!contractQuorum) {
-        const votableSupply = await (prisma as any)[
+        const votableSupply = await prisma[
           `${namespace}VotableSupply`
         ].findFirst({});
         return (BigInt(Number(votableSupply?.votable_supply)) * 30n) / 100n;

--- a/src/app/api/common/votableSupply/getVotableSupply.ts
+++ b/src/app/api/common/votableSupply/getVotableSupply.ts
@@ -4,7 +4,7 @@ import { cache } from "react";
 
 async function getVotableSupply() {
   const { namespace } = Tenant.current();
-  const votableSupply = await (prisma as any)[`${namespace}VotableSupply`].findFirst({});
+  const votableSupply = await prisma[`${namespace}VotableSupply`].findFirst({});
   if (!votableSupply) {
     throw new Error("No votable supply found");
   }

--- a/src/app/api/common/votes/getVotes.ts
+++ b/src/app/api/common/votes/getVotes.ts
@@ -232,7 +232,7 @@ async function getVotesForProposalAndDelegate({
   address: string;
 }) {
   const { namespace } = Tenant.current();
-  const votes = await (prisma as any)[`${namespace}Votes`].findMany({
+  const votes = await prisma[`${namespace}Votes`].findMany({
     where: { proposal_id, voter: address?.toLowerCase() },
   });
 
@@ -253,4 +253,6 @@ async function getVotesForProposalAndDelegate({
 export const fetchVotesForDelegate = cache(getVotesForDelegate);
 export const fetchVotesForProposal = cache(getVotesForProposal);
 export const fetchUserVotesForProposal = cache(getUserVotesForProposal);
-export const fetchVotesForProposalAndDelegate = cache(getVotesForProposalAndDelegate);
+export const fetchVotesForProposalAndDelegate = cache(
+  getVotesForProposalAndDelegate
+);

--- a/src/app/api/common/voting-power/getVotingPower.ts
+++ b/src/app/api/common/voting-power/getVotingPower.ts
@@ -40,7 +40,7 @@ async function getVotingPowerForProposalByAddress({
 }): Promise<VotingPowerData> {
   const { namespace, contracts } = Tenant.current();
 
-  const votingPowerQuery = (prisma as any)[`${namespace}VotingPowerSnaps`].findFirst({
+  const votingPowerQuery = prisma[`${namespace}VotingPowerSnaps`].findFirst({
     where: {
       delegate: address,
       block_number: {
@@ -138,14 +138,14 @@ async function getCurrentVotingPowerForAddress({
   address: string;
 }): Promise<VotingPowerData> {
   const { namespace, contracts } = Tenant.current();
-  const votingPower = await (prisma as any)[`${namespace}VotingPower`].findFirst({
+  const votingPower = await prisma[`${namespace}VotingPower`].findFirst({
     where: {
       delegate: address,
     },
   });
 
   // This query pulls only partially delegated voting power
-  const advancedVotingPower = await (prisma as any)[
+  const advancedVotingPower = await prisma[
     `${namespace}AdvancedVotingPower`
   ].findFirst({
     where: {
@@ -168,9 +168,7 @@ async function getCurrentVotingPowerForAddress({
  *  Voting Power available for subdelegation
  * @param addressOrENSName
  */
-const getVotingPowerAvailableForSubdelegation = (
-  addressOrENSName: string
-) =>
+const getVotingPowerAvailableForSubdelegation = (addressOrENSName: string) =>
   addressOrEnsNameWrap(
     getVotingPowerAvailableForSubdelegationForAddress,
     addressOrENSName
@@ -182,7 +180,7 @@ async function getVotingPowerAvailableForSubdelegationForAddress({
   address: string;
 }): Promise<string> {
   const { namespace, contracts } = Tenant.current();
-  const advancedVotingPower = await (prisma as any)[
+  const advancedVotingPower = await prisma[
     `${namespace}AdvancedVotingPower`
   ].findFirst({
     where: {
@@ -210,9 +208,7 @@ async function getVotingPowerAvailableForSubdelegationForAddress({
  * Represents the balance of the user's account
  * @param addressOrENSName
  */
-const getVotingPowerAvailableForDirectDelegation = (
-  addressOrENSName: string
-) =>
+const getVotingPowerAvailableForDirectDelegation = (addressOrENSName: string) =>
   addressOrEnsNameWrap(
     getVotingPowerAvailableForDirectDelegationForAddress,
     addressOrENSName
@@ -242,7 +238,7 @@ async function isAddressDelegatingToProxy({
   const { namespace } = Tenant.current();
   const [proxyAddress, delegatee] = await Promise.all([
     getProxyAddress(address),
-    (prisma as any)[`${namespace}Delegatees`].findFirst({
+    prisma[`${namespace}Delegatees`].findFirst({
       where: { delegator: address.toLowerCase() },
     }),
   ]);
@@ -274,8 +270,14 @@ async function getProxyAddressForAddress({
 }
 
 export const fetchVotingPowerForProposal = cache(getVotingPowerForProposal);
-export const fetchCurrentVotingPowerForNamespace = cache(getCurrentVotingPowerForNamespace);
-export const fetchVotingPowerAvailableForSubdelegation = cache(getVotingPowerAvailableForSubdelegation);
-export const fetchVotingPowerAvailableForDirectDelegation = cache(getVotingPowerAvailableForDirectDelegation);
+export const fetchCurrentVotingPowerForNamespace = cache(
+  getCurrentVotingPowerForNamespace
+);
+export const fetchVotingPowerAvailableForSubdelegation = cache(
+  getVotingPowerAvailableForSubdelegation
+);
+export const fetchVotingPowerAvailableForDirectDelegation = cache(
+  getVotingPowerAvailableForDirectDelegation
+);
 export const fetchIsDelegatingToProxy = cache(isDelegatingToProxy);
 export const fetchProxy = cache(getProxy);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,7 +2,7 @@ export const TENANT_NAMESPACES = {
   OPTIMISM: "optimism",
   ETHERFI: "etherfi",
   ENS: "ens",
-};
+} as const;
 export const proposalsFilterOptions = {
   relevant: {
     value: "Relevant",

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -3,11 +3,10 @@ import { ITokenContract } from "@/lib/contracts/common/interfaces/ITokenContract
 import { IGovernorContract } from "@/lib/contracts/common/interfaces/IGovernorContract";
 import { IAlligatorContract } from "@/lib/contracts/common/interfaces/IAlligatorContract";
 import { BaseContract } from "ethers";
+import { TENANT_NAMESPACES } from "./constants";
 
 export type TenantNamespace =
-  | TENANT_NAMESPACES.ENS
-  | TENANT_NAMESPACES.ETHERFI
-  | TENANT_NAMESPACES.OPTIMISM;
+  (typeof TENANT_NAMESPACES)[keyof typeof TENANT_NAMESPACES];
 
 export type TenantContracts = {
   token: TenantContract<ITokenContract>;


### PR DESCRIPTION
Unified all schemas so that we can infer prisma result types

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces TypeScript `as const` assertion, refactors type definitions, and optimizes API calls in various files.

### Detailed summary
- Added `as const` assertion in `constants.ts`
- Refactored type definitions in `types.d.ts`
- Optimized API calls in multiple files

> The following files were skipped due to too many changes: `src/app/api/common/delegations/getDelegations.ts`, `prisma/schema.prisma`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->