### PR TITLE
Remove refetch logic from the profile dropdown

### DIFF
--- a/src/hooks/useConnectedDelegate.ts
+++ b/src/hooks/useConnectedDelegate.ts
@@ -1,82 +1,17 @@
-import {
-  fetchConnectedDelegate,
-  revalidateDelegateAddressPage,
-} from "@/app/delegates/actions";
+import { fetchConnectedDelegate } from "@/app/delegates/actions";
 import { useAccount } from "wagmi";
-import { useState } from "react";
-import { useConnectButtonContext } from "@/contexts/ConnectButtonContext";
 import { useQuery } from "@tanstack/react-query";
-import { timeout } from "@/lib/utils";
-import { fetchDelegate } from "@/app/delegates/actions";
 
-/**
- * Define maximum number of retries, max retries 10 means 180 seconds waiting in total (advanced delegation voting power
- * takes around 120 seconds to update)
- */
-const MAX_RETRIES = 10;
-
-// TODO: think about strategy to fetch, since balance and voting power can change on every block,
-// also to prevent additional unnecessary fetches being done right now
 const useConnectedDelegate = () => {
-  const { refetchDelegate, setRefetchDelegate } = useConnectButtonContext();
   const { address } = useAccount();
-  const [retries, setRetries] = useState<number>(0);
-  const [lastVotingPower, setLastVotingPower] = useState<string | null>(null);
 
   const data = useQuery({
     enabled: !!address,
-    queryKey: ["useConnectedDelegate", address, refetchDelegate, retries],
+    queryKey: ["useConnectedDelegate", address],
     queryFn: async () => {
       const [delegate, advancedDelegators, balance] =
         await fetchConnectedDelegate(address!);
-      if (refetchDelegate) {
-        revalidateDelegateAddressPage(refetchDelegate.address);
-      }
-      setLastVotingPower(delegate.votingPower);
-
-      // If refetchDelegate?.votingPower we are looking for a revalidation on the page of the delegatee
-      if (refetchDelegate?.prevVotingPowerDelegatee) {
-        const delegatee = await fetchDelegate(refetchDelegate.address);
-        /**
-         * Materialized view that brings the new voting power takes one minute to sync
-         * Refetch delegate will be set to null by the delegateProfileImage
-         */
-        if (
-          delegatee.votingPower === refetchDelegate.prevVotingPowerDelegatee
-        ) {
-          // Check if maximum retries has been reached
-          if (retries < MAX_RETRIES) {
-            // Implement exponential backoff
-            await timeout(2000 * (retries + 1));
-            const _retries = retries + 1;
-            setRetries(_retries);
-          } else {
-            // Handle maximum retries reached
-            console.error("Maximum retries reached");
-          }
-        }
-        return { delegate, advancedDelegators, balance };
-      } else if (refetchDelegate) {
-        // When refetchDelegate is true, if last voting power is equal to actual it means indexer has not indexed the
-        // new voting power
-        if (delegate.votingPower === lastVotingPower) {
-          // Check if maximum retries has been reached
-          if (retries < MAX_RETRIES) {
-            // Implement exponential backoff
-            await timeout(2000 * (retries + 1));
-            const _retries = retries + 1;
-            setRetries(_retries);
-          } else {
-            // Handle maximum retries reached
-            console.error("Maximum retries reached");
-          }
-        } else {
-          setRefetchDelegate(null);
-        }
-        return { delegate, advancedDelegators, balance };
-      } else {
-        return { delegate, advancedDelegators, balance };
-      }
+      return { delegate, advancedDelegators, balance };
     },
   });
 


### PR DESCRIPTION
I think this refetching logic on the dropdown is unnecessary. It add some complexity that can prevent it existing the loading state

<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the `useConnectedDelegate` hook by removing unnecessary imports, refactoring query key dependencies, and simplifying the logic for fetching delegate data.

### Detailed summary
- Removed unused imports `useState` and `useConnectButtonContext`
- Refactored query key dependencies to simplify and improve performance
- Simplified logic for fetching delegate data based on address and refetching conditions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->