### PR TITLE
Patch swagger ballots params

### DIFF
--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -1722,10 +1722,6 @@ paths:
       responses:
         "200":
           description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RetroFundingBallot"
         "400":
           description: Bad Request
         "401":
@@ -1756,10 +1752,6 @@ paths:
       responses:
         "200":
           description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RetroFundingBallot"
         "400":
           description: Bad Request
         "401":

--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -1713,6 +1713,12 @@ paths:
       parameters:
         - $ref: "#/components/parameters/roundIdParam"
         - $ref: "#/components/parameters/ballotIdParam"
+        - name: osMultiplier
+          in: path
+          description: The OS multiplier to update the ballot with (1 - 5)
+          required: true
+          schema:
+            type: number
       responses:
         "200":
           description: OK
@@ -1740,6 +1746,13 @@ paths:
       parameters:
         - $ref: "#/components/parameters/roundIdParam"
         - $ref: "#/components/parameters/ballotIdParam"
+        - name: osOnly
+          in: path
+          description: >
+            The OS only flag to set for the ballot.
+          required: true
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds new parameters `osMultiplier` and `osOnly` to the API path for updating ballot details.

### Detailed summary
- Added `osMultiplier` parameter for updating ballot with OS multiplier (1 - 5)
- Added `osOnly` parameter for setting OS only flag for the ballot

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->