### PR TITLE
[RetroFunding API] Patch: wrap ballot response in array

### DIFF
--- a/src/app/api/common/ballots/getBallots.ts
+++ b/src/app/api/common/ballots/getBallots.ts
@@ -78,6 +78,8 @@ async function getBallotForAddress({
               ) THEN 'SUBMITTED'
               ELSE 'PENDING'
           END AS status,
+      b.created_at,
+      b.updated_at,
       os_only, 
       os_multiplier, 
       a.metric_id, 

--- a/src/app/api/common/ballots/getBallots.ts
+++ b/src/app/api/common/ballots/getBallots.ts
@@ -113,7 +113,7 @@ async function getBallotForAddress({
     };
   }
 
-  return calculateAllocations(ballot);
+  return [calculateAllocations(ballot)];
 }
 
 export const fetchBallots = cache(getBallotsApi);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to modify the `getBallotForAddress` function to return an array containing the result of `calculateAllocations` instead of a single object.

### Detailed summary
- Added `created_at` and `updated_at` fields to the query result
- Modified `getBallotForAddress` function to return an array containing the result of `calculateAllocations`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->