### PR TITLE
updated OP changelog

### DIFF
--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -53,6 +53,194 @@ export default function Page() {
               </div>
             </div>
             <div className="my-8 border-t border-gray-300"></div>
+            <div className={styles.changelogItem}>
+              <p id="changelogfeb2024" className={styles.changlogDate}>
+                {formatFullDate(new Date(2024, 3, 15))}
+              </p>
+              <h3 className={styles.changelogTitle}>
+                Governance Client Changelog #4
+              </h3>
+              <p>Morning OP collective,</p>
+              <p>
+                The past few weeks have been all about making our API faster and
+                more secure. We added authentication, started work on rate
+                limiting, and did some performance optimizations under the hood.
+              </p>
+              <p>
+                On the client side, we did some clean up around Optimistic
+                proposal creation and more improvements to make the loading of
+                delegate cards faster.
+              </p>
+              <p>Keep the feedback coming and have a great week,</p>
+              <p>
+                <a href="https://twitter.com/kentf">Kent</a>, Co-founder at{" "}
+                <a href="https://voteagora.com">Agora</a>
+              </p>
+              <br />
+              <br />
+              <h4> Major Updates </h4>
+              <ul>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/199"
+                      target="_blank"
+                    >
+                      API User Authentication
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="ttps://github.com/voteagora/agora-next/pull/201"
+                      target="_blank"
+                    >
+                      Simplified and Optimized Token Amount Display
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/202"
+                      target="_blank"
+                    >
+                      Enhanced Proposal Handling
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/212"
+                      target="_blank"
+                    >
+                      Formal OAS for Agora API
+                    </a>
+                  </p>
+                </li>
+              </ul>
+              <br />
+              <h4> Minor Updates </h4>
+              <ul>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/205"
+                      target="_blank"
+                    >
+                      Emit User Id with API Calls
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/182"
+                      target="_blank"
+                    >
+                      Update Various Components and Hooks
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/183"
+                      target="_blank"
+                    >
+                      Resolved Requests being cancelled when trying to vote
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/187"
+                      target="_blank"
+                    >
+                      API Routes and Validators & Pagination Logic{" "}
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href=" https://github.com/voteagora/agora-next/pull/191"
+                      target="_blank"
+                    >
+                      UI Consistency with Links{" "}
+                    </a>
+                  </p>
+                </li>
+              </ul>
+              <br />
+              <h4> Bug Fixes </h4>
+              <ul>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/180"
+                      target="_blank"
+                    >
+                      Fix - Creating Optimistic Proposals{" "}
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href=" https://github.com/voteagora/agora-next/pull/190"
+                      target="_blank"
+                    >
+                      Fix - Hover for Abstained Votes
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/193"
+                      target="_blank"
+                    >
+                      Fix - Approval Proposal Results for V6 Governor{" "}
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/195"
+                      target="_blank"
+                    >
+                      Fix - Vote Casted on Approval
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href="https://github.com/voteagora/agora-next/pull/200"
+                      target="_blank"
+                    >
+                      Fix - voteHoverCard → fetchDelegate Server Action
+                    </a>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    <a
+                      href=" https://github.com/voteagora/agora-next/pull/204"
+                      target="_blank"
+                    >
+                      Fix - Citizen/Delegate Double Loading
+                    </a>
+                  </p>
+                </li>
+              </ul>
+            </div>
+            <div className="my-8 border-t border-gray-300"></div>
             <div>
               <div className={styles.changelogItem}>
                 <p id="changelogfeb2024" className={styles.changelogDate}>

--- a/src/lib/contracts/generated/AlligatorOPV5.ts
+++ b/src/lib/contracts/generated/AlligatorOPV5.ts
@@ -40,7 +40,7 @@ export type SubdelegationRulesStructOutput = [
   notValidAfter: bigint,
   customRule: string,
   allowanceType: bigint,
-  allowance: bigint,
+  allowance: bigint
 ] & {
   maxRedelegations: bigint;
   blocksBeforeVoteCloses: bigint;
@@ -135,7 +135,7 @@ export interface AlligatorOPV5Interface extends Interface {
       BigNumberish,
       BigNumberish,
       BytesLike,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -160,7 +160,7 @@ export interface AlligatorOPV5Interface extends Interface {
       BytesLike,
       BigNumberish,
       BytesLike,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -175,7 +175,7 @@ export interface AlligatorOPV5Interface extends Interface {
       BigNumberish,
       BigNumberish,
       string,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -189,7 +189,7 @@ export interface AlligatorOPV5Interface extends Interface {
       BytesLike,
       BigNumberish,
       BytesLike,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(functionFragment: "owner", values?: undefined): string;
@@ -399,12 +399,12 @@ export namespace SubDelegationEvent {
   export type InputTuple = [
     from: AddressLike,
     to: AddressLike,
-    subdelegationRules: SubdelegationRulesStruct,
+    subdelegationRules: SubdelegationRulesStruct
   ];
   export type OutputTuple = [
     from: string,
     to: string,
-    subdelegationRules: SubdelegationRulesStructOutput,
+    subdelegationRules: SubdelegationRulesStructOutput
   ];
   export interface OutputObject {
     from: string;
@@ -421,12 +421,12 @@ export namespace SubDelegations_address_address_array_tuple_Event {
   export type InputTuple = [
     from: AddressLike,
     to: AddressLike[],
-    subdelegationRules: SubdelegationRulesStruct,
+    subdelegationRules: SubdelegationRulesStruct
   ];
   export type OutputTuple = [
     from: string,
     to: string[],
-    subdelegationRules: SubdelegationRulesStructOutput,
+    subdelegationRules: SubdelegationRulesStructOutput
   ];
   export interface OutputObject {
     from: string;
@@ -443,12 +443,12 @@ export namespace SubDelegations_address_address_array_tuple_array_Event {
   export type InputTuple = [
     from: AddressLike,
     to: AddressLike[],
-    subdelegationRules: SubdelegationRulesStruct[],
+    subdelegationRules: SubdelegationRulesStruct[]
   ];
   export type OutputTuple = [
     from: string,
     to: string[],
-    subdelegationRules: SubdelegationRulesStructOutput[],
+    subdelegationRules: SubdelegationRulesStructOutput[]
   ];
   export interface OutputObject {
     from: string;
@@ -491,14 +491,14 @@ export namespace VoteCastEvent {
     voter: AddressLike,
     authority: AddressLike[],
     proposalId: BigNumberish,
-    support: BigNumberish,
+    support: BigNumberish
   ];
   export type OutputTuple = [
     proxy: string,
     voter: string,
     authority: string[],
     proposalId: bigint,
-    support: bigint,
+    support: bigint
   ];
   export interface OutputObject {
     proxy: string;
@@ -519,14 +519,14 @@ export namespace VotesCastEvent {
     voter: AddressLike,
     authorities: AddressLike[][],
     proposalId: BigNumberish,
-    support: BigNumberish,
+    support: BigNumberish
   ];
   export type OutputTuple = [
     proxies: string[],
     voter: string,
     authorities: string[][],
     proposalId: bigint,
-    support: bigint,
+    support: bigint
   ];
   export interface OutputObject {
     proxies: string[];
@@ -611,7 +611,7 @@ export interface AlligatorOPV5 extends BaseContract {
       support: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -622,7 +622,7 @@ export interface AlligatorOPV5 extends BaseContract {
       authority: AddressLike[],
       proposalId: BigNumberish,
       support: BigNumberish,
-      reason: string,
+      reason: string
     ],
     [void],
     "nonpayable"
@@ -634,7 +634,7 @@ export interface AlligatorOPV5 extends BaseContract {
       proposalId: BigNumberish,
       support: BigNumberish,
       reason: string,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -646,7 +646,7 @@ export interface AlligatorOPV5 extends BaseContract {
       proposalId: BigNumberish,
       support: BigNumberish,
       reason: string,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -661,7 +661,7 @@ export interface AlligatorOPV5 extends BaseContract {
       params: BytesLike,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -680,7 +680,7 @@ export interface AlligatorOPV5 extends BaseContract {
       proposalId: BigNumberish,
       support: BigNumberish,
       reason: string,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -696,7 +696,7 @@ export interface AlligatorOPV5 extends BaseContract {
       params: BytesLike,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -745,7 +745,7 @@ export interface AlligatorOPV5 extends BaseContract {
         customRule: string;
         allowanceType: bigint;
         allowance: bigint;
-      },
+      }
     ],
     "view"
   >;
@@ -815,7 +815,7 @@ export interface AlligatorOPV5 extends BaseContract {
       support: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -827,7 +827,7 @@ export interface AlligatorOPV5 extends BaseContract {
       authority: AddressLike[],
       proposalId: BigNumberish,
       support: BigNumberish,
-      reason: string,
+      reason: string
     ],
     [void],
     "nonpayable"
@@ -840,7 +840,7 @@ export interface AlligatorOPV5 extends BaseContract {
       proposalId: BigNumberish,
       support: BigNumberish,
       reason: string,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -853,7 +853,7 @@ export interface AlligatorOPV5 extends BaseContract {
       proposalId: BigNumberish,
       support: BigNumberish,
       reason: string,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -869,7 +869,7 @@ export interface AlligatorOPV5 extends BaseContract {
       params: BytesLike,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -886,7 +886,7 @@ export interface AlligatorOPV5 extends BaseContract {
       proposalId: BigNumberish,
       support: BigNumberish,
       reason: string,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -903,7 +903,7 @@ export interface AlligatorOPV5 extends BaseContract {
       params: BytesLike,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -944,7 +944,9 @@ export interface AlligatorOPV5 extends BaseContract {
     [void],
     "nonpayable"
   >;
-  getFunction(nameOrSignature: "subdelegations"): TypedContractMethod<
+  getFunction(
+    nameOrSignature: "subdelegations"
+  ): TypedContractMethod<
     [from: AddressLike, to: AddressLike],
     [
       [bigint, bigint, bigint, bigint, string, bigint, bigint] & {
@@ -955,7 +957,7 @@ export interface AlligatorOPV5 extends BaseContract {
         customRule: string;
         allowanceType: bigint;
         allowance: bigint;
-      },
+      }
     ],
     "view"
   >;

--- a/src/lib/contracts/generated/ApprovalVotingModule.ts
+++ b/src/lib/contracts/generated/ApprovalVotingModule.ts
@@ -34,7 +34,7 @@ export type ProposalSettingsStructOutput = [
   criteria: bigint,
   budgetToken: string,
   criteriaValue: bigint,
-  budgetAmount: bigint,
+  budgetAmount: bigint
 ] & {
   maxApprovals: bigint;
   criteria: bigint;
@@ -205,7 +205,7 @@ export interface ApprovalVotingModule extends BaseContract {
       account: AddressLike,
       support: BigNumberish,
       weight: BigNumberish,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -218,7 +218,7 @@ export interface ApprovalVotingModule extends BaseContract {
         targets: string[];
         values: bigint[];
         calldatas: string[];
-      },
+      }
     ],
     "nonpayable"
   >;
@@ -248,7 +248,7 @@ export interface ApprovalVotingModule extends BaseContract {
         governor: string;
         initBalance: bigint;
         settings: ProposalSettingsStructOutput;
-      },
+      }
     ],
     "view"
   >;
@@ -257,7 +257,7 @@ export interface ApprovalVotingModule extends BaseContract {
     [
       proposalId: BigNumberish,
       proposalData: BytesLike,
-      descriptionHash: BytesLike,
+      descriptionHash: BytesLike
     ],
     [void],
     "nonpayable"
@@ -293,19 +293,21 @@ export interface ApprovalVotingModule extends BaseContract {
       account: AddressLike,
       support: BigNumberish,
       weight: BigNumberish,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
   >;
-  getFunction(nameOrSignature: "_formatExecuteParams"): TypedContractMethod<
+  getFunction(
+    nameOrSignature: "_formatExecuteParams"
+  ): TypedContractMethod<
     [proposalId: BigNumberish, proposalData: BytesLike],
     [
       [string[], bigint[], string[]] & {
         targets: string[];
         values: bigint[];
         calldatas: string[];
-      },
+      }
     ],
     "nonpayable"
   >;
@@ -326,14 +328,16 @@ export interface ApprovalVotingModule extends BaseContract {
     [bigint[]],
     "view"
   >;
-  getFunction(nameOrSignature: "proposals"): TypedContractMethod<
+  getFunction(
+    nameOrSignature: "proposals"
+  ): TypedContractMethod<
     [proposalId: BigNumberish],
     [
       [string, bigint, ProposalSettingsStructOutput] & {
         governor: string;
         initBalance: bigint;
         settings: ProposalSettingsStructOutput;
-      },
+      }
     ],
     "view"
   >;
@@ -343,7 +347,7 @@ export interface ApprovalVotingModule extends BaseContract {
     [
       proposalId: BigNumberish,
       proposalData: BytesLike,
-      descriptionHash: BytesLike,
+      descriptionHash: BytesLike
     ],
     [void],
     "nonpayable"

--- a/src/lib/contracts/generated/EtherfiToken.ts
+++ b/src/lib/contracts/generated/EtherfiToken.ts
@@ -117,7 +117,7 @@ export interface EtherfiTokenInterface extends Interface {
       BigNumberish,
       BigNumberish,
       BytesLike,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -155,7 +155,7 @@ export interface EtherfiTokenInterface extends Interface {
       BigNumberish,
       BigNumberish,
       BytesLike,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(functionFragment: "symbol", values?: undefined): string;
@@ -230,7 +230,7 @@ export namespace ApprovalEvent {
   export type InputTuple = [
     owner: AddressLike,
     spender: AddressLike,
-    value: BigNumberish,
+    value: BigNumberish
   ];
   export type OutputTuple = [owner: string, spender: string, value: bigint];
   export interface OutputObject {
@@ -248,12 +248,12 @@ export namespace DelegateChangedEvent {
   export type InputTuple = [
     delegator: AddressLike,
     fromDelegate: AddressLike,
-    toDelegate: AddressLike,
+    toDelegate: AddressLike
   ];
   export type OutputTuple = [
     delegator: string,
     fromDelegate: string,
-    toDelegate: string,
+    toDelegate: string
   ];
   export interface OutputObject {
     delegator: string;
@@ -270,12 +270,12 @@ export namespace DelegateVotesChangedEvent {
   export type InputTuple = [
     delegate: AddressLike,
     previousVotes: BigNumberish,
-    newVotes: BigNumberish,
+    newVotes: BigNumberish
   ];
   export type OutputTuple = [
     delegate: string,
     previousVotes: bigint,
-    newVotes: bigint,
+    newVotes: bigint
   ];
   export interface OutputObject {
     delegate: string;
@@ -302,7 +302,7 @@ export namespace TransferEvent {
   export type InputTuple = [
     from: AddressLike,
     to: AddressLike,
-    value: BigNumberish,
+    value: BigNumberish
   ];
   export type OutputTuple = [from: string, to: string, value: bigint];
   export interface OutputObject {
@@ -404,7 +404,7 @@ export interface EtherfiToken extends BaseContract {
       expiry: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -423,7 +423,7 @@ export interface EtherfiToken extends BaseContract {
         verifyingContract: string;
         salt: string;
         extensions: bigint[];
-      },
+      }
     ],
     "view"
   >;
@@ -456,7 +456,7 @@ export interface EtherfiToken extends BaseContract {
       deadline: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -540,7 +540,7 @@ export interface EtherfiToken extends BaseContract {
       expiry: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -548,7 +548,9 @@ export interface EtherfiToken extends BaseContract {
   getFunction(
     nameOrSignature: "delegates"
   ): TypedContractMethod<[account: AddressLike], [string], "view">;
-  getFunction(nameOrSignature: "eip712Domain"): TypedContractMethod<
+  getFunction(
+    nameOrSignature: "eip712Domain"
+  ): TypedContractMethod<
     [],
     [
       [string, string, string, bigint, string, string, bigint[]] & {
@@ -559,7 +561,7 @@ export interface EtherfiToken extends BaseContract {
         verifyingContract: string;
         salt: string;
         extensions: bigint[];
-      },
+      }
     ],
     "view"
   >;
@@ -595,7 +597,7 @@ export interface EtherfiToken extends BaseContract {
       deadline: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"

--- a/src/lib/contracts/generated/NounsGovernor.ts
+++ b/src/lib/contracts/generated/NounsGovernor.ts
@@ -33,7 +33,7 @@ export declare namespace NounsDAOStorageV3 {
   export type DynamicQuorumParamsStructOutput = [
     minQuorumVotesBPS: bigint,
     maxQuorumVotesBPS: bigint,
-    quorumCoefficient: bigint,
+    quorumCoefficient: bigint
   ] & {
     minQuorumVotesBPS: bigint;
     maxQuorumVotesBPS: bigint;
@@ -49,7 +49,7 @@ export declare namespace NounsDAOStorageV3 {
   export type ReceiptStructOutput = [
     hasVoted: boolean,
     support: bigint,
-    votes: bigint,
+    votes: bigint
   ] & { hasVoted: boolean; support: bigint; votes: bigint };
 
   export type NounsDAOParamsStruct = {
@@ -67,7 +67,7 @@ export declare namespace NounsDAOStorageV3 {
     proposalThresholdBPS: bigint,
     lastMinuteWindowInBlocks: bigint,
     objectionPeriodDurationInBlocks: bigint,
-    proposalUpdatablePeriodInBlocks: bigint,
+    proposalUpdatablePeriodInBlocks: bigint
   ] & {
     votingPeriod: bigint;
     votingDelay: bigint;
@@ -118,7 +118,7 @@ export declare namespace NounsDAOStorageV3 {
     signers: string[],
     updatePeriodEndBlock: bigint,
     objectionPeriodEndBlock: bigint,
-    executeOnTimelockV1: boolean,
+    executeOnTimelockV1: boolean
   ] & {
     id: bigint;
     proposer: string;
@@ -150,7 +150,7 @@ export declare namespace NounsDAOStorageV3 {
   export type ProposerSignatureStructOutput = [
     sig: string,
     signer: string,
-    expirationTimestamp: bigint,
+    expirationTimestamp: bigint
   ] & { sig: string; signer: string; expirationTimestamp: bigint };
 
   export type DynamicQuorumParamsCheckpointStruct = {
@@ -160,7 +160,7 @@ export declare namespace NounsDAOStorageV3 {
 
   export type DynamicQuorumParamsCheckpointStructOutput = [
     fromBlock: bigint,
-    params: NounsDAOStorageV3.DynamicQuorumParamsStructOutput,
+    params: NounsDAOStorageV3.DynamicQuorumParamsStructOutput
   ] & {
     fromBlock: bigint;
     params: NounsDAOStorageV3.DynamicQuorumParamsStructOutput;
@@ -201,7 +201,7 @@ export declare namespace NounsDAOStorageV2 {
     vetoed: boolean,
     executed: boolean,
     totalSupply: bigint,
-    creationBlock: bigint,
+    creationBlock: bigint
   ] & {
     id: bigint;
     proposer: string;
@@ -423,7 +423,7 @@ export interface NounsGovernorInterface extends Interface {
       AddressLike,
       AddressLike[],
       BigNumberish,
-      BigNumberish,
+      BigNumberish
     ]
   ): string;
   encodeFunctionData(
@@ -524,7 +524,7 @@ export interface NounsGovernorInterface extends Interface {
     values: [
       BigNumberish,
       BigNumberish,
-      NounsDAOStorageV3.DynamicQuorumParamsStruct,
+      NounsDAOStorageV3.DynamicQuorumParamsStruct
     ]
   ): string;
   encodeFunctionData(
@@ -592,7 +592,7 @@ export interface NounsGovernorInterface extends Interface {
       AddressLike,
       AddressLike,
       NounsDAOStorageV3.NounsDAOParamsStruct,
-      NounsDAOStorageV3.DynamicQuorumParamsStruct,
+      NounsDAOStorageV3.DynamicQuorumParamsStruct
     ]
   ): string;
   encodeFunctionData(
@@ -668,7 +668,7 @@ export interface NounsGovernorInterface extends Interface {
       BigNumberish[],
       string[],
       BytesLike[],
-      string,
+      string
     ]
   ): string;
   encodeFunctionData(
@@ -707,7 +707,7 @@ export interface NounsGovernorInterface extends Interface {
       string[],
       BytesLike[],
       string,
-      string,
+      string
     ]
   ): string;
   encodeFunctionData(
@@ -720,7 +720,7 @@ export interface NounsGovernorInterface extends Interface {
       string[],
       BytesLike[],
       string,
-      string,
+      string
     ]
   ): string;
   encodeFunctionData(
@@ -735,7 +735,7 @@ export interface NounsGovernorInterface extends Interface {
       BigNumberish[],
       string[],
       BytesLike[],
-      string,
+      string
     ]
   ): string;
   encodeFunctionData(functionFragment: "veto", values: [BigNumberish]): string;
@@ -1087,11 +1087,11 @@ export namespace DAOWithdrawNounsFromEscrowEvent {
 export namespace ERC20TokensToIncludeInForkSetEvent {
   export type InputTuple = [
     oldErc20Tokens: AddressLike[],
-    newErc20tokens: AddressLike[],
+    newErc20tokens: AddressLike[]
   ];
   export type OutputTuple = [
     oldErc20Tokens: string[],
-    newErc20tokens: string[],
+    newErc20tokens: string[]
   ];
   export interface OutputObject {
     oldErc20Tokens: string[];
@@ -1109,14 +1109,14 @@ export namespace EscrowedToForkEvent {
     owner: AddressLike,
     tokenIds: BigNumberish[],
     proposalIds: BigNumberish[],
-    reason: string,
+    reason: string
   ];
   export type OutputTuple = [
     forkId: bigint,
     owner: string,
     tokenIds: bigint[],
     proposalIds: bigint[],
-    reason: string,
+    reason: string
   ];
   export interface OutputObject {
     forkId: bigint;
@@ -1137,14 +1137,14 @@ export namespace ExecuteForkEvent {
     forkTreasury: AddressLike,
     forkToken: AddressLike,
     forkEndTimestamp: BigNumberish,
-    tokensInEscrow: BigNumberish,
+    tokensInEscrow: BigNumberish
   ];
   export type OutputTuple = [
     forkId: bigint,
     forkTreasury: string,
     forkToken: string,
     forkEndTimestamp: bigint,
-    tokensInEscrow: bigint,
+    tokensInEscrow: bigint
   ];
   export interface OutputObject {
     forkId: bigint;
@@ -1162,11 +1162,11 @@ export namespace ExecuteForkEvent {
 export namespace ForkDAODeployerSetEvent {
   export type InputTuple = [
     oldForkDAODeployer: AddressLike,
-    newForkDAODeployer: AddressLike,
+    newForkDAODeployer: AddressLike
   ];
   export type OutputTuple = [
     oldForkDAODeployer: string,
-    newForkDAODeployer: string,
+    newForkDAODeployer: string
   ];
   export interface OutputObject {
     oldForkDAODeployer: string;
@@ -1181,7 +1181,7 @@ export namespace ForkDAODeployerSetEvent {
 export namespace ForkPeriodSetEvent {
   export type InputTuple = [
     oldForkPeriod: BigNumberish,
-    newForkPeriod: BigNumberish,
+    newForkPeriod: BigNumberish
   ];
   export type OutputTuple = [oldForkPeriod: bigint, newForkPeriod: bigint];
   export interface OutputObject {
@@ -1197,11 +1197,11 @@ export namespace ForkPeriodSetEvent {
 export namespace ForkThresholdSetEvent {
   export type InputTuple = [
     oldForkThreshold: BigNumberish,
-    newForkThreshold: BigNumberish,
+    newForkThreshold: BigNumberish
   ];
   export type OutputTuple = [
     oldForkThreshold: bigint,
-    newForkThreshold: bigint,
+    newForkThreshold: bigint
   ];
   export interface OutputObject {
     oldForkThreshold: bigint;
@@ -1219,14 +1219,14 @@ export namespace JoinForkEvent {
     owner: AddressLike,
     tokenIds: BigNumberish[],
     proposalIds: BigNumberish[],
-    reason: string,
+    reason: string
   ];
   export type OutputTuple = [
     forkId: bigint,
     owner: string,
     tokenIds: bigint[],
     proposalIds: bigint[],
-    reason: string,
+    reason: string
   ];
   export interface OutputObject {
     forkId: bigint;
@@ -1244,11 +1244,11 @@ export namespace JoinForkEvent {
 export namespace LastMinuteWindowSetEvent {
   export type InputTuple = [
     oldLastMinuteWindowInBlocks: BigNumberish,
-    newLastMinuteWindowInBlocks: BigNumberish,
+    newLastMinuteWindowInBlocks: BigNumberish
   ];
   export type OutputTuple = [
     oldLastMinuteWindowInBlocks: bigint,
-    newLastMinuteWindowInBlocks: bigint,
+    newLastMinuteWindowInBlocks: bigint
   ];
   export interface OutputObject {
     oldLastMinuteWindowInBlocks: bigint;
@@ -1263,11 +1263,11 @@ export namespace LastMinuteWindowSetEvent {
 export namespace MaxQuorumVotesBPSSetEvent {
   export type InputTuple = [
     oldMaxQuorumVotesBPS: BigNumberish,
-    newMaxQuorumVotesBPS: BigNumberish,
+    newMaxQuorumVotesBPS: BigNumberish
   ];
   export type OutputTuple = [
     oldMaxQuorumVotesBPS: bigint,
-    newMaxQuorumVotesBPS: bigint,
+    newMaxQuorumVotesBPS: bigint
   ];
   export interface OutputObject {
     oldMaxQuorumVotesBPS: bigint;
@@ -1282,11 +1282,11 @@ export namespace MaxQuorumVotesBPSSetEvent {
 export namespace MinQuorumVotesBPSSetEvent {
   export type InputTuple = [
     oldMinQuorumVotesBPS: BigNumberish,
-    newMinQuorumVotesBPS: BigNumberish,
+    newMinQuorumVotesBPS: BigNumberish
   ];
   export type OutputTuple = [
     oldMinQuorumVotesBPS: bigint,
-    newMinQuorumVotesBPS: bigint,
+    newMinQuorumVotesBPS: bigint
   ];
   export interface OutputObject {
     oldMinQuorumVotesBPS: bigint;
@@ -1314,11 +1314,11 @@ export namespace NewAdminEvent {
 export namespace NewImplementationEvent {
   export type InputTuple = [
     oldImplementation: AddressLike,
-    newImplementation: AddressLike,
+    newImplementation: AddressLike
   ];
   export type OutputTuple = [
     oldImplementation: string,
-    newImplementation: string,
+    newImplementation: string
   ];
   export interface OutputObject {
     oldImplementation: string;
@@ -1333,7 +1333,7 @@ export namespace NewImplementationEvent {
 export namespace NewPendingAdminEvent {
   export type InputTuple = [
     oldPendingAdmin: AddressLike,
-    newPendingAdmin: AddressLike,
+    newPendingAdmin: AddressLike
   ];
   export type OutputTuple = [oldPendingAdmin: string, newPendingAdmin: string];
   export interface OutputObject {
@@ -1349,11 +1349,11 @@ export namespace NewPendingAdminEvent {
 export namespace NewPendingVetoerEvent {
   export type InputTuple = [
     oldPendingVetoer: AddressLike,
-    newPendingVetoer: AddressLike,
+    newPendingVetoer: AddressLike
   ];
   export type OutputTuple = [
     oldPendingVetoer: string,
-    newPendingVetoer: string,
+    newPendingVetoer: string
   ];
   export interface OutputObject {
     oldPendingVetoer: string;
@@ -1381,11 +1381,11 @@ export namespace NewVetoerEvent {
 export namespace ObjectionPeriodDurationSetEvent {
   export type InputTuple = [
     oldObjectionPeriodDurationInBlocks: BigNumberish,
-    newObjectionPeriodDurationInBlocks: BigNumberish,
+    newObjectionPeriodDurationInBlocks: BigNumberish
   ];
   export type OutputTuple = [
     oldObjectionPeriodDurationInBlocks: bigint,
-    newObjectionPeriodDurationInBlocks: bigint,
+    newObjectionPeriodDurationInBlocks: bigint
   ];
   export interface OutputObject {
     oldObjectionPeriodDurationInBlocks: bigint;
@@ -1419,7 +1419,7 @@ export namespace ProposalCreatedEvent {
     calldatas: BytesLike[],
     startBlock: BigNumberish,
     endBlock: BigNumberish,
-    description: string,
+    description: string
   ];
   export type OutputTuple = [
     id: bigint,
@@ -1430,7 +1430,7 @@ export namespace ProposalCreatedEvent {
     calldatas: string[],
     startBlock: bigint,
     endBlock: bigint,
-    description: string,
+    description: string
   ];
   export interface OutputObject {
     id: bigint;
@@ -1475,7 +1475,7 @@ export namespace ProposalCreatedWithRequirements_uint256_address_address_array_a
     updatePeriodEndBlock: BigNumberish,
     proposalThreshold: BigNumberish,
     quorumVotes: BigNumberish,
-    description: string,
+    description: string
   ];
   export type OutputTuple = [
     id: bigint,
@@ -1490,7 +1490,7 @@ export namespace ProposalCreatedWithRequirements_uint256_address_address_array_a
     updatePeriodEndBlock: bigint,
     proposalThreshold: bigint,
     quorumVotes: bigint,
-    description: string,
+    description: string
   ];
   export interface OutputObject {
     id: bigint;
@@ -1525,7 +1525,7 @@ export namespace ProposalCreatedWithRequirements_uint256_address_address_array_u
     endBlock: BigNumberish,
     proposalThreshold: BigNumberish,
     quorumVotes: BigNumberish,
-    description: string,
+    description: string
   ];
   export type OutputTuple = [
     id: bigint,
@@ -1538,7 +1538,7 @@ export namespace ProposalCreatedWithRequirements_uint256_address_address_array_u
     endBlock: bigint,
     proposalThreshold: bigint,
     quorumVotes: bigint,
-    description: string,
+    description: string
   ];
   export interface OutputObject {
     id: bigint;
@@ -1564,13 +1564,13 @@ export namespace ProposalDescriptionUpdatedEvent {
     id: BigNumberish,
     proposer: AddressLike,
     description: string,
-    updateMessage: string,
+    updateMessage: string
   ];
   export type OutputTuple = [
     id: bigint,
     proposer: string,
     description: string,
-    updateMessage: string,
+    updateMessage: string
   ];
   export interface OutputObject {
     id: bigint;
@@ -1599,7 +1599,7 @@ export namespace ProposalExecutedEvent {
 export namespace ProposalObjectionPeriodSetEvent {
   export type InputTuple = [
     id: BigNumberish,
-    objectionPeriodEndBlock: BigNumberish,
+    objectionPeriodEndBlock: BigNumberish
   ];
   export type OutputTuple = [id: bigint, objectionPeriodEndBlock: bigint];
   export interface OutputObject {
@@ -1628,11 +1628,11 @@ export namespace ProposalQueuedEvent {
 export namespace ProposalThresholdBPSSetEvent {
   export type InputTuple = [
     oldProposalThresholdBPS: BigNumberish,
-    newProposalThresholdBPS: BigNumberish,
+    newProposalThresholdBPS: BigNumberish
   ];
   export type OutputTuple = [
     oldProposalThresholdBPS: bigint,
-    newProposalThresholdBPS: bigint,
+    newProposalThresholdBPS: bigint
   ];
   export interface OutputObject {
     oldProposalThresholdBPS: bigint;
@@ -1652,7 +1652,7 @@ export namespace ProposalTransactionsUpdatedEvent {
     values: BigNumberish[],
     signatures: string[],
     calldatas: BytesLike[],
-    updateMessage: string,
+    updateMessage: string
   ];
   export type OutputTuple = [
     id: bigint,
@@ -1661,7 +1661,7 @@ export namespace ProposalTransactionsUpdatedEvent {
     values: bigint[],
     signatures: string[],
     calldatas: string[],
-    updateMessage: string,
+    updateMessage: string
   ];
   export interface OutputObject {
     id: bigint;
@@ -1681,11 +1681,11 @@ export namespace ProposalTransactionsUpdatedEvent {
 export namespace ProposalUpdatablePeriodSetEvent {
   export type InputTuple = [
     oldProposalUpdatablePeriodInBlocks: BigNumberish,
-    newProposalUpdatablePeriodInBlocks: BigNumberish,
+    newProposalUpdatablePeriodInBlocks: BigNumberish
   ];
   export type OutputTuple = [
     oldProposalUpdatablePeriodInBlocks: bigint,
-    newProposalUpdatablePeriodInBlocks: bigint,
+    newProposalUpdatablePeriodInBlocks: bigint
   ];
   export interface OutputObject {
     oldProposalUpdatablePeriodInBlocks: bigint;
@@ -1706,7 +1706,7 @@ export namespace ProposalUpdatedEvent {
     signatures: string[],
     calldatas: BytesLike[],
     description: string,
-    updateMessage: string,
+    updateMessage: string
   ];
   export type OutputTuple = [
     id: bigint,
@@ -1716,7 +1716,7 @@ export namespace ProposalUpdatedEvent {
     signatures: string[],
     calldatas: string[],
     description: string,
-    updateMessage: string,
+    updateMessage: string
   ];
   export interface OutputObject {
     id: bigint;
@@ -1749,11 +1749,11 @@ export namespace ProposalVetoedEvent {
 export namespace QuorumCoefficientSetEvent {
   export type InputTuple = [
     oldQuorumCoefficient: BigNumberish,
-    newQuorumCoefficient: BigNumberish,
+    newQuorumCoefficient: BigNumberish
   ];
   export type OutputTuple = [
     oldQuorumCoefficient: bigint,
-    newQuorumCoefficient: bigint,
+    newQuorumCoefficient: bigint
   ];
   export interface OutputObject {
     oldQuorumCoefficient: bigint;
@@ -1768,11 +1768,11 @@ export namespace QuorumCoefficientSetEvent {
 export namespace QuorumVotesBPSSetEvent {
   export type InputTuple = [
     oldQuorumVotesBPS: BigNumberish,
-    newQuorumVotesBPS: BigNumberish,
+    newQuorumVotesBPS: BigNumberish
   ];
   export type OutputTuple = [
     oldQuorumVotesBPS: bigint,
-    newQuorumVotesBPS: bigint,
+    newQuorumVotesBPS: bigint
   ];
   export interface OutputObject {
     oldQuorumVotesBPS: bigint;
@@ -1788,12 +1788,12 @@ export namespace RefundableVoteEvent {
   export type InputTuple = [
     voter: AddressLike,
     refundAmount: BigNumberish,
-    refundSent: boolean,
+    refundSent: boolean
   ];
   export type OutputTuple = [
     voter: string,
     refundAmount: bigint,
-    refundSent: boolean,
+    refundSent: boolean
   ];
   export interface OutputObject {
     voter: string;
@@ -1823,12 +1823,12 @@ export namespace TimelocksAndAdminSetEvent {
   export type InputTuple = [
     timelock: AddressLike,
     timelockV1: AddressLike,
-    admin: AddressLike,
+    admin: AddressLike
   ];
   export type OutputTuple = [
     timelock: string,
     timelockV1: string,
-    admin: string,
+    admin: string
   ];
   export interface OutputObject {
     timelock: string;
@@ -1847,14 +1847,14 @@ export namespace VoteCastEvent {
     proposalId: BigNumberish,
     support: BigNumberish,
     votes: BigNumberish,
-    reason: string,
+    reason: string
   ];
   export type OutputTuple = [
     voter: string,
     proposalId: bigint,
     support: bigint,
     votes: bigint,
-    reason: string,
+    reason: string
   ];
   export interface OutputObject {
     voter: string;
@@ -1872,11 +1872,11 @@ export namespace VoteCastEvent {
 export namespace VoteSnapshotBlockSwitchProposalIdSetEvent {
   export type InputTuple = [
     oldVoteSnapshotBlockSwitchProposalId: BigNumberish,
-    newVoteSnapshotBlockSwitchProposalId: BigNumberish,
+    newVoteSnapshotBlockSwitchProposalId: BigNumberish
   ];
   export type OutputTuple = [
     oldVoteSnapshotBlockSwitchProposalId: bigint,
-    newVoteSnapshotBlockSwitchProposalId: bigint,
+    newVoteSnapshotBlockSwitchProposalId: bigint
   ];
   export interface OutputObject {
     oldVoteSnapshotBlockSwitchProposalId: bigint;
@@ -1891,7 +1891,7 @@ export namespace VoteSnapshotBlockSwitchProposalIdSetEvent {
 export namespace VotingDelaySetEvent {
   export type InputTuple = [
     oldVotingDelay: BigNumberish,
-    newVotingDelay: BigNumberish,
+    newVotingDelay: BigNumberish
   ];
   export type OutputTuple = [oldVotingDelay: bigint, newVotingDelay: bigint];
   export interface OutputObject {
@@ -1907,7 +1907,7 @@ export namespace VotingDelaySetEvent {
 export namespace VotingPeriodSetEvent {
   export type InputTuple = [
     oldVotingPeriod: BigNumberish,
-    newVotingPeriod: BigNumberish,
+    newVotingPeriod: BigNumberish
   ];
   export type OutputTuple = [oldVotingPeriod: bigint, newVotingPeriod: bigint];
   export interface OutputObject {
@@ -1937,7 +1937,7 @@ export namespace WithdrawFromForkEscrowEvent {
   export type InputTuple = [
     forkId: BigNumberish,
     owner: AddressLike,
-    tokenIds: BigNumberish[],
+    tokenIds: BigNumberish[]
   ];
   export type OutputTuple = [forkId: bigint, owner: string, tokenIds: bigint[]];
   export interface OutputObject {
@@ -2016,7 +2016,7 @@ export interface NounsGovernor extends BaseContract {
     [
       newMinQuorumVotesBPS: BigNumberish,
       newMaxQuorumVotesBPS: BigNumberish,
-      newQuorumCoefficient: BigNumberish,
+      newQuorumCoefficient: BigNumberish
     ],
     [void],
     "nonpayable"
@@ -2046,7 +2046,7 @@ export interface NounsGovernor extends BaseContract {
       forkDAODeployer_: AddressLike,
       erc20TokensToIncludeInFork_: AddressLike[],
       forkPeriod_: BigNumberish,
-      forkThresholdBPS_: BigNumberish,
+      forkThresholdBPS_: BigNumberish
     ],
     [void],
     "nonpayable"
@@ -2122,7 +2122,7 @@ export interface NounsGovernor extends BaseContract {
     [
       newTimelock: AddressLike,
       newTimelockV1: AddressLike,
-      newAdmin: AddressLike,
+      newAdmin: AddressLike
     ],
     [void],
     "nonpayable"
@@ -2178,7 +2178,7 @@ export interface NounsGovernor extends BaseContract {
       support: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -2194,7 +2194,7 @@ export interface NounsGovernor extends BaseContract {
     [
       againstVotes: BigNumberish,
       totalSupply: BigNumberish,
-      params: NounsDAOStorageV3.DynamicQuorumParamsStruct,
+      params: NounsDAOStorageV3.DynamicQuorumParamsStruct
     ],
     [bigint],
     "view"
@@ -2246,7 +2246,7 @@ export interface NounsGovernor extends BaseContract {
         values: bigint[];
         signatures: string[];
         calldatas: string[];
-      },
+      }
     ],
     "view"
   >;
@@ -2271,7 +2271,7 @@ export interface NounsGovernor extends BaseContract {
       forkDAODeployer_: AddressLike,
       vetoer_: AddressLike,
       daoParams_: NounsDAOStorageV3.NounsDAOParamsStruct,
-      dynamicQuorumParams_: NounsDAOStorageV3.DynamicQuorumParamsStruct,
+      dynamicQuorumParams_: NounsDAOStorageV3.DynamicQuorumParamsStruct
     ],
     [void],
     "nonpayable"
@@ -2331,7 +2331,7 @@ export interface NounsGovernor extends BaseContract {
       values: BigNumberish[],
       signatures: string[],
       calldatas: BytesLike[],
-      description: string,
+      description: string
     ],
     [bigint],
     "nonpayable"
@@ -2344,7 +2344,7 @@ export interface NounsGovernor extends BaseContract {
       values: BigNumberish[],
       signatures: string[],
       calldatas: BytesLike[],
-      description: string,
+      description: string
     ],
     [bigint],
     "nonpayable"
@@ -2356,7 +2356,7 @@ export interface NounsGovernor extends BaseContract {
       values: BigNumberish[],
       signatures: string[],
       calldatas: BytesLike[],
-      description: string,
+      description: string
     ],
     [bigint],
     "nonpayable"
@@ -2398,7 +2398,7 @@ export interface NounsGovernor extends BaseContract {
       signatures: string[],
       calldatas: BytesLike[],
       description: string,
-      updateMessage: string,
+      updateMessage: string
     ],
     [void],
     "nonpayable"
@@ -2413,7 +2413,7 @@ export interface NounsGovernor extends BaseContract {
       signatures: string[],
       calldatas: BytesLike[],
       description: string,
-      updateMessage: string,
+      updateMessage: string
     ],
     [void],
     "nonpayable"
@@ -2432,7 +2432,7 @@ export interface NounsGovernor extends BaseContract {
       values: BigNumberish[],
       signatures: string[],
       calldatas: BytesLike[],
-      updateMessage: string,
+      updateMessage: string
     ],
     [void],
     "nonpayable"
@@ -2497,7 +2497,7 @@ export interface NounsGovernor extends BaseContract {
     [
       newMinQuorumVotesBPS: BigNumberish,
       newMaxQuorumVotesBPS: BigNumberish,
-      newQuorumCoefficient: BigNumberish,
+      newQuorumCoefficient: BigNumberish
     ],
     [void],
     "nonpayable"
@@ -2523,7 +2523,7 @@ export interface NounsGovernor extends BaseContract {
       forkDAODeployer_: AddressLike,
       erc20TokensToIncludeInFork_: AddressLike[],
       forkPeriod_: BigNumberish,
-      forkThresholdBPS_: BigNumberish,
+      forkThresholdBPS_: BigNumberish
     ],
     [void],
     "nonpayable"
@@ -2599,7 +2599,7 @@ export interface NounsGovernor extends BaseContract {
     [
       newTimelock: AddressLike,
       newTimelockV1: AddressLike,
-      newAdmin: AddressLike,
+      newAdmin: AddressLike
     ],
     [void],
     "nonpayable"
@@ -2654,7 +2654,7 @@ export interface NounsGovernor extends BaseContract {
       support: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -2672,7 +2672,7 @@ export interface NounsGovernor extends BaseContract {
     [
       againstVotes: BigNumberish,
       totalSupply: BigNumberish,
-      params: NounsDAOStorageV3.DynamicQuorumParamsStruct,
+      params: NounsDAOStorageV3.DynamicQuorumParamsStruct
     ],
     [bigint],
     "view"
@@ -2718,7 +2718,9 @@ export interface NounsGovernor extends BaseContract {
   getFunction(
     nameOrSignature: "forkThresholdBPS"
   ): TypedContractMethod<[], [bigint], "view">;
-  getFunction(nameOrSignature: "getActions"): TypedContractMethod<
+  getFunction(
+    nameOrSignature: "getActions"
+  ): TypedContractMethod<
     [proposalId: BigNumberish],
     [
       [string[], bigint[], string[], string[]] & {
@@ -2726,7 +2728,7 @@ export interface NounsGovernor extends BaseContract {
         values: bigint[];
         signatures: string[];
         calldatas: string[];
-      },
+      }
     ],
     "view"
   >;
@@ -2754,7 +2756,7 @@ export interface NounsGovernor extends BaseContract {
       forkDAODeployer_: AddressLike,
       vetoer_: AddressLike,
       daoParams_: NounsDAOStorageV3.NounsDAOParamsStruct,
-      dynamicQuorumParams_: NounsDAOStorageV3.DynamicQuorumParamsStruct,
+      dynamicQuorumParams_: NounsDAOStorageV3.DynamicQuorumParamsStruct
     ],
     [void],
     "nonpayable"
@@ -2827,7 +2829,7 @@ export interface NounsGovernor extends BaseContract {
       values: BigNumberish[],
       signatures: string[],
       calldatas: BytesLike[],
-      description: string,
+      description: string
     ],
     [bigint],
     "nonpayable"
@@ -2841,7 +2843,7 @@ export interface NounsGovernor extends BaseContract {
       values: BigNumberish[],
       signatures: string[],
       calldatas: BytesLike[],
-      description: string,
+      description: string
     ],
     [bigint],
     "nonpayable"
@@ -2854,7 +2856,7 @@ export interface NounsGovernor extends BaseContract {
       values: BigNumberish[],
       signatures: string[],
       calldatas: BytesLike[],
-      description: string,
+      description: string
     ],
     [bigint],
     "nonpayable"
@@ -2901,7 +2903,7 @@ export interface NounsGovernor extends BaseContract {
       signatures: string[],
       calldatas: BytesLike[],
       description: string,
-      updateMessage: string,
+      updateMessage: string
     ],
     [void],
     "nonpayable"
@@ -2917,7 +2919,7 @@ export interface NounsGovernor extends BaseContract {
       signatures: string[],
       calldatas: BytesLike[],
       description: string,
-      updateMessage: string,
+      updateMessage: string
     ],
     [void],
     "nonpayable"
@@ -2938,7 +2940,7 @@ export interface NounsGovernor extends BaseContract {
       values: BigNumberish[],
       signatures: string[],
       calldatas: BytesLike[],
-      updateMessage: string,
+      updateMessage: string
     ],
     [void],
     "nonpayable"

--- a/src/lib/contracts/generated/OptimismGovernor.ts
+++ b/src/lib/contracts/generated/OptimismGovernor.ts
@@ -161,7 +161,7 @@ export interface OptimismGovernorInterface extends Interface {
       BigNumberish,
       string,
       BigNumberish,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -181,7 +181,7 @@ export interface OptimismGovernorInterface extends Interface {
       BytesLike,
       BigNumberish,
       BytesLike,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -229,7 +229,7 @@ export interface OptimismGovernorInterface extends Interface {
       AddressLike,
       BigNumberish[],
       BigNumberish[],
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -580,7 +580,7 @@ export namespace ProposalCreated_uint256_address_address_array_uint256_array_str
     startBlock: BigNumberish,
     endBlock: BigNumberish,
     description: string,
-    proposalType: BigNumberish,
+    proposalType: BigNumberish
   ];
   export type OutputTuple = [
     proposalId: bigint,
@@ -592,7 +592,7 @@ export namespace ProposalCreated_uint256_address_address_array_uint256_array_str
     startBlock: bigint,
     endBlock: bigint,
     description: string,
-    proposalType: bigint,
+    proposalType: bigint
   ];
   export interface OutputObject {
     proposalId: bigint;
@@ -621,7 +621,7 @@ export namespace ProposalCreated_uint256_address_address_bytes_uint256_uint256_s
     startBlock: BigNumberish,
     endBlock: BigNumberish,
     description: string,
-    proposalType: BigNumberish,
+    proposalType: BigNumberish
   ];
   export type OutputTuple = [
     proposalId: bigint,
@@ -631,7 +631,7 @@ export namespace ProposalCreated_uint256_address_address_bytes_uint256_uint256_s
     startBlock: bigint,
     endBlock: bigint,
     description: string,
-    proposalType: bigint,
+    proposalType: bigint
   ];
   export interface OutputObject {
     proposalId: bigint;
@@ -657,7 +657,7 @@ export namespace ProposalCreated_uint256_address_address_bytes_uint256_uint256_s
     proposalData: BytesLike,
     startBlock: BigNumberish,
     endBlock: BigNumberish,
-    description: string,
+    description: string
   ];
   export type OutputTuple = [
     proposalId: bigint,
@@ -666,7 +666,7 @@ export namespace ProposalCreated_uint256_address_address_bytes_uint256_uint256_s
     proposalData: string,
     startBlock: bigint,
     endBlock: bigint,
-    description: string,
+    description: string
   ];
   export interface OutputObject {
     proposalId: bigint;
@@ -693,7 +693,7 @@ export namespace ProposalCreated_uint256_address_address_array_uint256_array_str
     calldatas: BytesLike[],
     startBlock: BigNumberish,
     endBlock: BigNumberish,
-    description: string,
+    description: string
   ];
   export type OutputTuple = [
     proposalId: bigint,
@@ -704,7 +704,7 @@ export namespace ProposalCreated_uint256_address_address_array_uint256_array_str
     calldatas: string[],
     startBlock: bigint,
     endBlock: bigint,
-    description: string,
+    description: string
   ];
   export interface OutputObject {
     proposalId: bigint;
@@ -751,11 +751,11 @@ export namespace ProposalExecutedEvent {
 export namespace ProposalThresholdSetEvent {
   export type InputTuple = [
     oldProposalThreshold: BigNumberish,
-    newProposalThreshold: BigNumberish,
+    newProposalThreshold: BigNumberish
   ];
   export type OutputTuple = [
     oldProposalThreshold: bigint,
-    newProposalThreshold: bigint,
+    newProposalThreshold: bigint
   ];
   export interface OutputObject {
     oldProposalThreshold: bigint;
@@ -770,7 +770,7 @@ export namespace ProposalThresholdSetEvent {
 export namespace ProposalTypeUpdatedEvent {
   export type InputTuple = [
     proposalId: BigNumberish,
-    proposalType: BigNumberish,
+    proposalType: BigNumberish
   ];
   export type OutputTuple = [proposalId: bigint, proposalType: bigint];
   export interface OutputObject {
@@ -786,11 +786,11 @@ export namespace ProposalTypeUpdatedEvent {
 export namespace QuorumNumeratorUpdatedEvent {
   export type InputTuple = [
     oldQuorumNumerator: BigNumberish,
-    newQuorumNumerator: BigNumberish,
+    newQuorumNumerator: BigNumberish
   ];
   export type OutputTuple = [
     oldQuorumNumerator: bigint,
-    newQuorumNumerator: bigint,
+    newQuorumNumerator: bigint
   ];
   export interface OutputObject {
     oldQuorumNumerator: bigint;
@@ -808,14 +808,14 @@ export namespace VoteCastEvent {
     proposalId: BigNumberish,
     support: BigNumberish,
     weight: BigNumberish,
-    reason: string,
+    reason: string
   ];
   export type OutputTuple = [
     voter: string,
     proposalId: bigint,
     support: bigint,
     weight: bigint,
-    reason: string,
+    reason: string
   ];
   export interface OutputObject {
     voter: string;
@@ -837,7 +837,7 @@ export namespace VoteCastWithParamsEvent {
     support: BigNumberish,
     weight: BigNumberish,
     reason: string,
-    params: BytesLike,
+    params: BytesLike
   ];
   export type OutputTuple = [
     voter: string,
@@ -845,7 +845,7 @@ export namespace VoteCastWithParamsEvent {
     support: bigint,
     weight: bigint,
     reason: string,
-    params: string,
+    params: string
   ];
   export interface OutputObject {
     voter: string;
@@ -864,7 +864,7 @@ export namespace VoteCastWithParamsEvent {
 export namespace VotingDelaySetEvent {
   export type InputTuple = [
     oldVotingDelay: BigNumberish,
-    newVotingDelay: BigNumberish,
+    newVotingDelay: BigNumberish
   ];
   export type OutputTuple = [oldVotingDelay: bigint, newVotingDelay: bigint];
   export interface OutputObject {
@@ -880,7 +880,7 @@ export namespace VotingDelaySetEvent {
 export namespace VotingPeriodSetEvent {
   export type InputTuple = [
     oldVotingPeriod: BigNumberish,
-    newVotingPeriod: BigNumberish,
+    newVotingPeriod: BigNumberish
   ];
   export type OutputTuple = [oldVotingPeriod: bigint, newVotingPeriod: bigint];
   export interface OutputObject {
@@ -963,7 +963,7 @@ export interface OptimismGovernor extends BaseContract {
       targets: AddressLike[],
       values: BigNumberish[],
       calldatas: BytesLike[],
-      descriptionHash: BytesLike,
+      descriptionHash: BytesLike
     ],
     [bigint],
     "nonpayable"
@@ -987,7 +987,7 @@ export interface OptimismGovernor extends BaseContract {
       support: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [bigint],
     "nonpayable"
@@ -1000,7 +1000,7 @@ export interface OptimismGovernor extends BaseContract {
       support: BigNumberish,
       reason: string,
       votes: BigNumberish,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -1017,7 +1017,7 @@ export interface OptimismGovernor extends BaseContract {
       proposalId: BigNumberish,
       support: BigNumberish,
       reason: string,
-      params: BytesLike,
+      params: BytesLike
     ],
     [bigint],
     "nonpayable"
@@ -1031,7 +1031,7 @@ export interface OptimismGovernor extends BaseContract {
       params: BytesLike,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [bigint],
     "nonpayable"
@@ -1048,7 +1048,7 @@ export interface OptimismGovernor extends BaseContract {
       targets: AddressLike[],
       values: BigNumberish[],
       calldatas: BytesLike[],
-      descriptionHash: BytesLike,
+      descriptionHash: BytesLike
     ],
     [bigint],
     "payable"
@@ -1083,7 +1083,7 @@ export interface OptimismGovernor extends BaseContract {
       targets: AddressLike[],
       values: BigNumberish[],
       calldatas: BytesLike[],
-      descriptionHash: BytesLike,
+      descriptionHash: BytesLike
     ],
     [bigint],
     "view"
@@ -1100,7 +1100,7 @@ export interface OptimismGovernor extends BaseContract {
       proposalId: BigNumberish,
       account: AddressLike,
       votes: BigNumberish,
-      accountVotes: BigNumberish,
+      accountVotes: BigNumberish
     ],
     [void],
     "nonpayable"
@@ -1116,7 +1116,7 @@ export interface OptimismGovernor extends BaseContract {
       arg1: AddressLike,
       arg2: BigNumberish[],
       arg3: BigNumberish[],
-      arg4: BytesLike,
+      arg4: BytesLike
     ],
     [string],
     "nonpayable"
@@ -1128,7 +1128,7 @@ export interface OptimismGovernor extends BaseContract {
       arg1: AddressLike,
       arg2: BigNumberish,
       arg3: BigNumberish,
-      arg4: BytesLike,
+      arg4: BytesLike
     ],
     [string],
     "nonpayable"
@@ -1161,7 +1161,7 @@ export interface OptimismGovernor extends BaseContract {
         againstVotes: bigint;
         forVotes: bigint;
         abstainVotes: bigint;
-      },
+      }
     ],
     "view"
   >;
@@ -1171,7 +1171,7 @@ export interface OptimismGovernor extends BaseContract {
       targets: AddressLike[],
       values: BigNumberish[],
       calldatas: BytesLike[],
-      description: string,
+      description: string
     ],
     [bigint],
     "nonpayable"
@@ -1183,7 +1183,7 @@ export interface OptimismGovernor extends BaseContract {
       values: BigNumberish[],
       calldatas: BytesLike[],
       description: string,
-      proposalType: BigNumberish,
+      proposalType: BigNumberish
     ],
     [bigint],
     "nonpayable"
@@ -1200,7 +1200,7 @@ export interface OptimismGovernor extends BaseContract {
       module: AddressLike,
       proposalData: BytesLike,
       description: string,
-      proposalType: BigNumberish,
+      proposalType: BigNumberish
     ],
     [bigint],
     "nonpayable"
@@ -1330,7 +1330,7 @@ export interface OptimismGovernor extends BaseContract {
       targets: AddressLike[],
       values: BigNumberish[],
       calldatas: BytesLike[],
-      descriptionHash: BytesLike,
+      descriptionHash: BytesLike
     ],
     [bigint],
     "nonpayable"
@@ -1357,7 +1357,7 @@ export interface OptimismGovernor extends BaseContract {
       support: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [bigint],
     "nonpayable"
@@ -1371,7 +1371,7 @@ export interface OptimismGovernor extends BaseContract {
       support: BigNumberish,
       reason: string,
       votes: BigNumberish,
-      params: BytesLike,
+      params: BytesLike
     ],
     [void],
     "nonpayable"
@@ -1390,7 +1390,7 @@ export interface OptimismGovernor extends BaseContract {
       proposalId: BigNumberish,
       support: BigNumberish,
       reason: string,
-      params: BytesLike,
+      params: BytesLike
     ],
     [bigint],
     "nonpayable"
@@ -1405,7 +1405,7 @@ export interface OptimismGovernor extends BaseContract {
       params: BytesLike,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [bigint],
     "nonpayable"
@@ -1424,7 +1424,7 @@ export interface OptimismGovernor extends BaseContract {
       targets: AddressLike[],
       values: BigNumberish[],
       calldatas: BytesLike[],
-      descriptionHash: BytesLike,
+      descriptionHash: BytesLike
     ],
     [bigint],
     "payable"
@@ -1464,7 +1464,7 @@ export interface OptimismGovernor extends BaseContract {
       targets: AddressLike[],
       values: BigNumberish[],
       calldatas: BytesLike[],
-      descriptionHash: BytesLike,
+      descriptionHash: BytesLike
     ],
     [bigint],
     "view"
@@ -1483,7 +1483,7 @@ export interface OptimismGovernor extends BaseContract {
       proposalId: BigNumberish,
       account: AddressLike,
       votes: BigNumberish,
-      accountVotes: BigNumberish,
+      accountVotes: BigNumberish
     ],
     [void],
     "nonpayable"
@@ -1502,7 +1502,7 @@ export interface OptimismGovernor extends BaseContract {
       arg1: AddressLike,
       arg2: BigNumberish[],
       arg3: BigNumberish[],
-      arg4: BytesLike,
+      arg4: BytesLike
     ],
     [string],
     "nonpayable"
@@ -1515,7 +1515,7 @@ export interface OptimismGovernor extends BaseContract {
       arg1: AddressLike,
       arg2: BigNumberish,
       arg3: BigNumberish,
-      arg4: BytesLike,
+      arg4: BytesLike
     ],
     [string],
     "nonpayable"
@@ -1536,14 +1536,16 @@ export interface OptimismGovernor extends BaseContract {
   getFunction(
     nameOrSignature: "proposalThreshold"
   ): TypedContractMethod<[], [bigint], "view">;
-  getFunction(nameOrSignature: "proposalVotes"): TypedContractMethod<
+  getFunction(
+    nameOrSignature: "proposalVotes"
+  ): TypedContractMethod<
     [proposalId: BigNumberish],
     [
       [bigint, bigint, bigint] & {
         againstVotes: bigint;
         forVotes: bigint;
         abstainVotes: bigint;
-      },
+      }
     ],
     "view"
   >;
@@ -1554,7 +1556,7 @@ export interface OptimismGovernor extends BaseContract {
       targets: AddressLike[],
       values: BigNumberish[],
       calldatas: BytesLike[],
-      description: string,
+      description: string
     ],
     [bigint],
     "nonpayable"
@@ -1567,7 +1569,7 @@ export interface OptimismGovernor extends BaseContract {
       values: BigNumberish[],
       calldatas: BytesLike[],
       description: string,
-      proposalType: BigNumberish,
+      proposalType: BigNumberish
     ],
     [bigint],
     "nonpayable"
@@ -1586,7 +1588,7 @@ export interface OptimismGovernor extends BaseContract {
       module: AddressLike,
       proposalData: BytesLike,
       description: string,
-      proposalType: BigNumberish,
+      proposalType: BigNumberish
     ],
     [bigint],
     "nonpayable"

--- a/src/lib/contracts/generated/OptimismToken.ts
+++ b/src/lib/contracts/generated/OptimismToken.ts
@@ -119,7 +119,7 @@ export interface OptimismTokenInterface extends Interface {
       BigNumberish,
       BigNumberish,
       BytesLike,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -162,7 +162,7 @@ export interface OptimismTokenInterface extends Interface {
       BigNumberish,
       BigNumberish,
       BytesLike,
-      BytesLike,
+      BytesLike
     ]
   ): string;
   encodeFunctionData(
@@ -257,7 +257,7 @@ export namespace ApprovalEvent {
   export type InputTuple = [
     owner: AddressLike,
     spender: AddressLike,
-    value: BigNumberish,
+    value: BigNumberish
   ];
   export type OutputTuple = [owner: string, spender: string, value: bigint];
   export interface OutputObject {
@@ -275,12 +275,12 @@ export namespace DelegateChangedEvent {
   export type InputTuple = [
     delegator: AddressLike,
     fromDelegate: AddressLike,
-    toDelegate: AddressLike,
+    toDelegate: AddressLike
   ];
   export type OutputTuple = [
     delegator: string,
     fromDelegate: string,
-    toDelegate: string,
+    toDelegate: string
   ];
   export interface OutputObject {
     delegator: string;
@@ -297,12 +297,12 @@ export namespace DelegateVotesChangedEvent {
   export type InputTuple = [
     delegate: AddressLike,
     previousBalance: BigNumberish,
-    newBalance: BigNumberish,
+    newBalance: BigNumberish
   ];
   export type OutputTuple = [
     delegate: string,
     previousBalance: bigint,
-    newBalance: bigint,
+    newBalance: bigint
   ];
   export interface OutputObject {
     delegate: string;
@@ -332,7 +332,7 @@ export namespace TransferEvent {
   export type InputTuple = [
     from: AddressLike,
     to: AddressLike,
-    value: BigNumberish,
+    value: BigNumberish
   ];
   export type OutputTuple = [from: string, to: string, value: bigint];
   export interface OutputObject {
@@ -436,7 +436,7 @@ export interface OptimismToken extends BaseContract {
       expiry: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -486,7 +486,7 @@ export interface OptimismToken extends BaseContract {
       deadline: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -579,7 +579,7 @@ export interface OptimismToken extends BaseContract {
       expiry: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"
@@ -636,7 +636,7 @@ export interface OptimismToken extends BaseContract {
       deadline: BigNumberish,
       v: BigNumberish,
       r: BytesLike,
-      s: BytesLike,
+      s: BytesLike
     ],
     [void],
     "nonpayable"

--- a/src/lib/contracts/generated/ProposalTypesConfigurator.ts
+++ b/src/lib/contracts/generated/ProposalTypesConfigurator.ts
@@ -32,7 +32,7 @@ export declare namespace IProposalTypesConfigurator {
   export type ProposalTypeStructOutput = [
     quorum: bigint,
     approvalThreshold: bigint,
-    name: string,
+    name: string
   ] & { quorum: bigint; approvalThreshold: bigint; name: string };
 }
 
@@ -81,13 +81,13 @@ export namespace ProposalTypeSetEvent {
     proposalTypeId: BigNumberish,
     quorum: BigNumberish,
     approvalThreshold: BigNumberish,
-    name: string,
+    name: string
   ];
   export type OutputTuple = [
     proposalTypeId: bigint,
     quorum: bigint,
     approvalThreshold: bigint,
-    name: string,
+    name: string
   ];
   export interface OutputObject {
     proposalTypeId: bigint;
@@ -159,7 +159,7 @@ export interface ProposalTypesConfigurator extends BaseContract {
       proposalTypeId: BigNumberish,
       quorum: BigNumberish,
       approvalThreshold: BigNumberish,
-      name: string,
+      name: string
     ],
     [void],
     "nonpayable"
@@ -189,7 +189,7 @@ export interface ProposalTypesConfigurator extends BaseContract {
       proposalTypeId: BigNumberish,
       quorum: BigNumberish,
       approvalThreshold: BigNumberish,
-      name: string,
+      name: string
     ],
     [void],
     "nonpayable"

--- a/src/lib/contracts/generated/VotableSupplyOracle.ts
+++ b/src/lib/contracts/generated/VotableSupplyOracle.ts
@@ -133,12 +133,12 @@ export namespace VotableSupplyCheckpointUpdatedEvent {
   export type InputTuple = [
     checkpointBlockNumber: BigNumberish,
     prevVotableSupply: BigNumberish,
-    newVotableSupply: BigNumberish,
+    newVotableSupply: BigNumberish
   ];
   export type OutputTuple = [
     checkpointBlockNumber: bigint,
     prevVotableSupply: bigint,
-    newVotableSupply: bigint,
+    newVotableSupply: bigint
   ];
   export interface OutputObject {
     checkpointBlockNumber: bigint;
@@ -154,11 +154,11 @@ export namespace VotableSupplyCheckpointUpdatedEvent {
 export namespace VotableSupplyUpdatedEvent {
   export type InputTuple = [
     prevVotableSupply: BigNumberish,
-    newVotableSupply: BigNumberish,
+    newVotableSupply: BigNumberish
   ];
   export type OutputTuple = [
     prevVotableSupply: bigint,
-    newVotableSupply: bigint,
+    newVotableSupply: bigint
   ];
   export interface OutputObject {
     prevVotableSupply: bigint;

--- a/src/lib/contracts/generated/common.ts
+++ b/src/lib/contracts/generated/common.ts
@@ -19,11 +19,9 @@ export interface TypedDeferredTopicFilter<_TCEvent extends TypedContractEvent>
 export interface TypedContractEvent<
   InputTuple extends Array<any> = any,
   OutputTuple extends Array<any> = any,
-  OutputObject = any,
+  OutputObject = any
 > {
-  (
-    ...args: Partial<InputTuple>
-  ): TypedDeferredTopicFilter<
+  (...args: Partial<InputTuple>): TypedDeferredTopicFilter<
     TypedContractEvent<InputTuple, OutputTuple, OutputObject>
   >;
   name: string;
@@ -31,10 +29,19 @@ export interface TypedContractEvent<
   getFragment(...args: Partial<InputTuple>): EventFragment;
 }
 
-type __TypechainAOutputTuple<T> =
-  T extends TypedContractEvent<infer _U, infer W> ? W : never;
-type __TypechainOutputObject<T> =
-  T extends TypedContractEvent<infer _U, infer _W, infer V> ? V : never;
+type __TypechainAOutputTuple<T> = T extends TypedContractEvent<
+  infer _U,
+  infer W
+>
+  ? W
+  : never;
+type __TypechainOutputObject<T> = T extends TypedContractEvent<
+  infer _U,
+  infer _W,
+  infer V
+>
+  ? V
+  : never;
 
 export interface TypedEventLog<TCEvent extends TypedContractEvent>
   extends Omit<EventLog, "args"> {
@@ -50,7 +57,7 @@ export type TypedListener<TCEvent extends TypedContractEvent> = (
   ...listenerArg: [
     ...__TypechainAOutputTuple<TCEvent>,
     TypedEventLog<TCEvent>,
-    ...undefined[],
+    ...undefined[]
   ]
 ) => void;
 
@@ -58,10 +65,15 @@ export type MinEthersFactory<C, ARGS> = {
   deploy(...a: ARGS[]): Promise<C>;
 };
 
-export type GetContractTypeFromFactory<F> =
-  F extends MinEthersFactory<infer C, any> ? C : never;
-export type GetARGsTypeFromFactory<F> =
-  F extends MinEthersFactory<any, any> ? Parameters<F["deploy"]> : never;
+export type GetContractTypeFromFactory<F> = F extends MinEthersFactory<
+  infer C,
+  any
+>
+  ? C
+  : never;
+export type GetARGsTypeFromFactory<F> = F extends MinEthersFactory<any, any>
+  ? Parameters<F["deploy"]>
+  : never;
 
 export type StateMutability = "nonpayable" | "payable" | "view";
 
@@ -78,15 +90,15 @@ export type ViewOverrides = Omit<TransactionRequest, "to" | "data">;
 export type Overrides<S extends StateMutability> = S extends "nonpayable"
   ? NonPayableOverrides
   : S extends "payable"
-    ? PayableOverrides
-    : ViewOverrides;
+  ? PayableOverrides
+  : ViewOverrides;
 
 export type PostfixOverrides<A extends Array<any>, S extends StateMutability> =
   | A
   | [...A, Overrides<S>];
 export type ContractMethodArgs<
   A extends Array<any>,
-  S extends StateMutability,
+  S extends StateMutability
 > = PostfixOverrides<{ [I in keyof A]-?: A[I] | Typed }, S>;
 
 export type DefaultReturnType<R> = R extends Array<any> ? R[0] : R;
@@ -95,11 +107,9 @@ export type DefaultReturnType<R> = R extends Array<any> ? R[0] : R;
 export interface TypedContractMethod<
   A extends Array<any> = Array<any>,
   R = any,
-  S extends StateMutability = "payable",
+  S extends StateMutability = "payable"
 > {
-  (
-    ...args: ContractMethodArgs<A, S>
-  ): S extends "view"
+  (...args: ContractMethodArgs<A, S>): S extends "view"
     ? Promise<DefaultReturnType<R>>
     : Promise<ContractTransactionResponse>;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates type definitions in multiple contract files for consistency and readability.

### Detailed summary
- Updated `bigint` types to `BigNumberish` for consistency
- Corrected typos in type definitions
- Ensured uniform formatting of type definitions

> The following files were skipped due to too many changes: `src/lib/contracts/generated/EtherfiToken.ts`, `src/app/changelog/page.tsx`, `src/lib/contracts/generated/AlligatorOPV5.ts`, `src/lib/contracts/generated/OptimismGovernor.ts`, `src/lib/contracts/generated/NounsGovernor.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->