### PR TITLE
[AGORA-1890] fix for missing optimistic proposal type

### DIFF
--- a/src/components/Proposals/ProposalCreation/ProposalTypeRow.tsx
+++ b/src/components/Proposals/ProposalCreation/ProposalTypeRow.tsx
@@ -24,7 +24,7 @@ function ProposalTypeRow({
   const { proposalType, proposalSettings } = form.state;
   const optimisticProposalSettingsIndex = proposalSettingsList.find(
     (item) => item.name === "Optimistic"
-  ).proposal_type_id;
+  )?.proposal_type_id;
   const infoText = () => {
     switch (proposalType) {
       case "Basic":
@@ -42,7 +42,7 @@ function ProposalTypeRow({
         optimisticProposalSettingsIndex.toString()
       );
     } else if (
-      proposalSettings === optimisticProposalSettingsIndex.toString()
+      proposalSettings === optimisticProposalSettingsIndex?.toString()
     ) {
       form.onChange.proposalSettings("0");
     }


### PR DESCRIPTION
when the proposal/create page is being statically generated on the server, we access the database to find the various proposal types available for the given contract.
in our build pipeline, we're using contract ID 0x54c943f19c2e983926e2d8c060ef3a956a653aa7 to filter Optimism.proposal_types.
Once we have those, they're being fed into CreateProposalForm.tsx and then into ProposalTypeRow.tsx .
ProposalTypeRow.tsx filters the passed in proposal types using the following code:
const optimisticProposalSettingsIndex = proposalSettingsList.find(
    (item) => item.name === "Optimistic"
  ).proposal_type_id;
However, doing the same lookup on our db, there is no "Optimistic" proposal type for contract 0x54c943f19c2e983926e2d8c060ef3a956a653aa7 . That reference to proposal_type_id then fails because the the object returned by proposalSettingsList.find is undefined, thus throwing an error during the static render.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the comparison of `proposalSettings` in the `ProposalTypeRow` component to handle a possible `null` value.

### Detailed summary
- Updated comparison of `proposalSettings` to handle `null` value
- Adjusted accessing `proposal_type_id` with optional chaining to prevent errors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->