### PR TITLE
[RetroFunding API] Patch: fix prisma is not defined error

### DIFF
--- a/src/app/api/common/ballots/getBallots.ts
+++ b/src/app/api/common/ballots/getBallots.ts
@@ -1,8 +1,9 @@
 import { paginateResultEx } from "@/app/lib/pagination";
 import { cache } from "react";
 import { addressOrEnsNameWrap } from "../utils/ensName";
-import { Ballots, allocations } from "@prisma/client";
+import { Ballots } from "@prisma/client";
 import { Ballot } from "./ballot";
+import prisma from "@/app/lib/prisma";
 
 async function getBallotsApi({
   roundId,

--- a/src/app/api/common/ballots/submitBallot.ts
+++ b/src/app/api/common/ballots/submitBallot.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { addressOrEnsNameWrap } from "../utils/ensName";
 import verifyMessage from "@/lib/serverVerifyMessage";
+import prisma from "@/app/lib/prisma";
 
 type BallotSubmission = {
   ballotContnet: {

--- a/src/app/api/common/ballots/updateBallot.ts
+++ b/src/app/api/common/ballots/updateBallot.ts
@@ -1,5 +1,6 @@
 import { cache } from "react";
 import { addressOrEnsNameWrap } from "../utils/ensName";
+import prisma from "@/app/lib/prisma";
 
 type BallotContent = {
   metric_id: string;

--- a/src/app/api/common/impactMetrics/getImpactMetrics.ts
+++ b/src/app/api/common/impactMetrics/getImpactMetrics.ts
@@ -1,4 +1,5 @@
 import { cache } from "react";
+import prisma from "@/app/lib/prisma";
 
 async function getImpactMetricsApi(roundId: string) {
   const impactMetrics = await prisma.metrics_data.findMany({

--- a/src/app/api/common/impactMetrics/viewImactMetric.ts
+++ b/src/app/api/common/impactMetrics/viewImactMetric.ts
@@ -1,4 +1,5 @@
 import { addressOrEnsNameWrap } from "../utils/ensName";
+import prisma from "@/app/lib/prisma";
 
 const viewImpactMetric = async ({
   addressOrENSName,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating API functions to use `prisma` for database operations.

### Detailed summary
- Added `prisma` import in `viewImpactMetric.ts`, `updateBallot.ts`, `getImpactMetrics.ts`, `submitBallot.ts`, and `getBallots.ts`
- Updated functions to use `prisma` for database operations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->