### PR TITLE
🤏 fixup imports and naming for new routes

### DIFF
--- a/src/app/api/delegates/[addressOrENSName]/route.ts
+++ b/src/app/api/delegates/[addressOrENSName]/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { fetchDelegate } from "@/app/api/common/delegates/getDelegates";
-import { authenticateApiUser } from "@/app/lib/middleware/auth";
+import { authenticateApiUser } from "@/app/lib/auth/serverAuth";
 import { traceWithUserId } from "@/app/api/v1/apiUtils";
 
 export async function GET(request: NextRequest) {
   const authResponse = await authenticateApiUser(request);
 
   if (!authResponse.authenticated) {
-    return new Response(authResponse.reason, { status: 401 });
+    return new Response(authResponse.failReason, { status: 401 });
   }
 
   return await traceWithUserId(authResponse.userId as string, async () => {

--- a/src/app/api/delegates/route.ts
+++ b/src/app/api/delegates/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { ZodError, z } from "zod";
 
-import { authenticateApiUser } from "@/app/lib/middleware/auth";
+import { authenticateApiUser } from "@/app/lib/auth/serverAuth";
 import { fetchDelegatesApi } from "@/app/api/common/delegates/getDelegates";
 import {
   type Delegate,
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
   const authResponse = await authenticateApiUser(request);
 
   if (!authResponse.authenticated) {
-    return new Response(authResponse.reason, { status: 401 });
+    return new Response(authResponse.failReason, { status: 401 });
   }
 
   return await traceWithUserId(authResponse.userId as string, async () => {

--- a/src/app/api/v1/retrofunding/rounds/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { authenticateApiUser } from "@/app/lib/middleware/auth";
+import { authenticateApiUser } from "@/app/lib/auth/serverAuth";
 import { traceWithUserId } from "@/app/api/v1/apiUtils";
 
 import { fetchRetroFundingRounds } from "@/app/api/common/rounds/getRetroFundingRounds";
@@ -11,7 +11,7 @@ export async function GET(
   const authResponse = await authenticateApiUser(request);
 
   if (!authResponse.authenticated) {
-    return new Response(authResponse.reason, { status: 401 });
+    return new Response(authResponse.failReason, { status: 401 });
   }
 
   return await traceWithUserId(authResponse.userId as string, async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates authentication middleware imports in multiple routes to use `serverAuth` instead of `middleware/auth`.

### Detailed summary
- Updated `authenticateApiUser` import to use `serverAuth` in multiple route files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->