### PR TITLE
[RetroFunding API] fix: os multiplier is a float not an int

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,7 +107,7 @@ model Ballots {
   address       String        @db.VarChar(255)
   round         Int
   os_only       Boolean       @default(false)
-  os_multiplier Int           @default(1)
+  os_multiplier Float         @default(1)
   created_at    DateTime      @default(now()) @db.Timestamptz(6)
   updated_at    DateTime      @default(now()) @db.Timestamptz(6)
   allocations   allocations[]

--- a/src/app/api/common/utils/validators.ts
+++ b/src/app/api/common/utils/validators.ts
@@ -44,3 +44,25 @@ export const createOptionalNumberValidator = (
     ])
     .transform((x) => (x !== null ? x : defaultValue));
 };
+
+/*
+  Creates a zod schema for validating input against min and max number values for float types.
+  If input is null, returns the supplied default value.
+*/
+export const createOptionalFloatNumberValidator = (
+  min: number,
+  max: number,
+  defaultValue: number
+) => {
+  return z
+    .union([
+      z.literal(null),
+      z
+        .string()
+        .transform((x) => parseFloat(x))
+        .refine((x) => x >= min)
+        .refine((x) => x <= max),
+      z.number().min(min).max(max).default(defaultValue),
+    ])
+    .transform((x) => (x !== null ? x : defaultValue));
+};

--- a/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/osMultiplier/[multiplier]/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/osMultiplier/[multiplier]/route.ts
@@ -1,5 +1,5 @@
 import { updateBallotOsMultiplier } from "@/app/api/common/ballots/updateBallot";
-import { createOptionalNumberValidator } from "@/app/api/common/utils/validators";
+import { createOptionalFloatNumberValidator } from "@/app/api/common/utils/validators";
 import { traceWithUserId } from "@/app/api/v1/apiUtils";
 import {
   authenticateApiUser,
@@ -7,7 +7,7 @@ import {
 } from "@/app/lib/auth/serverAuth";
 import { NextRequest, NextResponse } from "next/server";
 
-const multiplierValidator = createOptionalNumberValidator(1, 5, 1);
+const multiplierValidator = createOptionalFloatNumberValidator(1, 5, 1);
 
 export async function POST(
   request: NextRequest,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the data type of `os_multiplier` field in `schema.prisma` from `Int` to `Float` and introduces a new validator for float numbers in the API.

### Detailed summary
- Updated `os_multiplier` field in `schema.prisma` from `Int` to `Float`
- Added `createOptionalFloatNumberValidator` in `validators.ts` for float number validation
- Updated the validator import and usage in `route.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->