### PR TITLE
[AGORA-1743] Emit User Id with all API Calls

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -79,6 +79,8 @@ const nextConfig = {
   },
   experimental: {
     instrumentationHook: true,
+    // Necessary to prevent github.com/open-telemetry/opentelemetry-js/issues/4297
+    serverComponentsExternalPackages:["@opentelemetry/sdk-node"]
   },
 };
 

--- a/src/app/api/v1/delegates/route.ts
+++ b/src/app/api/v1/delegates/route.ts
@@ -23,7 +23,7 @@ const offsetValidator = createOptionalNumberValidator(0, Number.MAX_SAFE_INTEGER
 
 export async function GET(request: NextRequest) {
   const authResponse = await authenticateApiUser(request);
-  setCurrentSpanAttributes({ user_id: authResponse.userId })
+  setCurrentSpanAttributes({ "user_id": authResponse.userId })
 
   if (!authResponse.authenticated) {
     return new Response(authResponse.reason, { status: 401 });

--- a/src/app/api/v1/delegates/route.ts
+++ b/src/app/api/v1/delegates/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/app/api/common/delegates/delegate";
 
 import { createOptionalNumberValidator, createOptionalStringValidator } from "@/app/api/common/utils/validators";
+import { setCurrentSpanAttributes } from "@/app/lib/logging";
 
 const DEFAULT_SORT = "most_delegators";
 const DEFAULT_MAX_LIMIT = 100;
@@ -22,6 +23,7 @@ const offsetValidator = createOptionalNumberValidator(0, Number.MAX_SAFE_INTEGER
 
 export async function GET(request: NextRequest) {
   const authResponse = await authenticateApiUser(request);
+  setCurrentSpanAttributes({ user_id: authResponse.userId })
 
   if (!authResponse.authenticated) {
     return new Response(authResponse.reason, { status: 401 });

--- a/src/app/lib/logging.ts
+++ b/src/app/lib/logging.ts
@@ -1,9 +1,15 @@
+import { trace, Span } from "@opentelemetry/api";
+import { type NextRequest } from "next/server";
 import { performance } from "perf_hooks";
 import * as util from "util";
+
+import { SERVICE_NAME } from "@/instrumentation";
 
 // 'dev' is used in vercel dev and preview, both of which need to have coloring disabled
 // for emission and ingestion of logs into datadog
 const log_emission = process.env.NEXT_PUBLIC_AGORA_ENV === "prod" || process.env.NEXT_PUBLIC_AGORA_ENV === "dev";
+
+const tracer = trace.getTracer(SERVICE_NAME);
 
 const time_this = async <T>(
   fn: () => Promise<T>,
@@ -44,5 +50,12 @@ const time_this_sync = <T>(
     );
   }
 };
+
+export const setCurrentSpanAttributes = <T>(
+  span_attrs: Record<string, any>
+) => {
+  const span = trace.getActiveSpan() as Span;
+  span.setAttributes(span_attrs);
+}
 
 export { time_this, time_this_sync };

--- a/src/app/lib/middleware/auth.ts
+++ b/src/app/lib/middleware/auth.ts
@@ -42,6 +42,7 @@ function hashApiKey(apiKey: string) {
 
 export async function authenticateApiUser(request: NextRequest): Promise<AuthResponse> {
   let prisma: any;
+  // Needed for Vercel middleware to run in non-node runtime
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     prismaModule = await import("@/app/lib/prisma");
     prisma = prismaModule.default;

--- a/src/app/lib/middleware/auth.ts
+++ b/src/app/lib/middleware/auth.ts
@@ -11,6 +11,7 @@ const REASON_DISABLED_USER = "User disabled";
 
 export type AuthResponse = {
   authenticated: boolean;
+  userId?: string;
   reason?: string;
 };
 
@@ -71,6 +72,8 @@ export async function authenticateApiUser(request: NextRequest): Promise<AuthRes
       authenticated: false,
       reason: REASON_DISABLED_USER,
     };
+  } else {
+    authResponse.userId = user.id;
   }
 
   return authResponse;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds OpenTelemetry instrumentation to server components, enhances authentication with user ID, and improves logging with span attributes.

### Detailed summary
- Added OpenTelemetry instrumentation to server components in `next.config.js`
- Enhanced authentication with user ID in `src/app/api/v1/delegates/route.ts`
- Improved logging by setting span attributes in `src/app/lib/logging.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->