### PR TITLE
Fixes scrollbar issue on delegate vote with reason card

### DIFF
--- a/src/components/Delegates/DelegateVotes/delegateVotes.module.scss
+++ b/src/components/Delegates/DelegateVotes/delegateVotes.module.scss
@@ -27,6 +27,12 @@
   display: grid;
   overflow-y: hidden;
   grid-template-columns: 1fr 1px 1fr;
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox */
+
+  ::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 
   @media (max-width: $screen-sm) {
     grid-template-rows: 1fr;
@@ -70,14 +76,19 @@
 }
 
 .vote_reason_container {
-  overflow-y: scroll;
-  overflow-x: scroll;
+  overflow-x: hidden;
   padding: $spacing-4 $spacing-6;
   font-size: $font-size-xs;
   font-weight: $font-weight-medium;
   white-space: pre-wrap;
   color: #66676b;
-  width: fit-content;
+  word-wrap: break-word;
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox */
+
+  ::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 
   @media (max-width: $screen-sm) {
     padding-top: 0;


### PR DESCRIPTION
Resolves AGORA-1931

The text now wraps when the string is long enough to warrant horizontal scrolling.
<img width="860" alt="Screenshot 2024-04-22 at 12 50 08 PM" src="https://github.com/voteagora/agora-next/assets/12549482/27150102-ec01-471a-a87d-e13594ad88b5">

Here it is on mobile.
<img width="612" alt="Screenshot 2024-04-22 at 12 58 44 PM" src="https://github.com/voteagora/agora-next/assets/12549482/d4a24c4c-6706-47a4-9370-5edf27542583">

I had to hide the scrollbar in some cases, otherwise we got this strange blocking artifact around the corners.
<img width="568" alt="Screenshot 2024-04-22 at 12 58 55 PM" src="https://github.com/voteagora/agora-next/assets/12549482/d92c9e96-cb1c-440c-b5e3-557364b7f870">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the styling of scrollbars in the `DelegateVotes` component. 

### Detailed summary
- Updated scrollbar styles for different browsers
- Improved text wrapping in `vote_reason_container` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->