### PR TITLE
Add DAO Engagement - Proposal Vote Counts (`/analytics/vote`)

### DIFF
--- a/src/app/api/analytics/vote/route.ts
+++ b/src/app/api/analytics/vote/route.ts
@@ -17,7 +17,7 @@ async function getProposalVoteCounts() {
                 FROM   alltenant.dao_engagement_votes
                 WHERE  tenant = '${namespace}'
                     GROUP  BY 1
-                    ORDER  BY 1`
+                    ORDER  BY 1`;
 
   const result = await prisma.$queryRawUnsafe<ProposalCount[]>(QRY);
 
@@ -27,7 +27,7 @@ async function getProposalVoteCounts() {
 const fetchProposalVoteCounts = cache(getProposalVoteCounts);
 
 export async function GET(request: NextRequest) {
-   const authResponse = await authenticateApiUser(request);
+  const authResponse = await authenticateApiUser(request);
 
   if (!authResponse.authenticated) {
     return new Response(authResponse.failReason, { status: 401 });

--- a/src/app/api/analytics/vote/route.ts
+++ b/src/app/api/analytics/vote/route.ts
@@ -27,11 +27,11 @@ async function getProposalVoteCounts() {
 const fetchProposalVoteCounts = cache(getProposalVoteCounts);
 
 export async function GET(request: NextRequest) {
-  // const authResponse = await authenticateApiUser(request);
+   const authResponse = await authenticateApiUser(request);
 
-  // if (!authResponse.authenticated) {
-  //  return new Response(authResponse.failReason, { status: 401 });
-  //}
+  if (!authResponse.authenticated) {
+    return new Response(authResponse.failReason, { status: 401 });
+  }
 
   try {
     const communityInfo = await fetchProposalVoteCounts();

--- a/src/app/api/analytics/vote/route.ts
+++ b/src/app/api/analytics/vote/route.ts
@@ -1,0 +1,44 @@
+import prisma from "@/app/lib/prisma";
+import Tenant from "@/lib/tenant/tenant";
+import { NextResponse, type NextRequest } from "next/server";
+import { authenticateApiUser } from "@/app/lib/auth/serverAuth";
+import { cache } from "react";
+
+type ProposalCount = {
+  proposalId: number;
+  votes: number;
+};
+
+async function getProposalVoteCounts() {
+  const { namespace } = Tenant.current();
+
+  const QRY = `SELECT proposal_id,
+                    SUM(vote_count) votes
+                FROM   alltenant.dao_engagement_votes
+                WHERE  tenant = '${namespace}'
+                    GROUP  BY 1
+                    ORDER  BY 1`
+
+  const result = await prisma.$queryRawUnsafe<ProposalCount[]>(QRY);
+
+  return { result };
+}
+
+const fetchProposalVoteCounts = cache(getProposalVoteCounts);
+
+export async function GET(request: NextRequest) {
+  // const authResponse = await authenticateApiUser(request);
+
+  // if (!authResponse.authenticated) {
+  //  return new Response(authResponse.failReason, { status: 401 });
+  //}
+
+  try {
+    const communityInfo = await fetchProposalVoteCounts();
+    return NextResponse.json(communityInfo);
+  } catch (e: any) {
+    return new Response("Internal server error: " + e.toString(), {
+      status: 500,
+    });
+  }
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to implement a route for fetching proposal vote counts from a database using Prisma and Next.js server-side APIs.

### Detailed summary
- Added route for fetching proposal vote counts
- Implemented Prisma query to retrieve vote counts
- Integrated authentication for API user
- Utilized caching for vote count retrieval
- Handled error responses for server-side errors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->