### PR TITLE
fix bug BigInt(0)

### DIFF
--- a/src/components/Dialogs/AdvancedDelegateDialog/AdvancedDelegateDialog.tsx
+++ b/src/components/Dialogs/AdvancedDelegateDialog/AdvancedDelegateDialog.tsx
@@ -56,7 +56,7 @@ export function AdvancedDelegateDialog({
   const [directDelegatedVP, setDirectDelegatedVP] = useState<bigint>(0n);
   const { setOpen } = useModal();
   const params = useParams<{ addressOrENSName: string }>();
-  const { contracts, slug } = Tenant.current();
+  const { slug } = Tenant.current();
 
   const fetchData = useCallback(async () => {
     try {
@@ -281,7 +281,6 @@ function InfoDialog({
   directDelegatedVP: bigint;
 }) {
   const directDelegatedFromOthers = BigInt(directDelegatedVP) - BigInt(balance);
-  const { token } = Tenant.current();
   return (
     <div className="absolute w-full bg-white rounded-lg shadow-newDefault">
       <VStack className={styles.amount_container + " !pb-0 !px-0"}>

--- a/src/components/Header/DesktopProfileDropDown.tsx
+++ b/src/components/Header/DesktopProfileDropDown.tsx
@@ -13,7 +13,6 @@ import styles from "./header.module.scss";
 import Image from "next/image";
 import { PanelRow } from "../Delegates/DelegateCard/DelegateCard";
 import useConnectedDelegate from "@/hooks/useConnectedDelegate";
-import Tenant from "@/lib/tenant/tenant";
 
 type Props = {
   ensName: string | undefined;
@@ -33,7 +32,6 @@ const ValueWrapper = ({
   );
 
 export const DesktopProfileDropDown = ({ ensName }: Props) => {
-  const { token } = Tenant.current();
   const { disconnect } = useDisconnect();
   const { address } = useAccount();
   const { isLoading, delegate, balance } = useConnectedDelegate();

--- a/src/components/Header/MobileProfileDropDown.tsx
+++ b/src/components/Header/MobileProfileDropDown.tsx
@@ -14,7 +14,6 @@ import TokenAmountDisplay from "../shared/TokenAmountDisplay";
 import styles from "./header.module.scss";
 import { PanelRow } from "../Delegates/DelegateCard/DelegateCard";
 import useConnectedDelegate from "@/hooks/useConnectedDelegate";
-import Tenant from "@/lib/tenant/tenant";
 
 type Props = {
   ensName: string | undefined;
@@ -42,7 +41,6 @@ const MobileValueWrapper = ({
 
 export const MobileProfileDropDown = ({ ensName }: Props) => {
   const { disconnect } = useDisconnect();
-  const { token } = Tenant.current();
   const { address } = useAccount();
   const { isLoading, delegate, balance } = useConnectedDelegate();
   const hasStatement = !!delegate?.statement;

--- a/src/components/Proposals/Proposal/OPStandardProposalStatus.jsx
+++ b/src/components/Proposals/Proposal/OPStandardProposalStatus.jsx
@@ -1,9 +1,9 @@
-import { HStack, VStack } from "@/components/Layout/Stack";
+import { HStack } from "@/components/Layout/Stack";
 import styles from "./proposal.module.scss";
 import { TokenAmountDisplay } from "@/lib/utils";
-import { BigNumberish, formatUnits } from "ethers";
+import { formatUnits } from "ethers";
 
-function formatNumber(amount, decimals, maximumSignificantDigits = 4) {
+function formatNumber(amount, decimals) {
   const standardUnitAmount = Number(formatUnits(amount, decimals));
   return standardUnitAmount;
 }

--- a/src/components/Proposals/ProposalPage/ApprovedTransactions/ApprovedTransactions.jsx
+++ b/src/components/Proposals/ProposalPage/ApprovedTransactions/ApprovedTransactions.jsx
@@ -40,7 +40,7 @@ export default function ApprovedTransactions({ proposalData }) {
                 <p className="font-mono text-xs font-medium leading-4 text-gray-af">
                   <OptionDescription
                     description={option.description}
-                    value={option.budgetTokensSpent}
+                    value={option.budgetTokensSpent || BigInt(0)}
                     target={option.targets[0]}
                   />
                 </p>

--- a/src/components/Proposals/ProposalPage/ApprovedTransactions/OptionDescription.jsx
+++ b/src/components/Proposals/ProposalPage/ApprovedTransactions/OptionDescription.jsx
@@ -1,10 +1,7 @@
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import { shortAddress } from "@/lib/utils";
-import Tenant from "@/lib/tenant/tenant";
 
 export default function OptionDescription({ description, value, target }) {
-  const { token } = Tenant.current();
-
   return (
     <span>
       {"//"} {description} requesting <TokenAmountDisplay amount={value} />{" "}

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalProposalCriteria/ApprovalProposalCriteria.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalProposalCriteria/ApprovalProposalCriteria.jsx
@@ -1,10 +1,8 @@
 import { HStack, VStack } from "@/components/Layout/Stack";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import ProposalStatusDetail from "@/components/Proposals/ProposalStatus/ProposalStatusDetail";
-import Tenant from "@/lib/tenant/tenant";
 
 export default function ApprovalProposalCriteria({ proposal }) {
-  const { token } = Tenant.current();
   const proposalData = proposal.proposalData;
   const proposalResults = proposal.proposalResults;
   const proposalSettings = proposalData.proposalSettings;

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -5,14 +5,12 @@ import { Proposal } from "@/app/api/common/proposals/proposal";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import { ParsedProposalResults } from "@/lib/proposalUtils";
 import ProposalStatusDetail from "@/components/Proposals/ProposalStatus/ProposalStatusDetail";
-import Tenant from "@/lib/tenant/tenant";
 
 export default function ProposalVotesSummary({
   proposal,
 }: {
   proposal: Proposal;
 }) {
-  const { token } = Tenant.current();
   const results =
     proposal.proposalResults as ParsedProposalResults["STANDARD"]["kind"];
   return (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the handling of default values and remove unnecessary `Tenant.current()` calls in various components.

### Detailed summary
- Added default value of `BigInt(0)` if `option.budgetTokensSpent` is falsy
- Removed `Tenant.current()` calls in multiple components
- Updated import of `formatUnits` in `OPStandardProposalStatus.jsx`
- Updated `formatNumber` function signature in `OPStandardProposalStatus.jsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->