### PR TITLE
[AGORA-1899][AGORA-1898][AGORA-1920] Use OTLP and not console for span emissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/resolvers": "^3.3.2",
+    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api-logs": "^0.49.1",
     "@opentelemetry/auto-instrumentations-node": "^0.43.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.49.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.49.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lodash": "^4.17.0",
     "lokijs": "^1.5.12",
     "lucide-react": "^0.258.0",
-    "next": "^14.0.1",
+    "next": "14.1.4",
     "pino-pretty": "^10.0.1",
     "postcss": "8.4.23",
     "postgres": "^3.3.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@heroicons/react": "^2.0.18",
     "@hookform/resolvers": "^3.3.2",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/api-logs": "^0.49.1",
+    "@opentelemetry/api-logs": "^0.46.0",
     "@opentelemetry/auto-instrumentations-node": "^0.43.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.49.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.49.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@heroicons/react": "^2.0.18",
     "@hookform/resolvers": "^3.3.2",
     "@opentelemetry/auto-instrumentations-node": "^0.43.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.49.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.49.1",
     "@opentelemetry/resources": "^1.22.0",
     "@opentelemetry/sdk-node": "^0.49.1",

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -16,7 +16,7 @@ export const getDelegateStatement = (addressOrENSName: string) => {
     },
     () => getDelegateStatementForAddress({ address: addressOrENSName })
   );
-}
+};
 
 /*
   Gets delegate statement from Postgres, or DynamoDB if not found

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -7,8 +7,16 @@ import { addressOrEnsNameWrap } from "../utils/ensName";
 import Tenant from "@/lib/tenant/tenant";
 import { DaoSlug } from "@prisma/client";
 
-export const getDelegateStatement = (addressOrENSName: string) =>
-  addressOrEnsNameWrap(getDelegateStatementForAddress, addressOrENSName);
+import { doInSpan } from "@/app/lib/logging";
+
+export const getDelegateStatement = (addressOrENSName: string) => {
+  return doInSpan(
+    {
+      name: "getDelegateStatement",
+    },
+    () => getDelegateStatementForAddress({ address: addressOrENSName })
+  );
+}
 
 /*
   Gets delegate statement from Postgres, or DynamoDB if not found

--- a/src/app/api/v1/apiUtils.ts
+++ b/src/app/api/v1/apiUtils.ts
@@ -1,0 +1,13 @@
+import * as log from "@/app/lib/logging";
+import * as otel from "@opentelemetry/api";
+import { SEMATTRS_ENDUSER_ID } from "@opentelemetry/semantic-conventions";
+
+export const withUserId = <T>(userId: string, fn: () => Promise<T>) => {
+  log.addSpanAttributes({ [SEMATTRS_ENDUSER_ID]: userId });
+  // Next JS is instrumented with OTel, and as such, any API call will have
+  // an active span and context. The below cast should be safe if used in an API route.
+  const ctxt = log.addBaggage({
+    [SEMATTRS_ENDUSER_ID]: userId as string,
+  }) as otel.Context;
+  return otel.context.with(ctxt, fn);
+};

--- a/src/app/api/v1/delegates/[addressOrENSName]/route.ts
+++ b/src/app/api/v1/delegates/[addressOrENSName]/route.ts
@@ -1,15 +1,16 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { fetchDelegate } from "@/app/api/common/delegates/getDelegates";
 import { authenticateApiUser } from "@/app/lib/middleware/auth";
-import { setCurrentSpanAttributes } from "@/app/lib/logging";
+import { addSpanAttributes } from "@/app/lib/logging";
 
 export async function GET(request: NextRequest) {
   const authResponse = await authenticateApiUser(request);
-  setCurrentSpanAttributes({ user_id: authResponse.userId });
 
   if (!authResponse.authenticated) {
     return new Response(authResponse.reason, { status: 401 });
   }
+
+  addSpanAttributes({ user_id: authResponse.userId });
 
   try {
     const addressOrENSName = request.nextUrl.pathname.split("/")[4];

--- a/src/app/api/v1/delegates/[addressOrENSName]/route.ts
+++ b/src/app/api/v1/delegates/[addressOrENSName]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { fetchDelegate } from "@/app/api/common/delegates/getDelegates";
 import { authenticateApiUser } from "@/app/lib/middleware/auth";
-import { addSpanAttributes } from "@/app/lib/logging";
+import { withUserId } from "../../apiUtils";
 
 export async function GET(request: NextRequest) {
   const authResponse = await authenticateApiUser(request);
@@ -10,15 +10,15 @@ export async function GET(request: NextRequest) {
     return new Response(authResponse.reason, { status: 401 });
   }
 
-  addSpanAttributes({ user_id: authResponse.userId });
-
-  try {
-    const addressOrENSName = request.nextUrl.pathname.split("/")[4];
-    const delegate = await fetchDelegate(addressOrENSName);
-    return NextResponse.json(delegate);
-  } catch (e: any) {
-    return new Response("Internal server error: " + e.toString(), {
-      status: 500,
-    });
-  }
+  return await withUserId(authResponse.userId as string, async () => {
+    try {
+      const addressOrENSName = request.nextUrl.pathname.split("/")[4];
+      const delegate = await fetchDelegate(addressOrENSName);
+      return NextResponse.json(delegate);
+    } catch (e: any) {
+      return new Response("Internal server error: " + e.toString(), {
+        status: 500,
+      });
+    }
+  });
 }

--- a/src/app/api/v1/delegates/route.ts
+++ b/src/app/api/v1/delegates/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
   if (!authResponse.authenticated) {
     return new Response(authResponse.reason, { status: 401 });
   }
-  
+
   addSpanAttributes({ user_id: authResponse.userId });
   addBaggage({ user_id: authResponse.userId as string });
 

--- a/src/app/api/v1/delegates/route.ts
+++ b/src/app/api/v1/delegates/route.ts
@@ -42,7 +42,6 @@ export async function GET(request: NextRequest) {
     return new Response(authResponse.reason, { status: 401 });
   }
 
-
   return await withUserId(authResponse.userId as string, async () => {
     const params = request.nextUrl.searchParams;
     try {

--- a/src/app/api/v1/delegates/route.ts
+++ b/src/app/api/v1/delegates/route.ts
@@ -13,7 +13,7 @@ import {
   createOptionalNumberValidator,
   createOptionalStringValidator,
 } from "@/app/api/common/utils/validators";
-import { setCurrentSpanAttributes } from "@/app/lib/logging";
+import { addBaggage, addSpanAttributes } from "@/app/lib/logging";
 
 const DEFAULT_SORT = "most_delegators";
 const DEFAULT_MAX_LIMIT = 100;
@@ -37,11 +37,13 @@ const offsetValidator = createOptionalNumberValidator(
 
 export async function GET(request: NextRequest) {
   const authResponse = await authenticateApiUser(request);
-  setCurrentSpanAttributes({ user_id: authResponse.userId });
 
   if (!authResponse.authenticated) {
     return new Response(authResponse.reason, { status: 401 });
   }
+  
+  addSpanAttributes({ user_id: authResponse.userId });
+  addBaggage({ user_id: authResponse.userId as string });
 
   const params = request.nextUrl.searchParams;
   try {

--- a/src/app/api/v1/delegates/route.ts
+++ b/src/app/api/v1/delegates/route.ts
@@ -65,5 +65,5 @@ export async function GET(request: NextRequest) {
         status: 500,
       });
     }
-  } 
+  });
 }

--- a/src/app/lib/logging.ts
+++ b/src/app/lib/logging.ts
@@ -59,17 +59,19 @@ export const time_this_sync = <T>(
   OTel contexts are immutable; as such, we create a new context with the added baggage.
 */
 export const addBaggage = (
-  baggage: Record<string, string> | undefined
-): otel.Context | null => {
-  let ctxt: otel.Context | null = null;
-  if (baggage) {
+  baggageToAdd: Record<string, string> | undefined
+): otel.Context => {
+  let ctxt: otel.Context;
+  if (baggageToAdd) {
     let baggage =
       otel.propagation.getBaggage(otel.context.active()) ||
       otel.propagation.createBaggage();
-    Object.entries(baggage).forEach(([key, value]) => {
+    Object.entries(baggageToAdd).forEach(([key, value]) => {
       baggage = baggage.setEntry(key, { value: value });
     });
     ctxt = otel.propagation.setBaggage(otel.context.active(), baggage);
+  } else {
+    ctxt = otel.context.active();
   }
   return ctxt;
 };

--- a/src/app/lib/logging.ts
+++ b/src/app/lib/logging.ts
@@ -1,8 +1,9 @@
-import { trace, Span } from "@opentelemetry/api";
+import * as otel from "@opentelemetry/api";
 import { type NextRequest } from "next/server";
 import { performance } from "perf_hooks";
 import * as util from "util";
 
+import { SEMATTRS_EXCEPTION_ESCAPED } from "@opentelemetry/semantic-conventions";
 import { SERVICE_NAME } from "@/instrumentation";
 
 // 'dev' is used in vercel dev and preview, both of which need to have coloring disabled
@@ -11,9 +12,9 @@ const log_emission =
   process.env.NEXT_PUBLIC_AGORA_ENV === "prod" ||
   process.env.NEXT_PUBLIC_AGORA_ENV === "dev";
 
-const tracer = trace.getTracer(SERVICE_NAME);
+export const OTEL_API_TRACER = otel.trace.getTracer(SERVICE_NAME);
 
-const time_this = async <T>(
+export const time_this = async <T>(
   fn: () => Promise<T>,
   log_fields: Record<string, any>
 ) => {
@@ -33,7 +34,7 @@ const time_this = async <T>(
   }
 };
 
-const time_this_sync = <T>(fn: () => T, log_fields: Record<string, any>) => {
+export const time_this_sync = <T>(fn: () => T, log_fields: Record<string, any>) => {
   const start = performance.now();
   try {
     return fn();
@@ -50,11 +51,94 @@ const time_this_sync = <T>(fn: () => T, log_fields: Record<string, any>) => {
   }
 };
 
-export const setCurrentSpanAttributes = <T>(
-  span_attrs: Record<string, any>
-) => {
-  const span = trace.getActiveSpan() as Span;
-  span.setAttributes(span_attrs);
-};
+/* 
+  Adds baggage to active context.
+  OTel contexts are immutable; as such, we create a new context with the added baggage.
+*/
+export const addBaggage = (baggage: Record<string, string> | undefined): otel.Context | null => {
+  let ctxt: otel.Context | null = null;
+  if (baggage) {
+    let baggage = otel.propagation.getBaggage(otel.context.active()) || otel.propagation.createBaggage();
+    Object.entries(baggage).forEach(([key, value]) => {
+      baggage = baggage.setEntry(key, {value: value});
+    });
+    ctxt = otel.propagation.setBaggage(otel.context.active(), baggage);
+  }
+  return ctxt;
+}
 
-export { time_this, time_this_sync };
+/*
+  Adds span attributes to the supplied span, or the active span if none is supplied.
+  No-op if there is no span supplied or if there is not an active span.
+*/
+export const addSpanAttributes = (span_attrs: Record<string, any>, span: otel.Span | null = null) => {
+  const chosenSpan = span || otel.trace.getActiveSpan();
+  if (chosenSpan) {
+    chosenSpan.setAttributes(span_attrs);
+    otel.trace.setSpan(otel.context.active(), chosenSpan);
+  }
+}
+
+/*
+  Runs supplied function within a span specified by the metadata.
+  If no tracer is supplied, uses the global tracer to create a span.
+  Adds all baggage in context as span attributes, including additional baggage.  
+*/
+export const doInSpan = <T>(
+  metadata: {
+    name: string;
+    tracer?: otel.Tracer;
+    additionalBaggage?: Record<string, string>;
+  },
+  fn: () => T
+): T | Promise<T> | undefined => {
+  const { tracer, name } = metadata;
+  let selectedTracer: otel.Tracer;
+  if (!tracer) {
+    selectedTracer = OTEL_API_TRACER;
+  } else {
+    selectedTracer = tracer;
+  }
+
+  const newCtxt = addBaggage(metadata.additionalBaggage);
+  
+  const startAndRunInSpan = () => selectedTracer.startActiveSpan(name, (span) => {
+    const handleSuccess = (response: T) => {
+      span.setStatus({ code: otel.SpanStatusCode.OK });
+      span.end();
+      return response;
+    };
+
+    const catchError = (error: otel.Exception) => {
+      span.recordException(error);
+      span.setStatus({ code: otel.SpanStatusCode.ERROR });
+      span.setAttribute(SEMATTRS_EXCEPTION_ESCAPED, true);
+      span.end();
+      throw error;
+    };
+
+    // unpack baggage and add to span attributes 
+    const baggage = otel.propagation.getBaggage(otel.context.active());
+    if (baggage) {
+      baggage.getAllEntries().forEach(([key, bag]) => {
+        span.setAttribute(key, bag.value);
+      });
+    }
+
+    try {
+      const response = fn();
+      if (response instanceof Promise) {
+        return response.then(handleSuccess, catchError);
+      }
+      return handleSuccess(response);
+    } catch (error) {
+      catchError(error as otel.Exception);
+    }
+  });
+
+  if (newCtxt) {
+    return otel.context.with(newCtxt, startAndRunInSpan);
+  } else {
+    return startAndRunInSpan();
+  }
+};

--- a/src/components/Dialogs/AdvancedDelegateDialog/SuccessView.tsx
+++ b/src/components/Dialogs/AdvancedDelegateDialog/SuccessView.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import BlockScanUrls from "@/components/shared/BlockScanUrl";
 import Image from "next/image";
-import successfulDelegation from "public/images/successfulDelegation.svg";
+import successfulDelegation from "../../../../../public/images/successfulDelegation.svg";
 import { useConnectButtonContext } from "@/contexts/ConnectButtonContext";
 import { useEffect } from "react";
 

--- a/src/components/Dialogs/AdvancedDelegateDialog/SuccessView.tsx
+++ b/src/components/Dialogs/AdvancedDelegateDialog/SuccessView.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import BlockScanUrls from "@/components/shared/BlockScanUrl";
 import Image from "next/image";
-import successfulDelegation from "../../../../../public/images/successfulDelegation.svg";
+import successfulDelegation from "../../../../public/images/successfulDelegation.svg";
 import { useConnectButtonContext } from "@/contexts/ConnectButtonContext";
 import { useEffect } from "react";
 

--- a/src/components/Proposals/ProposalPage/CastVoteDialog/CastVoteDialog.tsx
+++ b/src/components/Proposals/ProposalPage/CastVoteDialog/CastVoteDialog.tsx
@@ -11,8 +11,8 @@ import useAdvancedVoting from "../../../../hooks/useAdvancedVoting";
 import { CastVoteDialogProps } from "@/components/Dialogs/DialogProvider/dialogs";
 import { Button } from "@/components/ui/button";
 import { MissingVote, getVpToDisplay } from "@/lib/voteUtils";
-import pendingImage from "public/images/action-pending.svg";
-import congrats from "public/images/congrats.svg";
+import pendingImage from "../../../../../public/images/action-pending.svg";
+import congrats from "../../../../../public/images/congrats.svg";
 import BlockScanUrls from "@/components/shared/BlockScanUrl";
 
 export type SupportTextProps = {

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -1,30 +1,30 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import {
   SimpleSpanProcessor,
-  ConsoleSpanExporter,
 } from "@opentelemetry/sdk-trace-node";
-import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import {
   PeriodicExportingMetricReader,
-  ConsoleMetricExporter,
 } from "@opentelemetry/sdk-metrics";
 import { Resource } from "@opentelemetry/resources";
 import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
 import { SERVICE_NAME } from "./instrumentation";
-// TODO: Use OTLP exporter when we have a supported metrics collector or OTLP endpoint
-// import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 
 // NOTE: this instrumentation code will not run on the Vercel edge
 const sdk = new NodeSDK({
   resource: new Resource({
     [SEMRESATTRS_SERVICE_NAME]: SERVICE_NAME,
   }),
-  traceExporter: new ConsoleSpanExporter(),
+  traceExporter: new OTLPTraceExporter(),
   metricReader: new PeriodicExportingMetricReader({
-    exporter: new ConsoleMetricExporter(),
+    exporter: new OTLPMetricExporter(),
   }),
-  spanProcessor: new SimpleSpanProcessor(new ConsoleSpanExporter()),
-  // instrumentations: [getNodeAutoInstrumentations()],
+  spanProcessors: [
+    new SimpleSpanProcessor(
+      new OTLPTraceExporter()
+    )
+  ],
 });
 sdk.start();

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -1,12 +1,8 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
-import {
-  SimpleSpanProcessor,
-} from "@opentelemetry/sdk-trace-node";
+import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
-import {
-  PeriodicExportingMetricReader,
-} from "@opentelemetry/sdk-metrics";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { Resource } from "@opentelemetry/resources";
 import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
@@ -21,10 +17,6 @@ const sdk = new NodeSDK({
   metricReader: new PeriodicExportingMetricReader({
     exporter: new OTLPMetricExporter(),
   }),
-  spanProcessors: [
-    new SimpleSpanProcessor(
-      new OTLPTraceExporter()
-    )
-  ],
+  spanProcessors: [new SimpleSpanProcessor(new OTLPTraceExporter())],
 });
 sdk.start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1326,6 +1326,11 @@
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 
+"@opentelemetry/api@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.7.0.tgz#b139c81999c23e3c8d3c0a7234480e945920fc40"
+  integrity sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==
+
 "@opentelemetry/api@^1.0.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.8.0.tgz#5aa7abb48f23f693068ed2999ae627d2f7d902ec"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,7 +1312,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@opentelemetry/api-logs@0.46.0":
+"@opentelemetry/api-logs@0.46.0", "@opentelemetry/api-logs@^0.46.0":
   version "0.46.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.46.0.tgz#25b407de1c2b238a103789d750f6469a43a4f08c"
   integrity sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,10 +1222,10 @@
     "@motionone/dom" "^10.16.4"
     tslib "^2.3.1"
 
-"@next/env@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.0.3.tgz#9a58b296e7ae04ffebce8a4e5bd0f87f71de86bd"
-  integrity sha512-7xRqh9nMvP5xrW4/+L0jgRRX+HoNRGnfJpD+5Wq6/13j3dsdzxO3BCXn7D3hMqsDb+vjZnJq+vI7+EtgrYZTeA==
+"@next/env@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.1.4.tgz#432e80651733fbd67230bf262aee28be65252674"
+  integrity sha512-e7X7bbn3Z6DWnDi75UWn+REgAbLEqxI8Tq2pkFOFAMpWAWApz/YCUhtWMWn410h8Q2fYiYL7Yg5OlxMOCfFjJQ==
 
 "@next/eslint-plugin-next@13.4.1":
   version "13.4.1"
@@ -1234,50 +1234,50 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-darwin-arm64@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.3.tgz#b1a0440ffbf69056451947c4aea5b6d887e9fbbc"
-  integrity sha512-64JbSvi3nbbcEtyitNn2LEDS/hcleAFpHdykpcnrstITFlzFgB/bW0ER5/SJJwUPj+ZPY+z3e+1jAfcczRLVGw==
+"@next/swc-darwin-arm64@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.4.tgz#a3bca0dc4393ac4cf3169bbf24df63441de66bb7"
+  integrity sha512-ubmUkbmW65nIAOmoxT1IROZdmmJMmdYvXIe8211send9ZYJu+SqxSnJM4TrPj9wmL6g9Atvj0S/2cFmMSS99jg==
 
-"@next/swc-darwin-x64@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.3.tgz#48b527ef7eb5dbdcaf62fd107bc3a78371f36f09"
-  integrity sha512-RkTf+KbAD0SgYdVn1XzqE/+sIxYGB7NLMZRn9I4Z24afrhUpVJx6L8hsRnIwxz3ERE2NFURNliPjJ2QNfnWicQ==
+"@next/swc-darwin-x64@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.4.tgz#ba3683d4e2d30099f3f2864dd7349a4d9f440140"
+  integrity sha512-b0Xo1ELj3u7IkZWAKcJPJEhBop117U78l70nfoQGo4xUSvv0PJSTaV4U9xQBLvZlnjsYkc8RwQN1HoH/oQmLlQ==
 
-"@next/swc-linux-arm64-gnu@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.3.tgz#0a36475a38b2855ab8ea0fe8b56899bc90184c0f"
-  integrity sha512-3tBWGgz7M9RKLO6sPWC6c4pAw4geujSwQ7q7Si4d6bo0l6cLs4tmO+lnSwFp1Tm3lxwfMk0SgkJT7EdwYSJvcg==
+"@next/swc-linux-arm64-gnu@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.4.tgz#3519969293f16379954b7e196deb0c1eecbb2f8b"
+  integrity sha512-457G0hcLrdYA/u1O2XkRMsDKId5VKe3uKPvrKVOyuARa6nXrdhJOOYU9hkKKyQTMru1B8qEP78IAhf/1XnVqKA==
 
-"@next/swc-linux-arm64-musl@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.3.tgz#25328a9f55baa09fde6364e7e47ade65c655034f"
-  integrity sha512-v0v8Kb8j8T23jvVUWZeA2D8+izWspeyeDGNaT2/mTHWp7+37fiNfL8bmBWiOmeumXkacM/AB0XOUQvEbncSnHA==
+"@next/swc-linux-arm64-musl@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.4.tgz#4bb3196bd402b3f84cf5373ff1021f547264d62f"
+  integrity sha512-l/kMG+z6MB+fKA9KdtyprkTQ1ihlJcBh66cf0HvqGP+rXBbOXX0dpJatjZbHeunvEHoBBS69GYQG5ry78JMy3g==
 
-"@next/swc-linux-x64-gnu@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.3.tgz#594b747e3c8896b2da67bba54fcf8a6b5a410e5e"
-  integrity sha512-VM1aE1tJKLBwMGtyBR21yy+STfl0MapMQnNrXkxeyLs0GFv/kZqXS5Jw/TQ3TSUnbv0QPDf/X8sDXuMtSgG6eg==
+"@next/swc-linux-x64-gnu@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.4.tgz#1b3372c98c83dcdab946cdb4ee06e068b8139ba3"
+  integrity sha512-BapIFZ3ZRnvQ1uWbmqEGJuPT9cgLwvKtxhK/L2t4QYO7l+/DxXuIGjvp1x8rvfa/x1FFSsipERZK70pewbtJtw==
 
-"@next/swc-linux-x64-musl@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.3.tgz#a02da58fc6ecad8cf5c5a2a96a7f6030ec7f6215"
-  integrity sha512-64EnmKy18MYFL5CzLaSuUn561hbO1Gk16jM/KHznYP3iCIfF9e3yULtHaMy0D8zbHfxset9LTOv6cuYKJgcOxg==
+"@next/swc-linux-x64-musl@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.4.tgz#8459088bdc872648ff78f121db596f2533df5808"
+  integrity sha512-mqVxTwk4XuBl49qn2A5UmzFImoL1iLm0KQQwtdRJRKl21ylQwwGCxJtIYo2rbfkZHoSKlh/YgztY0qH3wG1xIg==
 
-"@next/swc-win32-arm64-msvc@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.3.tgz#bf2be23d3ba2ebd0d4a9376a31f783efdb677b48"
-  integrity sha512-WRDp8QrmsL1bbGtsh5GqQ/KWulmrnMBgbnb+59qNTW1kVi1nG/2ndZLkcbs2GX7NpFLlToLRMWSQXmPzQm4tog==
+"@next/swc-win32-arm64-msvc@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.4.tgz#84280a08c00cc3be24ddd3a12f4617b108e6dea6"
+  integrity sha512-xzxF4ErcumXjO2Pvg/wVGrtr9QQJLk3IyQX1ddAC/fi6/5jZCZ9xpuL9Tzc4KPWMFq8GGWFVDMshZOdHGdkvag==
 
-"@next/swc-win32-ia32-msvc@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.3.tgz#839f8de85a4bf2c3c69242483ab87cb916427551"
-  integrity sha512-EKffQeqCrj+t6qFFhIFTRoqb2QwX1mU7iTOvMyLbYw3QtqTw9sMwjykyiMlZlrfm2a4fA84+/aeW+PMg1MjuTg==
+"@next/swc-win32-ia32-msvc@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.4.tgz#23ff7f4bd0a27177428669ef6fa5c3923c738031"
+  integrity sha512-WZiz8OdbkpRw6/IU/lredZWKKZopUMhcI2F+XiMAcPja0uZYdMTZQRoQ0WZcvinn9xZAidimE7tN9W5v9Yyfyw==
 
-"@next/swc-win32-x64-msvc@14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.3.tgz#27b623612b1d0cea6efe0a0d31aa1a335fc99647"
-  integrity sha512-ERhKPSJ1vQrPiwrs15Pjz/rvDHZmkmvbf/BjPN/UCOI++ODftT0GtasDPi0j+y6PPJi5HsXw+dpRaXUaw4vjuQ==
+"@next/swc-win32-x64-msvc@14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.4.tgz#bccf5beccfde66d6c66fa4e2509118c796385eda"
+  integrity sha512-4Rto21sPfw555sZ/XNLqfxDUNeLhNYGO2dlPqsnuCg8N8a2a9u1ltqBOPQ4vj1Gf7eJC0W2hHG2eYUHuiXgY2w==
 
 "@noble/curves@1.2.0", "@noble/curves@^1.2.0", "@noble/curves@~1.2.0":
   version "1.2.0"
@@ -5050,10 +5050,15 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
-caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001565:
+caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001565:
   version "1.0.30001566"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz#61a8e17caf3752e3e426d4239c549ebbb37fef0d"
   integrity sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==
+
+caniuse-lite@^1.0.30001579:
+  version "1.0.30001600"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz#93a3ee17a35aa6a9f0c6ef1b2ab49507d1ab9079"
+  integrity sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -6546,11 +6551,6 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-to-regexp@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
-  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
-
 glob@7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -6648,7 +6648,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -8065,28 +8065,28 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next@^14.0.1:
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/next/-/next-14.0.3.tgz#8d801a08eaefe5974203d71092fccc463103a03f"
-  integrity sha512-AbYdRNfImBr3XGtvnwOxq8ekVCwbFTv/UJoLwmaX89nk9i051AEY4/HAWzU0YpaTDw8IofUpmuIlvzWF13jxIw==
+next@14.1.4:
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/next/-/next-14.1.4.tgz#203310f7310578563fd5c961f0db4729ce7a502d"
+  integrity sha512-1WTaXeSrUwlz/XcnhGTY7+8eiaFvdet5z9u3V2jb+Ek1vFo0VhHKSAIJvDWfQpttWjnyw14kBeq28TPq7bTeEQ==
   dependencies:
-    "@next/env" "14.0.3"
+    "@next/env" "14.1.4"
     "@swc/helpers" "0.5.2"
     busboy "1.6.0"
-    caniuse-lite "^1.0.30001406"
+    caniuse-lite "^1.0.30001579"
+    graceful-fs "^4.2.11"
     postcss "8.4.31"
     styled-jsx "5.1.1"
-    watchpack "2.4.0"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "14.0.3"
-    "@next/swc-darwin-x64" "14.0.3"
-    "@next/swc-linux-arm64-gnu" "14.0.3"
-    "@next/swc-linux-arm64-musl" "14.0.3"
-    "@next/swc-linux-x64-gnu" "14.0.3"
-    "@next/swc-linux-x64-musl" "14.0.3"
-    "@next/swc-win32-arm64-msvc" "14.0.3"
-    "@next/swc-win32-ia32-msvc" "14.0.3"
-    "@next/swc-win32-x64-msvc" "14.0.3"
+    "@next/swc-darwin-arm64" "14.1.4"
+    "@next/swc-darwin-x64" "14.1.4"
+    "@next/swc-linux-arm64-gnu" "14.1.4"
+    "@next/swc-linux-arm64-musl" "14.1.4"
+    "@next/swc-linux-x64-gnu" "14.1.4"
+    "@next/swc-linux-x64-musl" "14.1.4"
+    "@next/swc-win32-arm64-msvc" "14.1.4"
+    "@next/swc-win32-ia32-msvc" "14.1.4"
+    "@next/swc-win32-x64-msvc" "14.1.4"
 
 node-addon-api@^2.0.0:
   version "2.0.2"
@@ -10279,14 +10279,6 @@ wagmi@^1.4.7:
     "@wagmi/core" "1.4.8"
     abitype "0.8.7"
     use-sync-external-store "^1.2.0"
-
-watchpack@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
-  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
-  dependencies:
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.1.2"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,6 +1405,17 @@
   dependencies:
     "@opentelemetry/semantic-conventions" "1.22.0"
 
+"@opentelemetry/exporter-metrics-otlp-http@^0.49.1":
+  version "0.49.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.49.1.tgz#e38a84f771468a13850d22bcb9a1cee09a95e835"
+  integrity sha512-t/sWYqfcwn81SvYHIyYJDlJD2CjFz3/h2t4j+XCtdoHAfu+WVJQmwLsGYJPlCDp3UXQfFpMJMWvLlvtD2SL+rg==
+  dependencies:
+    "@opentelemetry/core" "1.22.0"
+    "@opentelemetry/otlp-exporter-base" "0.49.1"
+    "@opentelemetry/otlp-transformer" "0.49.1"
+    "@opentelemetry/resources" "1.22.0"
+    "@opentelemetry/sdk-metrics" "1.22.0"
+
 "@opentelemetry/exporter-trace-otlp-grpc@0.46.0":
   version "0.46.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz#72161fdb56c67531836221d886208604f31654c1"


### PR DESCRIPTION
- Bump next version (add relative import to fix issue with breaking imports)
- Resolve OTel peer dependency issues
- Use OTLP

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates import paths and adds OpenTelemetry logging features. 

### Detailed summary
- Updated import paths for images in multiple components
- Added OpenTelemetry logging functions for tracing and context management
- Updated dependencies for OpenTelemetry to include exporters and APIs

> The following files were skipped due to too many changes: `src/app/lib/logging.ts`, `yarn.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->