### PR TITLE
Deprecate dynamo store

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "generate-apikey": "ts-node src/scripts/generateApiKey.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.454.0",
     "@babel/core": "^7.0.0-0",
     "@emotion/css": "^11.11.2",
     "@headlessui/react": "^1.7.17",
@@ -81,6 +80,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.454.0",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.10",
     "@typechain/ethers-v6": "^0.5.1",

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -2,10 +2,8 @@ import "server-only";
 
 import prisma from "@/app/lib/prisma";
 import { cache } from "react";
-import { makeDynamoClient } from "@/app/lib/dynamodb";
 import { addressOrEnsNameWrap } from "../utils/ensName";
 import Tenant from "@/lib/tenant/tenant";
-import { DaoSlug } from "@prisma/client";
 
 export const getDelegateStatement = (addressOrENSName: string) =>
   addressOrEnsNameWrap(getDelegateStatementForAddress, addressOrENSName);
@@ -20,61 +18,9 @@ async function getDelegateStatementForAddress({
 }) {
   const { slug } = Tenant.current();
 
-  const postgreqsqlData = await prisma.delegateStatements
+  return prisma.delegateStatements
     .findFirst({ where: { address: address.toLowerCase(), dao_slug: slug } })
     .catch((error) => console.error(error));
-  return postgreqsqlData
-    ? postgreqsqlData
-    : slug === DaoSlug.OP // Only fetch from Dynamo for optimism
-    ? await getDelegateStatementForAddressDynamo(address)
-    : null;
-}
-
-/*
-  Gets delegate statement from DynamoDB
-*/
-async function getDelegateStatementForAddressDynamo(address: string) {
-  const dynamoDBClient = makeDynamoClient();
-
-  try {
-    const data = await dynamoDBClient.getItem({
-      TableName: "ApplicationData",
-      Key: {
-        PartitionKey: { S: "DelegateStatement" },
-        SortKey: { S: address },
-      },
-      ProjectionExpression: "address, signature, signedPayload",
-    });
-
-    // If the item exists, return the payload
-    if (data.Item) {
-      // Extract the signedPayload attribute from the Item object
-      const signedPayload = data.Item.signedPayload.S;
-
-      const delegateStatementObject = JSON.parse(signedPayload as string);
-
-      return {
-        address, // assuming 'address' is a variable containing the address
-        email: null,
-        payload: {
-          leastValuableProposals:
-            delegateStatementObject.leastValuableProposals,
-          mostValuableProposals: delegateStatementObject.mostValuableProposals,
-          openToSponsoringProposals:
-            delegateStatementObject.openToSponsoringProposals,
-          delegateStatement: delegateStatementObject.delegateStatement,
-          topIssues: delegateStatementObject.topIssues,
-        },
-        twitter: delegateStatementObject.twitter,
-        discord: delegateStatementObject.discord,
-      };
-    } else {
-      return null;
-    }
-  } catch (error) {
-    console.error(error);
-    return null;
-  }
 }
 
 export const fetchDelegateStatement = cache(getDelegateStatement);

--- a/src/scripts/uploadDelegateStatements.ts
+++ b/src/scripts/uploadDelegateStatements.ts
@@ -1,0 +1,73 @@
+const { PrismaClient } = require("@prisma/client");
+const { DaoSlug } = require("@prisma/client");
+const fs = require("fs");
+const readline = require("readline");
+
+async function main(filePath: string) {
+  const prisma = new PrismaClient({});
+
+  const fileStream = fs.createReadStream(filePath);
+  const rl = readline.createInterface({
+    input: fileStream,
+    crlfDelay: Infinity,
+  });
+
+  const delegateStatements = [];
+
+  for await (const line of rl) {
+    // console.log(line);
+
+    // Each line in the file is a complete JSON object
+    const statement = JSON.parse(line);
+    delegateStatements.push({
+      address: statement.SortKey.toLowerCase(),
+      dao_slug: DaoSlug.OP,
+      signature: statement.signature,
+      payload: JSON.parse(statement.signedPayload),
+      twitter: JSON.parse(statement.signedPayload)?.twitter,
+      discord: JSON.parse(statement.signedPayload)?.discord,
+      email: null,
+    });
+  }
+
+  try {
+    // Retrieve existing IDs
+    const existingIds = new Set(
+      (
+        await prisma.delegateStatements.findMany({
+          select: { address: true },
+          where: {
+            address: {
+              in: delegateStatements.map((stmt) => stmt.address),
+            },
+          },
+        })
+      ).map((stmt: any) => stmt.address)
+    );
+
+    console.log(`${existingIds.size} existing statements found.`);
+    console.log(existingIds);
+
+    // Filter out existing records
+    const newStatements = delegateStatements.filter(
+      (stmt) => !existingIds.has(stmt.address)
+    );
+
+    // Bulk insert new records
+    if (newStatements.length > 0) {
+      await prisma.delegateStatements.createMany({
+        data: newStatements,
+        skipDuplicates: true, // This ensures we skip duplicates if any exist
+      });
+      console.log(`${newStatements.length} new statements have been added.`);
+    } else {
+      console.log("No new statements to add.");
+    }
+  } catch (error) {
+    console.error("Error processing the JSONL file:", error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main("statements.jsonl");


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the codebase to use Prisma for database operations and remove DynamoDB dependency.

### Detailed summary
- Added `PrismaClient` for database operations
- Refactored functions to use Prisma queries instead of DynamoDB
- Removed unused imports and DynamoDB related code

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->