### PR TITLE
Fix comment delete for comments w/ votes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -164,7 +164,7 @@ model metrics_comments_votes {
   vote             Int
   created_at       DateTime         @default(now()) @db.Timestamptz(6)
   updated_at       DateTime         @default(now()) @db.Timestamptz(6)
-  metrics_comments metrics_comments @relation(fields: [comment_id], references: [comment_id], onDelete: NoAction, onUpdate: NoAction)
+  metrics_comments metrics_comments @relation(fields: [comment_id], references: [comment_id], onDelete: Cascade, onUpdate: NoAction)
 
   @@id([comment_id, voter])
   @@schema("retro_funding")

--- a/src/app/api/common/comments/deleteImpactMetricComment.ts
+++ b/src/app/api/common/comments/deleteImpactMetricComment.ts
@@ -6,13 +6,18 @@ async function deleteImpactMetricCommentApi({
 }: {
   commentId: number;
 }) {
+
+
+  const deletedVotes = await prisma.metrics_comments_votes.deleteMany({
+    where: {
+      comment_id: commentId
+    }
+  });
+
   const deletedComment = await prisma.metrics_comments.delete({
     where: {
       comment_id: commentId,
-    },
-    include: {
-      metrics_comments_votes: true,
-    },
+    }
   });
 
   return {

--- a/src/app/api/common/comments/deleteImpactMetricComment.ts
+++ b/src/app/api/common/comments/deleteImpactMetricComment.ts
@@ -6,18 +6,13 @@ async function deleteImpactMetricCommentApi({
 }: {
   commentId: number;
 }) {
-
-
-  const deletedVotes = await prisma.metrics_comments_votes.deleteMany({
-    where: {
-      comment_id: commentId
-    }
-  });
-
   const deletedComment = await prisma.metrics_comments.delete({
     where: {
       comment_id: commentId,
-    }
+    },
+    include: {
+      metrics_comments_votes: true,
+    },
   });
 
   return {

--- a/src/app/api/common/comments/deleteImpactMetricComment.ts
+++ b/src/app/api/common/comments/deleteImpactMetricComment.ts
@@ -7,47 +7,22 @@ async function deleteImpactMetricCommentApi({
   commentId: number;
 }) {
 
-  const votesExist = await prisma.metrics_comments_votes.findMany({
+
+  const deletedVotes = await prisma.metrics_comments_votes.deleteMany({
     where: {
-      comment_id: commentId,
-    },
-  });
-
-  // If related votes exist, delete them
-  if (votesExist.length > 0) {
-    await prisma.metrics_comments_votes.deleteMany({
-      where: {
-        comment_id: commentId,
-      },
-    });
-  }
-
-  // Check if the comment exists before attempting to delete it
-  const commentExists = await prisma.metrics_comments.findUnique({
-    where: {
-      comment_id: commentId,
-    },
-  });
-
-  if (commentExists) {
-    // Delete the record in the main table
-    const deletedComment = await prisma.metrics_comments.delete({
-      where: {
-        comment_id: commentId,
-      },
-    });
-
-    return {
-      comment_id: deletedComment.comment_id,
-    };
-  }
-
-  else {
-    return {
-      comment_id: -1,
+      comment_id: commentId
     }
-  }
+  });
 
+  const deletedComment = await prisma.metrics_comments.delete({
+    where: {
+      comment_id: commentId,
+    }
+  });
+
+  return {
+    comment_id: deletedComment.comment_id,
+  };
 }
 
 export const deleteImpactMetricComment = cache(deleteImpactMetricCommentApi);

--- a/src/app/api/common/comments/deleteImpactMetricComment.ts
+++ b/src/app/api/common/comments/deleteImpactMetricComment.ts
@@ -7,22 +7,47 @@ async function deleteImpactMetricCommentApi({
   commentId: number;
 }) {
 
-
-  const deletedVotes = await prisma.metrics_comments_votes.deleteMany({
-    where: {
-      comment_id: commentId
-    }
-  });
-
-  const deletedComment = await prisma.metrics_comments.delete({
+  const votesExist = await prisma.metrics_comments_votes.findMany({
     where: {
       comment_id: commentId,
-    }
+    },
   });
 
-  return {
-    comment_id: deletedComment.comment_id,
-  };
+  // If related votes exist, delete them
+  if (votesExist.length > 0) {
+    await prisma.metrics_comments_votes.deleteMany({
+      where: {
+        comment_id: commentId,
+      },
+    });
+  }
+
+  // Check if the comment exists before attempting to delete it
+  const commentExists = await prisma.metrics_comments.findUnique({
+    where: {
+      comment_id: commentId,
+    },
+  });
+
+  if (commentExists) {
+    // Delete the record in the main table
+    const deletedComment = await prisma.metrics_comments.delete({
+      where: {
+        comment_id: commentId,
+      },
+    });
+
+    return {
+      comment_id: deletedComment.comment_id,
+    };
+  }
+
+  else {
+    return {
+      comment_id: -1,
+    }
+  }
+
 }
 
 export const deleteImpactMetricComment = cache(deleteImpactMetricCommentApi);


### PR DESCRIPTION
This PR attempts two methods to fix the `DELETE` method for comments, with votes.

The 1st method is completely reverted, in favour of the relation-based `CASCADE` declared implicitly via the ORM-client and deployed redundantly via SQL (by hand).

### Testing

Creating fake comments w/ votes...

```
INSERT INTO retro_funding.metrics_comments (metric_id,address,"comment",created_at,updated_at) VALUES
	 ('gas_fees','0xf66CcEDcD3f99C234cefA713Ab7399F5DD3a6770','test','2024-06-08 01:45:58.170','2024-06-08 01:45:58.170');

	
INSERT INTO retro_funding.metrics_comments_votes (comment_id,voter,vote,created_at,updated_at) VALUES
	 (39,'0xf66CcEDcD3f99C234cefA713Ab7399F5DD3a6771',1,'2024-06-08 01:47:41.086','2024-06-08 01:56:23.781');
```

...then calling `http://localhost:3000/api/v1/retrofunding/rounds/4/impactMetrics/gas_fees/comments/39`

### Migration

The following was applied by hand...

```
ALTER TABLE retro_funding.metrics_comments_votes DROP CONSTRAINT metrics_comments_votes_comment_id_fkey 
ALTER TABLE retro_funding.metrics_comments_votes ADD CONSTRAINT metrics_comments_votes_comment_id_fkey FOREIGN KEY (comment_id) REFERENCES retro_funding.metrics_comments(comment_id) on delete CASCADE;
```



<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the database schema in `schema.prisma` to change the deletion behavior of `metrics_comments` relation from `NoAction` to `Cascade`.

### Detailed summary
- Updated deletion behavior of `metrics_comments` relation from `NoAction` to `Cascade`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->