### PR TITLE
Aggregate dissagregated metrics(?)

### DIFF
--- a/src/app/api/common/ballots/getBallots.ts
+++ b/src/app/api/common/ballots/getBallots.ts
@@ -148,12 +148,14 @@ async function getBallotForAddress({
           na.name,
           na.image,
           na.metric_id,
-          na.normalized_allocation,
-          na.normalized_allocation * 10000000 AS normalized_allocation_amount
+          SUM(na.normalized_allocation) as normalized_allocation,
+          SUM(na.normalized_allocation) * 10000000 AS normalized_allocation_amount
       FROM 
           normalized_allocations na
+      group by
+      	  1, 2, 3, 4, 5, 6
       ORDER BY 
-          na.normalized_allocation DESC
+          SUM(na.normalized_allocation) DESC
   )
   , aggregated_project_allocations AS (
       SELECT 


### PR DESCRIPTION
This PR attempts to aggregate project-level metrics, such that only one metric shows up.  At the time of writing this PR, it's unclear what these disaggregates actually are.

I have not tested this change, anywhere other than a SQL client against prod.  

The updated SQL, indeed returns only 1 row per metric, and the numbers sum to the project level allocation.