### PR TITLE
add locked flag to swagger schema

### DIFF
--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -1749,6 +1749,8 @@ paths:
                   type: string
                 allocationAmount:
                   type: string
+                locked:
+                  type: boolean
       responses:
         "201":
           description: Created


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new field `locked` of type boolean to the `allocationAmount` object in the `oas_v1.yaml` file.

### Detailed summary
- Added `locked` field of type boolean to the `allocationAmount` object in `oas_v1.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->