### PR TITLE
Undo Implicit Type Correction on `uniswapStakedDeposits`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -910,11 +910,11 @@ view uniswapProposalTypes {
 }
 
 view uniswapStakedDeposits {
-  deposit_id  String @unique
+  deposit_id  BigInt  @unique
   depositor   String
   beneficiary String
   delegatee   String
-  amount      String
+  amount      Decimal @db.Decimal
 
   @@map("staked_deposits")
   @@schema("uniswap")


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the data types in the `uniswapStakedDeposits` view in the Prisma schema to use `BigInt` for `deposit_id` and `Decimal` for `amount`.

### Detailed summary
- Changed `deposit_id` type from `String` to `BigInt`
- Changed `amount` type from `String` to `Decimal`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->