### PR TITLE
Ferrodri/agora 1900 bugs in advanced delegation

### DIFF
--- a/src/components/Dialogs/AdvancedDelegateDialog/AdvancedDelegateDialog.tsx
+++ b/src/components/Dialogs/AdvancedDelegateDialog/AdvancedDelegateDialog.tsx
@@ -217,7 +217,9 @@ export function AdvancedDelegateDialog({
                   </HStack>
                   <AdvancedDelegationDisplayAmount amount={availableBalance} />
                 </VStack>
-                <VStack className="max-h-[400px] overflow-y-scroll">
+                <VStack
+                  className={`overflow-y-scroll ${overflowDelegation ? "max-h-[240px] sm:max-h-[400px]" : "max-h-[400px]"}`}
+                >
                   {delegatees.map((delegatee, index) => (
                     <SubdelegationToRow
                       key={index}


### PR DESCRIPTION
In mobile when you have overdelegated the claim text was not visible.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to dynamically adjust the max height of a `VStack` component based on a condition in `AdvancedDelegateDialog.tsx`.

### Detailed summary
- Dynamically adjust max height of `VStack` based on `overflowDelegation` condition
- Update `className` prop with conditional logic

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->