### PR TITLE
[RetroFunding API] Fix: include is_os in the api response

### DIFF
--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -676,6 +676,8 @@ components:
                 type: string
               allocation:
                 type: number
+              is_os:
+                type: boolean
         views:
           type: integer
         added_to_ballot:

--- a/src/app/api/common/impactMetrics/getImpactMetrics.ts
+++ b/src/app/api/common/impactMetrics/getImpactMetrics.ts
@@ -36,6 +36,7 @@ async function getImpactMetricsApi(roundId: string) {
           name: project.projects_data.project_name,
           image: project.projects_data.project_image,
           allocation: project.allocation,
+          is_os: project.is_os,
         };
       }),
       comments: impactMetric.metrics_comments.map((comment) => {
@@ -107,6 +108,7 @@ async function getImpactMetricApi(impactMetricId: string) {
         name: project.projects_data.project_name,
         image: project.projects_data.project_image,
         allocation: project.allocation,
+        is_os: project.is_os,
       };
     }),
     comments: impactMetric.metrics_comments.map((comment) => {

--- a/src/app/info/page.tsx
+++ b/src/app/info/page.tsx
@@ -8,7 +8,7 @@ export async function generateMetadata({}) {
   const { title, description } = page.meta;
 
   const preview = `/api/images/og/proposals?title=${encodeURIComponent(
-    title,
+    title
   )}&description=${encodeURIComponent(description)}`;
 
   return {
@@ -32,7 +32,6 @@ export async function generateMetadata({}) {
 }
 
 export default async function Page() {
-
   const { ui } = Tenant.current();
   if (!ui.toggle("info")) {
     return <div>Route not supported for namespace</div>;
@@ -51,8 +50,7 @@ export default async function Page() {
                 Live – ETHFI token launch
               </div>
               <div>
-                <div
-                  className="w-[13px] h-[13px] rounded-full bg-indigo-800 relative -left-[31px] border-4 -top-4"></div>
+                <div className="w-[13px] h-[13px] rounded-full bg-indigo-800 relative -left-[31px] border-4 -top-4"></div>
                 On March 18th, we’re launching the $ETHFI token and taking the
                 first step towards full decentralization.
               </div>

--- a/src/components/Delegates/DelegateCard/DelegateActions.tsx
+++ b/src/components/Delegates/DelegateCard/DelegateActions.tsx
@@ -33,13 +33,14 @@ export function DelegateActions({
   const hasAlligator = contracts?.alligator;
 
   const isRetired = ui.delegates?.retired.includes(
-    delegate.address.toLowerCase(),
+    delegate.address.toLowerCase()
   );
 
   if (isRetired) {
     return (
       <div className="rounded-lg border border-gray-300 p-2 bg-gray-100 text-xs font-medium text-gray-700">
-        This voter has stepped down. If you are currently delegated to them, please select a new voter.
+        This voter has stepped down. If you are currently delegated to them,
+        please select a new voter.
       </div>
     );
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a new `is_os` field to the `allocation` object in `oas_v1.yaml`, update `getImpactMetrics.ts` and `DelegateActions.tsx`, and refactor `page.tsx`.

### Detailed summary
- Added `is_os` field to `allocation` object in `oas_v1.yaml`
- Updated `getImpactMetrics.ts` to include `is_os` field
- Updated `DelegateActions.tsx` for better UI display
- Refactored `page.tsx` by removing unnecessary code and improving readability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->