### PR TITLE
[1854, 1884] Move connected delegate server action to client

### DIFF
--- a/src/app/api/v1/delegates/[addressOrENSName]/delegation-chains/route.ts
+++ b/src/app/api/v1/delegates/[addressOrENSName]/delegation-chains/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { fetchAllDelegatorsInChains, } from "@/app/api/common/delegations/getDelegations";
+import { authenticateApiUser } from "@/app/lib/middleware/auth";
+import { setCurrentSpanAttributes } from "@/app/lib/logging";
+
+export async function GET(request: NextRequest) {
+  const authResponse = await authenticateApiUser(request);
+  setCurrentSpanAttributes({ user_id: authResponse.userId });
+
+  if (!authResponse.authenticated) {
+    return new Response(authResponse.reason, { status: 401 });
+  }
+
+  try {
+    const addressOrENSName = request.nextUrl.pathname.split("/")[4];
+    const delegate = await fetchAllDelegatorsInChains(addressOrENSName);
+    return NextResponse.json(delegate);
+  } catch (e: any) {
+    return new Response("Internal server error: " + e.toString(), {
+      status: 500,
+    });
+  }
+}

--- a/src/app/delegates/actions.ts
+++ b/src/app/delegates/actions.ts
@@ -114,14 +114,6 @@ export async function balanceOf(address: string) {
   return contracts.token.contract.balanceOf(address);
 }
 
-export const fetchConnectedDelegate = async (address: string) => {
-  return await Promise.all([
-    fetchDelegate(address),
-    fetchAllDelegatorsInChainsForAddress(address),
-    balanceOf(address),
-  ]);
-};
-
 export const revalidateDelegateAddressPage = async (
   delegateAddress: string
 ) => {


### PR DESCRIPTION
Preview link: https://agora-next-53yht28w7-voteagora.vercel.app/

I did set the PR as a draft in case you want to change the API route @Flip-Liquid

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `useConnectedDelegate` hook to use `AgoraAPI` for fetching delegate data efficiently.

### Detailed summary
- Refactored `useConnectedDelegate` to use `AgoraAPI` for fetching delegate data
- Removed `fetchConnectedDelegate` function from `actions.ts`
- Updated API calls in `route.ts` to use `fetchAllDelegatorsInChains`
- Added imports and removed unnecessary functions from `useConnectedDelegate.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->