### PR TITLE
add proposals created count to voter stats

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -361,6 +361,7 @@ view OptimismVoterStats {
   for                BigInt?
   abstain            BigInt?
   against            BigInt?
+  proposals_proposed BigInt?
 
   @@map("voter_stats")
   @@schema("optimism")
@@ -641,6 +642,7 @@ view etherfiVoterStats {
   for                BigInt?
   abstain            BigInt?
   against            BigInt?
+  proposals_proposed BigInt?
 
   @@map("voter_stats")
   @@schema("etherfi")
@@ -814,6 +816,7 @@ view uniswapVoterStats {
   for                BigInt?
   abstain            BigInt?
   against            BigInt?
+  proposals_proposed BigInt?
 
   @@map("voter_stats")
   @@schema("uniswap")

--- a/src/app/api/common/delegates/delegate.d.ts
+++ b/src/app/api/common/delegates/delegate.d.ts
@@ -36,4 +36,5 @@ export type DelegateStats = {
   voting_power: OptimismVotingPower["voting_power"];
   advanced_vp: OptimismAdvancedVotingPower["advanced_vp"];
   num_of_delegators: OptimismDelegates["num_of_delegators"];
+  proposals_created: OptimismDelegates["proposals_created"];
 };

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -296,7 +296,7 @@ async function getDelegate(addressOrENSName: string): Promise<Delegate> {
       quorum && quorum > 0n
         ? Number((totalVotingPower * 10000n) / quorum) / 10000
         : 0,
-    proposalsCreated: 0n,
+    proposalsCreated: delegate?.proposals_created || 0n,
     proposalsVotedOn: delegate?.proposals_voted || 0n,
     votedFor: delegate?.for?.toString() || "0",
     votedAgainst: delegate?.against?.toString() || "0",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new field `proposals_created` to the `OptimismDelegates` type and updates usage across files for delegate proposals.

### Detailed summary
- Added `proposals_created` field to `OptimismDelegates` type
- Updated `proposalsCreated` logic in `getDelegates.ts`
- Added `proposals_proposed` field to `prisma/schema.prisma` for multiple schemas

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->