### PR TITLE
[AGORA-1940]👁️🤏 emit vercel env, branch name, etc w/otel

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -4,7 +4,10 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { Resource } from "@opentelemetry/resources";
-import { SEMRESATTRS_DEPLOYMENT_ENVIRONMENT, SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import {
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+  SEMRESATTRS_SERVICE_NAME,
+} from "@opentelemetry/semantic-conventions";
 
 import { SERVICE_NAME } from "./instrumentation";
 

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -4,7 +4,7 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { Resource } from "@opentelemetry/resources";
-import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { SEMRESATTRS_DEPLOYMENT_ENVIRONMENT, SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
 import { SERVICE_NAME } from "./instrumentation";
 
@@ -12,6 +12,14 @@ import { SERVICE_NAME } from "./instrumentation";
 const sdk = new NodeSDK({
   resource: new Resource({
     [SEMRESATTRS_SERVICE_NAME]: SERVICE_NAME,
+    [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: process.env.VERCEL_ENV,
+    "node.env": process.env.NODE_ENV,
+    "vercel.env": process.env.VERCEL_ENV,
+    "vercel.region": process.env.VERCEL_REGION,
+    "vercel.runtime": process.env.NEXT_RUNTIME,
+    "vercel.sha": process.env.VERCEL_GIT_COMMIT_SHA,
+    "vercel.host": process.env.VERCEL_URL,
+    "vercel.branch_host": process.env.VERCEL_BRANCH_URL,
   }),
   traceExporter: new OTLPTraceExporter(),
   metricReader: new PeriodicExportingMetricReader({

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -6,6 +6,18 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("./instrumentation.node");
   } else {
-    registerOTel({ serviceName: SERVICE_NAME });
+    registerOTel({
+      serviceName: SERVICE_NAME,
+      attributes: {
+        "service.name": SERVICE_NAME,
+        "node.env": process.env.NODE_ENV,
+        "vercel.env": process.env.VERCEL_ENV,
+        "vercel.region": process.env.VERCEL_REGION,
+        "vercel.runtime": process.env.NEXT_RUNTIME,
+        "vercel.sha": process.env.VERCEL_GIT_COMMIT_SHA,
+        "vercel.host": process.env.VERCEL_URL,
+        "vercel.branch_host": process.env.VERCEL_BRANCH_URL,
+      },
+    });
   }
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -9,9 +9,9 @@ export async function register() {
     registerOTel({
       serviceName: SERVICE_NAME,
       attributes: {
-        "service.name": SERVICE_NAME,
-        "node.env": process.env.NODE_ENV,
+        "deployment.environment": process.env.VERCEL_ENV,
         "vercel.env": process.env.VERCEL_ENV,
+        "node.env": process.env.NODE_ENV,
         "vercel.region": process.env.VERCEL_REGION,
         "vercel.runtime": process.env.NEXT_RUNTIME,
         "vercel.sha": process.env.VERCEL_GIT_COMMIT_SHA,


### PR DESCRIPTION
allow discernment on datadog between our various environments

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances OpenTelemetry instrumentation by adding environment attributes for Vercel deployment.

### Detailed summary
- Added environment attributes for Vercel deployment in `instrumentation.ts`
- Updated imports and resource initialization in `instrumentation.node.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->