### PR TITLE
[RetroFunding API] schema fixes: enforce snake_case

### DIFF
--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -1894,7 +1894,7 @@ paths:
             schema:
               type: object
               properties:
-                metricId:
+                metric_id:
                   type: string
                 allocation:
                   type: number

--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -893,9 +893,7 @@ components:
           summary: Address or ENS of the ballot caster
           description: Address or ENS of the ballot caster.
           type: string
-        roundId:
-          type: integer
-        ballotContent:
+        ballot_content:
           type: object
           properties:
             allocations:

--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -535,16 +535,16 @@ components:
         A discussion comment, including the author, timestamp, and content.
       type: object
       properties:
-        commentId:
+        comment_id:
           summary: Comment ID
           description: The unique ID of the comment.
           type: string
-        createdAt:
+        created_at:
           summary: Timestamp of the comment
           description: The timestamp at which the comment was created.
           type: string
           format: date-time
-        updatedAt:
+        updated_at:
           summary: Timestamp of the comment edit
           description: The timestamp at which the comment was last edited.
           type: string
@@ -557,7 +557,7 @@ components:
           summary: Author of the comment
           description: The delegate address of the author of the comment.
           type: string
-        votesCount:
+        votes_count:
           summary: Count of votes on the comment
           description: The number of votes on the comment.
           type: integer
@@ -571,7 +571,7 @@ components:
         A vote on a comment, including the voter, timestamp, and vote (-1, 0, 1).
       type: object
       properties:
-        commentId:
+        comment_id:
           summary: Comment ID
           description: The unique ID of the comment.
           type: string
@@ -583,12 +583,12 @@ components:
           summary: Vote value
           description: The value of the vote (-1, 0, 1).
           type: integer
-        createdAt:
+        created_at:
           summary: Timestamp of the vote
           description: The timestamp at which the comment was created.
           type: string
           format: date-time
-        updatedAt:
+        updated_at:
           summary: Timestamp of the vote update
           description: The timestamp at which the comment was last edited.
           type: string

--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -661,12 +661,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Comment"
-        projectAllocations:
+        allocations_per_project:
           type: array
           items:
             type: object
             properties:
-              projectId:
+              project_id:
                 type: string
               name:
                 type: string
@@ -676,7 +676,7 @@ components:
                 type: number
         views:
           type: integer
-        addedToBallots:
+        added_to_ballot:
           type: integer
     ProjectMember:
       summary: Member of a RGPF project
@@ -1952,12 +1952,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  impactMetrics:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/RetroFundingImpactMetric"
+                type: array
+                items:
+                  $ref: "#/components/schemas/RetroFundingImpactMetric"
         "400":
           description: Bad Request
         "401":

--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -848,9 +848,7 @@ components:
       properties:
         project_id:
           type: string
-        total_allocation_share:
-          type: number
-        total_allocation_amount:
+        allocation:
           type: number
         allocations_per_metric:
           type: array
@@ -859,9 +857,8 @@ components:
             properties:
               metric_id:
                 type: string
-              allocation_share:
+              allocation:
                 type: number
-
     RetroFundingBallot:
       summary: A ballot for an RetroFunding round
       description: >
@@ -872,7 +869,7 @@ components:
           summary: Address of the voter
           description: Address of the voter
           type: string
-        roundId:
+        round_id:
           type: integer
         status:
           type: string

--- a/src/app/api/common/ballots/submitBallot.ts
+++ b/src/app/api/common/ballots/submitBallot.ts
@@ -23,7 +23,7 @@ async function submitBallotForAddress({
   roundId: number;
   address: string;
 }) {
-  const payload = JSON.stringify(data.ballotContnet);
+  const payload = JSON.stringify(data.ballot_content);
 
   const isSignatureValid = await verifyMessage({
     address: address as `0x${string}`,

--- a/src/app/api/common/comments/createImpactMetricComment.ts
+++ b/src/app/api/common/comments/createImpactMetricComment.ts
@@ -23,22 +23,22 @@ async function createImpactMetricCommentApi({
   });
 
   return {
-    commentId: newComment.comment_id,
+    comment_id: newComment.comment_id,
     comment: newComment.comment,
     address: newComment.address,
-    createdAt: newComment.created_at,
-    updatedAt: newComment.updated_at,
-    votesCount: newComment.metrics_comments_votes.reduce(
+    created_at: newComment.created_at,
+    updated_at: newComment.updated_at,
+    votes_count: newComment.metrics_comments_votes.reduce(
       (acc, vote) => acc + vote.vote,
       0
     ),
     votes: newComment.metrics_comments_votes.map((vote) => {
       return {
-        commentId: vote.comment_id,
+        comment_id: vote.comment_id,
         address: vote.voter,
         vote: vote.vote,
-        createdAt: vote.created_at,
-        updatedAt: vote.updated_at,
+        created_at: vote.created_at,
+        updated_at: vote.updated_at,
       };
     }),
   };

--- a/src/app/api/common/comments/deleteImpactMetricComment.ts
+++ b/src/app/api/common/comments/deleteImpactMetricComment.ts
@@ -16,7 +16,7 @@ async function deleteImpactMetricCommentApi({
   });
 
   return {
-    commentId: deletedComment.comment_id,
+    comment_id: deletedComment.comment_id,
   };
 }
 

--- a/src/app/api/common/comments/getImpactMetricCommentVotes.ts
+++ b/src/app/api/common/comments/getImpactMetricCommentVotes.ts
@@ -15,11 +15,11 @@ async function getImpactMetricCommentVotesApi({
 
   return votes.map((vote) => {
     return {
-      commentId: vote.comment_id,
+      comment_id: vote.comment_id,
       address: vote.voter,
       vote: vote.vote,
-      createdAt: vote.created_at,
-      updatedAt: vote.updated_at,
+      created_at: vote.created_at,
+      updated_at: vote.updated_at,
     };
   });
 }

--- a/src/app/api/common/comments/getImpactMetricComments.ts
+++ b/src/app/api/common/comments/getImpactMetricComments.ts
@@ -67,22 +67,22 @@ async function getImpactMetricCommentsApi({
     meta: comments.meta,
     data: comments.data.map((comment) => {
       return {
-        commentId: comment.comment_id,
+        comment_id: comment.comment_id,
         comment: comment.comment,
         address: comment.address,
-        createdAt: comment.created_at,
-        updatedAt: comment.updated_at,
-        votesCount: comment.metrics_comments_votes.reduce(
+        created_at: comment.created_at,
+        updated_at: comment.updated_at,
+        votes_count: comment.metrics_comments_votes.reduce(
           (acc, vote) => acc + vote.vote,
           0
         ),
         votes: comment.metrics_comments_votes.map((vote) => {
           return {
-            commentId: vote.comment_id,
+            comment_id: vote.comment_id,
             address: vote.voter,
             vote: vote.vote,
-            createdAt: vote.created_at,
-            updatedAt: vote.updated_at,
+            created_at: vote.created_at,
+            updated_at: vote.updated_at,
           };
         }),
       };
@@ -107,22 +107,22 @@ async function getImpactMetricCommentApi(
   }
 
   return {
-    commentId: comment.comment_id,
+    comment_id: comment.comment_id,
     comment: comment.comment,
     address: comment.address,
-    createdAt: comment.created_at,
-    updatedAt: comment.updated_at,
-    votesCount: comment.metrics_comments_votes.reduce(
+    created_at: comment.created_at,
+    updated_at: comment.updated_at,
+    votes_count: comment.metrics_comments_votes.reduce(
       (acc, vote) => acc + vote.vote,
       0
     ),
     votes: comment.metrics_comments_votes.map((vote) => {
       return {
-        commentId: vote.comment_id,
+        comment_id: vote.comment_id,
         address: vote.voter,
         vote: vote.vote,
-        createdAt: vote.created_at,
-        updatedAt: vote.updated_at,
+        created_at: vote.created_at,
+        updated_at: vote.updated_at,
       };
     }),
   };

--- a/src/app/api/common/comments/impactMetricComment.d.ts
+++ b/src/app/api/common/comments/impactMetricComment.d.ts
@@ -6,19 +6,19 @@ export type ImpactMetrciCommentPayload =
   };
 
 export type ImpactMetricComment = {
-  commentId: number;
+  comment_id: number;
   comment: string;
   address: string;
-  createdAt: Date;
-  updatedAt: Date;
-  votesCount: number;
+  created_at: Date;
+  updated_at: Date;
+  votes_count: number;
   votes: ImpactMetricCommentVote[];
 };
 
 export type ImpactMetricCommentVote = {
-  commentId: number;
+  comment_id: number;
   address: string;
   vote: number;
-  createdAt: Date;
-  updatedAt: Date;
+  created_at: Date;
+  updated_at: Date;
 };

--- a/src/app/api/common/comments/updateImpactMetricComment.ts
+++ b/src/app/api/common/comments/updateImpactMetricComment.ts
@@ -29,22 +29,22 @@ async function updateImpactMetricCommentApi({
   });
 
   return {
-    commentId: updatedComment.comment_id,
+    comment_id: updatedComment.comment_id,
     comment: updatedComment.comment,
     address: updatedComment.address,
-    createdAt: updatedComment.created_at,
-    updatedAt: updatedComment.updated_at,
-    votesCount: updatedComment.metrics_comments_votes.reduce(
+    created_at: updatedComment.created_at,
+    updated_at: updatedComment.updated_at,
+    votes_count: updatedComment.metrics_comments_votes.reduce(
       (acc, vote) => acc + vote.vote,
       0
     ),
     votes: updatedComment.metrics_comments_votes.map((vote) => {
       return {
-        commentId: vote.comment_id,
+        comment_id: vote.comment_id,
         address: vote.voter,
         vote: vote.vote,
-        createdAt: vote.created_at,
-        updatedAt: vote.updated_at,
+        created_at: vote.created_at,
+        updated_at: vote.updated_at,
       };
     }),
   };

--- a/src/app/api/common/comments/updateImpactMetricCommentVote.ts
+++ b/src/app/api/common/comments/updateImpactMetricCommentVote.ts
@@ -30,11 +30,11 @@ async function updateImpactMetricCommentVoteApi({
   });
 
   return {
-    commentId: commentVote.comment_id,
+    comment_id: commentVote.comment_id,
     address: commentVote.voter,
     vote: commentVote.vote,
-    createdAt: commentVote.created_at,
-    updatedAt: commentVote.updated_at,
+    created_at: commentVote.created_at,
+    updated_at: commentVote.updated_at,
   };
 }
 

--- a/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
@@ -11,7 +11,7 @@ const ballotContentSchema = z.object({
 });
 
 const ballotSubmissionSchema = z.object({
-  ballotContnet: ballotContentSchema,
+  ballot_content: ballotContentSchema,
   signature: z.string().regex(/^0x[a-fA-F0-9]{130}$/),
 });
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update variable names and schemas related to comments, ballots, and impact metrics for consistency and clarity.

### Detailed summary
- Updated variable names from `commentId` to `comment_id` for consistency.
- Updated schemas to reflect the changes in variable names for comments, ballots, and impact metrics.
- Added include statements and orderBy conditions for `metrics_comments` and `metrics_projects` in `getImpactMetrics.ts`.
- Renamed properties in the OAS file from `commentId` to `comment_id` for consistency.

> The following files were skipped due to too many changes: `src/app/api/common/impactMetrics/getImpactMetrics.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->