### PR TITLE
🔐🤏 use bearer token in api client

### DIFF
--- a/src/app/lib/agoraAPI.js
+++ b/src/app/lib/agoraAPI.js
@@ -8,7 +8,7 @@ class AgoraAPI {
    * Initializes a new instance of the AgoraAPI class.
    */
   constructor() {
-    this.apiKey = process.env.NEXT_PUBLIC_AGORA_API_KEY;
+    this.bearerToken = `Bearer ${process.env.NEXT_PUBLIC_AGORA_API_KEY}`;
   }
 
   /**
@@ -18,7 +18,7 @@ class AgoraAPI {
     const res = await fetch(`/api/${version}${endpoint}`, {
       method: "GET",
       headers: {
-        authorization: this.apiKey,
+        authorization: this.bearerToken,
       },
     });
 
@@ -37,7 +37,7 @@ class AgoraAPI {
     const res = await fetch(`/api/${version}${endpoint}`, {
       method: "POST",
       headers: {
-        authorization: this.apiKey,
+        authorization: this.bearerToken,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(data),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the AgoraAPI class in `agoraAPI.js` to use a bearer token instead of an API key for authorization.

### Detailed summary
- Updated `constructor` to set `bearerToken` using the API key
- Replaced usages of `apiKey` with `bearerToken` in `GET` and `POST` requests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->