### PR TITLE
Fixes duplicate twitter metadata

### DIFF
--- a/src/app/delegates/[addressOrENSName]/page.tsx
+++ b/src/app/delegates/[addressOrENSName]/page.tsx
@@ -73,10 +73,10 @@ export async function generateMetadata(
         },
       ],
     },
-    other: {
-      ["twitter:card"]: "summary_large_image",
-      ["twitter:title"]: title,
-      ["twitter:description"]: description,
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
     },
   };
 }

--- a/src/app/delegates/edit/page.tsx
+++ b/src/app/delegates/edit/page.tsx
@@ -22,10 +22,10 @@ export async function generateMetadata({}) {
         },
       ],
     },
-    other: {
-      ["twitter:card"]: "summary_large_image",
-      ["twitter:title"]: title,
-      ["twitter:description"]: description,
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
     },
   };
 }

--- a/src/app/delegates/page.jsx
+++ b/src/app/delegates/page.jsx
@@ -56,10 +56,10 @@ export async function generateMetadata({}, parent) {
         },
       ],
     },
-    other: {
-      ["twitter:card"]: "summary_large_image",
-      ["twitter:title"]: title,
-      ["twitter:description"]: description,
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
     },
   };
 }

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -65,11 +65,6 @@ export async function generateMetadata({}, parent) {
       title,
       description,
     },
-    // other: {
-    //   ["twitter:card"]: "summary_large_image",
-    //   ["twitter:title"]: title,
-    //   ["twitter:description"]: description,
-    // },
   };
 }
 

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -60,11 +60,16 @@ export async function generateMetadata({}, parent) {
         },
       ],
     },
-    other: {
-      ["twitter:card"]: "summary_large_image",
-      ["twitter:title"]: title,
-      ["twitter:description"]: description,
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
     },
+    // other: {
+    //   ["twitter:card"]: "summary_large_image",
+    //   ["twitter:title"]: title,
+    //   ["twitter:description"]: description,
+    // },
   };
 }
 

--- a/src/app/proposals/[proposal_id]/page.jsx
+++ b/src/app/proposals/[proposal_id]/page.jsx
@@ -34,10 +34,10 @@ export async function generateMetadata({ params }, parent) {
         },
       ],
     },
-    other: {
-      ["twitter:card"]: "summary_large_image",
-      ["twitter:title"]: title,
-      ["twitter:description"]: description,
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
     },
   };
 }

--- a/src/app/retropgf/3/summary/page.tsx
+++ b/src/app/retropgf/3/summary/page.tsx
@@ -30,10 +30,10 @@ export async function generateMetadata() {
         },
       ],
     },
-    other: {
-      ["twitter:card"]: "summary_large_image",
-      ["twitter:title"]: title,
-      ["twitter:description"]: description,
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
     },
   };
 }


### PR DESCRIPTION
Resolves AGORA-1872
Fairly certain this resolves it, it was resolving the issue on local.
Once this PR builds on vercel we can test by inspecting the metadata and [OG previews](https://vercel.com/docs/deployments/og-preview).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the structure of Twitter metadata in multiple page components to use a nested `twitter` object.

### Detailed summary
- Updated Twitter metadata structure in `page.jsx`, `page.tsx`, and other related files
- Replaced individual properties with a nested `twitter` object for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->