### PR TITLE
Add oss bool to default/mock project data

### DIFF
--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -735,6 +735,8 @@ components:
           type: string
         socialLinks:
           $ref: "#/components/schemas/SocialLinks"
+        oss:
+          type: boolean
         team:
           type: array
           items:

--- a/src/app/api/common/projects/getProjects.ts
+++ b/src/app/api/common/projects/getProjects.ts
@@ -84,6 +84,7 @@ async function getProjectsApi() {
     deployedContracts: defaultDeployedContracts,
     categories: defaultCategories,
     funding: defaultFunding,
+    oss: true,
   };
   return {
     metadata: pageMetadata,


### PR DESCRIPTION
This doesn't seem right.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new field `oss` of type boolean to `socialLinks` in `oas_v1.yaml` and sets `oss` to true in `getProjects.ts`.

### Detailed summary
- Added a `oss` field of type boolean to `socialLinks` in `oas_v1.yaml`
- Set `oss` to true in the `getProjects.ts` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->