### PR TITLE
Pull uniswap schemas

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  schemas  = ["agora", "config", "ens", "etherfi", "optimism", "snapshot"]
+  schemas  = ["agora", "config", "ens", "etherfi", "optimism", "snapshot", "uniswap"]
 }
 
 model DelegateStatements {
@@ -267,6 +267,17 @@ view ensDelegatees {
   @@schema("ens")
 }
 
+view OptimismStakedDeposits {
+  deposit_id  BigInt  @unique
+  depositor   String
+  beneficiary String
+  delegatee   String
+  amount      Decimal @db.Decimal
+
+  @@map("staked_deposits")
+  @@schema("optimism")
+}
+
 view ensDelegates {
   delegate          String   @unique
   num_of_delegators Decimal? @db.Decimal
@@ -410,6 +421,17 @@ view ensProposalTypes {
   inputs             Json
 
   @@map("proposal_types")
+  @@schema("ens")
+}
+
+view ensStakedDeposits {
+  deposit_id  BigInt  @unique
+  depositor   String
+  beneficiary String
+  delegatee   String
+  amount      Decimal @db.Decimal
+
+  @@map("staked_deposits")
   @@schema("ens")
 }
 
@@ -567,6 +589,184 @@ view etherfiProposalTypes {
 
   @@map("proposal_types")
   @@schema("etherfi")
+}
+
+view etherfiStakedDeposits {
+  deposit_id  BigInt  @unique
+  depositor   String
+  beneficiary String
+  delegatee   String
+  amount      Decimal @db.Decimal
+
+  @@map("staked_deposits")
+  @@schema("etherfi")
+}
+
+view uniswapDelegatees {
+  delegator    String  @unique
+  delegatee    String
+  block_number BigInt
+  balance      Decimal @db.Decimal
+
+  @@map("delegatees")
+  @@schema("uniswap")
+}
+
+view uniswapDelegates {
+  delegate          String   @unique
+  num_of_delegators Decimal? @db.Decimal
+  direct_vp         Decimal? @db.Decimal
+  advanced_vp       Decimal? @db.Decimal
+  voting_power      Decimal? @db.Decimal
+
+  @@map("delegates")
+  @@schema("uniswap")
+}
+
+view uniswapVotableSupply {
+  votable_supply String @unique
+
+  @@map("votable_supply")
+  @@schema("uniswap")
+}
+
+view uniswapVotingPower {
+  delegate     String  @unique
+  voting_power String?
+
+  @@map("voting_power")
+  @@schema("uniswap")
+}
+
+view uniswapVotingPowerSnaps {
+  id           String   @id
+  delegate     String?
+  balance      String?
+  block_number BigInt?
+  ordinal      Decimal? @db.Decimal
+
+  @@map("voting_power_snaps")
+  @@schema("uniswap")
+}
+
+view uniswapProposals {
+  proposal_id        String       @unique
+  contract           String       @db.VarChar
+  proposer           String
+  description        String?
+  ordinal            Decimal      @db.Decimal
+  created_block      BigInt?
+  start_block        String
+  end_block          String?
+  cancelled_block    BigInt?
+  executed_block     BigInt?
+  proposal_data      Json?
+  proposal_data_raw  String?
+  proposal_type      ProposalType
+  proposal_type_data Json?
+  proposal_results   Json?
+
+  @@map("proposals")
+  @@schema("uniswap")
+}
+
+view uniswapVoterStats {
+  voter              String   @unique
+  proposals_voted    BigInt?
+  participation_rate Float?
+  last_10_props      Decimal? @db.Decimal
+  for                BigInt?
+  abstain            BigInt?
+  against            BigInt?
+
+  @@map("voter_stats")
+  @@schema("uniswap")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view uniswapVotes {
+  transaction_hash String       @unique @db.VarChar
+  proposal_id      String
+  voter            String
+  support          String
+  weight           Decimal      @db.Decimal
+  reason           String?
+  block_number     BigInt
+  params           String?
+  start_block      String?
+  description      String?
+  proposal_data    Json
+  proposal_type    ProposalType
+
+  @@map("votes")
+  @@schema("uniswap")
+}
+
+view uniswapAdvancedDelegatees {
+  pair             String  @unique
+  from             String
+  to               String
+  delegated_amount Decimal @db.Decimal
+  delegated_share  Decimal @db.Decimal
+  block_number     BigInt
+  contract         String? @db.VarChar
+
+  @@map("advanced_delegatees")
+  @@schema("uniswap")
+}
+
+view uniswapAdvancedVotingPower {
+  delegate                 String   @unique
+  vp_allowance             Decimal  @db.Decimal
+  vp_delegatable_allowance Decimal  @db.Decimal
+  delegated_vp             Decimal  @db.Decimal
+  advanced_vp              Decimal  @db.Decimal
+  subdelegated_share       Decimal? @db.Decimal
+  contract                 String?  @db.VarChar
+
+  @@map("advanced_voting_power")
+  @@schema("uniswap")
+}
+
+view uniswapAuthorityChainsSnaps {
+  id                   String   @unique
+  delegate             String
+  rules                Json[]
+  chain                String[]
+  proxy                String
+  balance              Decimal  @db.Decimal
+  allowance            Decimal  @db.Decimal
+  contract             String?  @db.VarChar
+  balance_block_number BigInt
+  balance_ordinal      Decimal? @db.Decimal
+
+  @@map("authority_chains_snaps")
+  @@schema("uniswap")
+}
+
+view uniswapProposalTypes {
+  id                 String @unique
+  contract           String @db.VarChar
+  block_number       BigInt
+  proposal_type_id   String
+  quorum             String
+  approval_threshold String
+  name               String
+  inputs             Json
+
+  @@map("proposal_types")
+  @@schema("uniswap")
+}
+
+view uniswapStakedDeposits {
+  deposit_id  BigInt  @unique
+  depositor   String
+  beneficiary String
+  delegatee   String
+  amount      Decimal @db.Decimal
+
+  @@map("staked_deposits")
+  @@schema("uniswap")
 }
 
 /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
@@ -956,6 +1156,128 @@ view etherfi_vote_cast_with_params_events {
   @@schema("etherfi")
 }
 
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view uniswap_advanced_voting_power_raw_snaps {
+  chain_str           String?
+  delegate            String?
+  chain               String[]
+  rules               Json?
+  allowance           Decimal? @db.Decimal
+  subdelegated_share  Decimal? @db.Decimal
+  subdelegated_amount Decimal? @db.Decimal
+  balance             Decimal? @db.Decimal
+  block_number        BigInt?
+  proxy               String?
+  contract            String?  @db.VarChar
+  ordinal             Decimal? @db.Decimal
+
+  @@map("advanced_voting_power_raw_snaps")
+  @@ignore
+  @@schema("uniswap")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view uniswap_authority_chains {
+  delegate  String?
+  rules     Json?
+  chain     String[]
+  balance   Decimal? @db.Decimal
+  allowance Decimal? @db.Decimal
+  contract  String?  @db.VarChar
+
+  @@map("authority_chains")
+  @@ignore
+  @@schema("uniswap")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+/// This view or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+view uniswap_delegates_wrapper {
+  delegate          String?
+  num_of_delegators Decimal? @db.Decimal
+  direct_vp         Decimal? @db.Decimal
+  advanced_vp       Decimal? @db.Decimal
+  voting_power      Decimal? @db.Decimal
+
+  @@map("delegates_wrapper")
+  @@ignore
+  @@schema("uniswap")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view uniswap_direct_chains {
+  delegate  String?
+  rules     Json?
+  chain     String?
+  balance   Decimal? @db.Decimal
+  allowance Decimal? @db.Decimal
+  contract  String?  @db.VarChar
+
+  @@map("direct_chains")
+  @@ignore
+  @@schema("uniswap")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view uniswap_direct_chains_snaps {
+  delegate             String?
+  rules                Json?
+  chain                String?
+  proxy                String?
+  balance              Decimal? @db.Decimal
+  balance_block_number BigInt?
+  allowance            Decimal? @db.Decimal
+  contract             String?  @db.VarChar
+  balance_ordinal      Decimal? @db.Decimal
+
+  @@map("direct_chains_snaps")
+  @@ignore
+  @@schema("uniswap")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view uniswap_vote_cast_events {
+  transaction_hash String?
+  proposal_id      String?
+  voter            String?
+  support          String?
+  weight           Decimal? @db.Decimal
+  reason           String?
+  block_number     BigInt?
+  params           String?
+
+  @@map("vote_cast_events")
+  @@ignore
+  @@schema("uniswap")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view uniswap_vote_cast_with_params_events {
+  transaction_hash String?
+  proposal_id      String?
+  voter            String?
+  support          String?
+  weight           Decimal? @db.Decimal
+  reason           String?
+  block_number     BigInt?
+  params           String?
+
+  @@map("vote_cast_with_params_events")
+  @@ignore
+  @@schema("uniswap")
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view delgatees {
+  delegator    String?
+  delegatee    String?
+  block_number BigInt?
+  balance      Decimal? @db.Decimal
+
+  @@ignore
+  @@schema("optimism")
+}
+
 enum DaoSlug {
   OP
   ENS
@@ -963,6 +1285,7 @@ enum DaoSlug {
   NOUNS
   LYRA
   ETHERFI
+  UNISWAP
 
   @@map("dao_slug")
   @@schema("config")


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for Uniswap-related views in the Prisma schema.

### Detailed summary
- Added views for Uniswap-related data such as delegates, staked deposits, voter stats, proposals, and more.
- Updated the schema to include Uniswap-specific views and mappings.
- Enhanced the Prisma schema to handle Uniswap data effectively.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->