### PR TITLE
dirty fix for getting the right number of delegators

### DIFF
--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -361,7 +361,7 @@ async function getDelegate(addressOrENSName: string): Promise<Delegate> {
     lastTenProps: delegate?.last_10_props?.toFixed() || "0",
     numOfDelegators:
       // Use cached amount when recalculation is expensive
-      cachedNumOfDelegators < 1000n
+      cachedNumOfDelegators < 1000n && namespace === "optimism"
         ? BigInt(
             (await numOfDelegatesQuery)?.[0]?.num_of_delegators.toString() ||
               "0"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on optimizing the `getDelegates` function by using a cached amount when the recalculation is expensive, but only if the namespace is "optimism".

### Detailed summary
- Added a condition to use cached amount only if namespace is "optimism"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->