### PR TITLE
Add top delegate weights endpoint (`/analytics/top/delegates`)

### DIFF
--- a/src/app/api/analytics/top/delegates/route.ts
+++ b/src/app/api/analytics/top/delegates/route.ts
@@ -8,9 +8,7 @@ type AddressWeight = {
   weight: string;
 };
 
-
 async function getTopDelegateWeights() {
-
   const { contracts } = Tenant.current();
 
   const QRY = `WITH 
@@ -37,11 +35,10 @@ async function getTopDelegateWeights() {
 
   const result = await prisma.$queryRawUnsafe<AddressWeight[]>(QRY);
 
-  return {result};
+  return { result };
 }
 
 const fetchDelegateWeights = cache(getTopDelegateWeights);
-
 
 export async function GET(request: NextRequest) {
   // const authResponse = await authenticateApiUser(request);

--- a/src/app/api/analytics/top/delegates/route.ts
+++ b/src/app/api/analytics/top/delegates/route.ts
@@ -1,6 +1,7 @@
 import prisma from "@/app/lib/prisma";
 import Tenant from "@/lib/tenant/tenant";
 import { NextResponse, type NextRequest } from "next/server";
+import { authenticateApiUser } from "@/app/lib/auth/serverAuth";
 import { cache } from "react";
 
 type AddressWeight = {
@@ -41,11 +42,11 @@ async function getTopDelegateWeights() {
 const fetchDelegateWeights = cache(getTopDelegateWeights);
 
 export async function GET(request: NextRequest) {
-  // const authResponse = await authenticateApiUser(request);
+  const authResponse = await authenticateApiUser(request);
 
-  // if (!authResponse.authenticated) {
-  //  return new Response(authResponse.failReason, { status: 401 });
-  //}
+  if (!authResponse.authenticated) {
+   return new Response(authResponse.failReason, { status: 401 });
+  }
 
   try {
     const weights = await fetchDelegateWeights();

--- a/src/app/api/analytics/top/delegates/route.ts
+++ b/src/app/api/analytics/top/delegates/route.ts
@@ -1,0 +1,61 @@
+import prisma from "@/app/lib/prisma";
+import Tenant from "@/lib/tenant/tenant";
+import { NextResponse, type NextRequest } from "next/server";
+import { cache } from "react";
+
+type AddressWeight = {
+  address: string;
+  weight: string;
+};
+
+
+async function getTopDelegateWeights() {
+
+  const { contracts } = Tenant.current();
+
+  const QRY = `WITH 
+                
+                total_voting_power
+                AS (SELECT Sum(voting_power) tot
+                    FROM   uniswap.delegates
+                    WHERE  contract = '${contracts.token.address}'),
+                
+                weightings
+                AS (SELECT delegate,
+                            voting_power / (SELECT tot
+                                            FROM   total_voting_power) AS
+                            fraction_of_voting_power
+                    FROM   uniswap.delegates
+                    WHERE  direct_vp > 0
+                    ORDER  BY voting_power)
+
+                SELECT delegate AS address,
+                       round(fraction_of_voting_power * 100.0,3) AS weight
+                FROM   weightings
+                WHERE  fraction_of_voting_power > 0.01
+                ORDER  BY fraction_of_voting_power DESC; `;
+
+  const result = await prisma.$queryRawUnsafe<AddressWeight[]>(QRY);
+
+  return {result};
+}
+
+const fetchDelegateWeights = cache(getTopDelegateWeights);
+
+
+export async function GET(request: NextRequest) {
+  // const authResponse = await authenticateApiUser(request);
+
+  // if (!authResponse.authenticated) {
+  //  return new Response(authResponse.failReason, { status: 401 });
+  //}
+
+  try {
+    const weights = await fetchDelegateWeights();
+    return NextResponse.json(weights);
+  } catch (e: any) {
+    return new Response("Internal server error: " + e.toString(), {
+      status: 500,
+    });
+  }
+}

--- a/src/app/api/analytics/top/delegates/route.ts
+++ b/src/app/api/analytics/top/delegates/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest) {
   const authResponse = await authenticateApiUser(request);
 
   if (!authResponse.authenticated) {
-   return new Response(authResponse.failReason, { status: 401 });
+    return new Response(authResponse.failReason, { status: 401 });
   }
 
   try {


### PR DESCRIPTION
This PR adds an endpoint for exposing the top delegate weights

See `GET`  `/api/analytics/top/delegates`

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a route for fetching the top delegate weights in analytics.

### Detailed summary
- Added route for fetching delegate weights
- Implemented logic to calculate top delegate weights
- Integrated authentication for API user
- Caching delegate weights data for optimization

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->