### PR TITLE
fixed line break on mobile prop descriptions

### DIFF
--- a/src/components/Proposals/Proposal/Proposal.jsx
+++ b/src/components/Proposals/Proposal/Proposal.jsx
@@ -52,7 +52,9 @@ export default function Proposal({ proposal, votableSupply }) {
               </div>
             </HStack>
           )}
-          <div className={cn(styles.cell_content_body, styles.proposal_title)}>
+          <div
+            className={`${styles.cell_content_body} ${styles.proposal_title} overflow-visible whitespace-normal break-words`}
+          >
             {proposal.markdowntitle.length > 80
               ? `${proposal.markdowntitle.slice(0, 80)}...`
               : proposal.markdowntitle}


### PR DESCRIPTION
![CleanShot 2024-05-02 at 19 49 02@2x](https://github.com/voteagora/agora-next/assets/12737/7640f36e-6fb6-4134-b38d-9e1e4595efab)

![CleanShot 2024-05-02 at 20 39 56@2x](https://github.com/voteagora/agora-next/assets/12737/f341a273-810a-414d-9b34-3663873181a1)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the styling of the Proposal title in `Proposal.jsx` by adding overflow-visible, whitespace-normal, and break-words classes.

### Detailed summary
- Updated `className` in `div` to include additional styling classes for overflow, whitespace, and word breaking.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->