### PR TITLE
[1875] Add title and metadata to retropgf3 page and application page

### DIFF
--- a/src/app/retropgf/3/application/[id]/page.tsx
+++ b/src/app/retropgf/3/application/[id]/page.tsx
@@ -4,6 +4,37 @@ import RetroPGFApplicationBanner from "@/components/RetroPGF/RetroPGFApplication
 import RetroPGFApplicationContent from "@/components/RetroPGF/RetroPGFApplicationContent";
 import Tenant from "@/lib/tenant/tenant";
 
+export async function generateMetadata() {
+  const title = "Agora - Optimism's RetroPGF Round 3 Summary";
+  const description =
+    "See which of your favourite projects were allocated in Optimism's RetroPGF Round 3.";
+
+  const preview = `/api/images/og/proposals?title=${encodeURIComponent(
+    "Optimism Agora"
+  )}&description=${encodeURIComponent(
+    "Home of token house governance and RPGF"
+  )}`;
+
+  return {
+    title: title,
+    description: description,
+    openGraph: {
+      images: [
+        {
+          url: preview,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
 export default async function Page({
   params: { id },
 }: {

--- a/src/app/retropgf/3/page.tsx
+++ b/src/app/retropgf/3/page.tsx
@@ -5,6 +5,37 @@ import { getRetroPGFResults } from "@/app/retropgf/actions";
 import { retroPGFCategories, retroPGFSort } from "@/lib/constants";
 import Tenant from "@/lib/tenant/tenant";
 
+export async function generateMetadata() {
+  const title = "Agora - Optimism's RetroPGF Round 3 Summary";
+  const description =
+    "See which of your favourite projects were allocated in Optimism's RetroPGF Round 3.";
+
+  const preview = `/api/images/og/proposals?title=${encodeURIComponent(
+    "Optimism Agora"
+  )}&description=${encodeURIComponent(
+    "Home of token house governance and RPGF"
+  )}`;
+
+  return {
+    title: title,
+    description: description,
+    openGraph: {
+      images: [
+        {
+          url: preview,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
 export default async function Page({
   searchParams,
 }: {

--- a/src/app/retropgf/3/summary/page.tsx
+++ b/src/app/retropgf/3/summary/page.tsx
@@ -6,8 +6,6 @@ import Link from "next/link";
 import Tenant from "@/lib/tenant/tenant";
 
 export async function generateMetadata() {
-  const { ui } = Tenant.current();
-
   const title = "Agora - Optimism's RetroPGF Round 3 Summary";
   const description =
     "See which of your favourite projects were allocated in Optimism's RetroPGF Round 3.";


### PR DESCRIPTION
I finally left this title and description following https://vote.optimism.io/retropgf/3/summary which was already set.

Title: Agora - Optimism's RetroPGF Round 3 Summary
Description: See which of your favourite projects were allocated in Optimism's RetroPGF Round 3.

Preview link: https://agora-next-h3t0wwj3t-voteagora.vercel.app/

Example image:
<img width="570" alt="Screenshot 2024-04-23 at 10 07 10" src="https://github.com/voteagora/agora-next/assets/29060919/42c736a5-6a2a-4b2b-8d5a-e16d3880f1bf">
