### PR TITLE
Don't show deleted proposal types

### DIFF
--- a/src/app/api/common/proposals/getProposals.ts
+++ b/src/app/api/common/proposals/getProposals.ts
@@ -102,6 +102,9 @@ async function getProposalTypes() {
   return prisma[`${namespace}ProposalTypes`].findMany({
     where: {
       contract: contracts.proposalTypesConfigurator!.address,
+      name: {
+        not: "",
+      },
     },
   });
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the query in `getProposals.ts` to filter proposals by a non-empty `name`.

### Detailed summary
- Updated the query in `getProposals.ts` to filter proposals by a non-empty `name`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->