### PR TITLE
Add url to getImpactMetrics.ts

### DIFF
--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -657,6 +657,8 @@ components:
           type: string
         description:
           type: string
+        url:
+          type: string
         comments:
           type: array
           items:

--- a/src/app/api/common/impactMetrics/getImpactMetrics.ts
+++ b/src/app/api/common/impactMetrics/getImpactMetrics.ts
@@ -29,6 +29,7 @@ async function getImpactMetricsApi(roundId: string) {
       metric_id: impactMetric.metric_id,
       name: impactMetric.name,
       description: impactMetric.description,
+      url: impactMetric.url,
       allocations_per_project: impactMetric.metrics_projects.map((project) => {
         return {
           project_id: project.projects_data.project_id,
@@ -99,6 +100,7 @@ async function getImpactMetricApi(impactMetricId: string) {
     metric_id: impactMetric.metric_id,
     name: impactMetric.name,
     description: impactMetric.description,
+    url: impactMetric.url,
     allocations_per_project: impactMetric.metrics_projects.map((project) => {
       return {
         project_id: project.projects_data.project_id,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new `url` field to the `impactMetrics` object in the OpenAPI spec and the `getImpactMetrics.ts` file to include URLs for impact metrics.

### Detailed summary
- Added `url` field to `impactMetrics` object in OpenAPI spec.
- Updated `getImpactMetrics.ts` to include `url` field for impact metrics.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->