### PR TITLE
[RetroFunding API] fix comments sort by votes_count

### DIFF
--- a/src/app/api/common/comments/getImpactMetricComments.ts
+++ b/src/app/api/common/comments/getImpactMetricComments.ts
@@ -26,7 +26,7 @@ async function getImpactMetricCommentsApi({
           return prisma.$queryRawUnsafe<ImpactMetrciCommentPayload[]>(
             `
           SELECT mc.*, 
-          SUM(mcv.vote) AS votes_count, 
+          COALESCE(SUM(mcv.vote),0) AS votes_count, 
           ARRAY_AGG(jsonb_build_object(
             'comment_id', mcv.comment_id,
             'voter', mcv.voter,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `getImpactMetricComments` function by ensuring a default value of 0 for `votes_count` and using `COALESCE`. 

### Detailed summary
- Updated SQL query to use `COALESCE` for `SUM` function
- Ensured `votes_count` has a default value of 0

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->