### PR TITLE
Upgrade `/analytics/metrics` endpoint to include Google Analytics V4 data

### DIFF
--- a/src/app/api/analytics/metric/[metric_id]/[frequency]/route.ts
+++ b/src/app/api/analytics/metric/[metric_id]/[frequency]/route.ts
@@ -9,13 +9,20 @@ type MetricValue = {
   day: string;
   date: string;
   ts: number;
-  value: number;
+  value: any;
 };
 
 async function getMetricTS(metricId: string, frequency: string) {
   const { namespace } = Tenant.current();
 
-  let availableMetrics = [
+  let availableGoogleMetrics = [
+    "activeUsers",
+    "averageSessionDuration",
+    "screenPageViews",
+    "bounceRate",
+  ];
+
+  let availableChainMetrics = [
     "total_votable_supply",
     "majority_threshold",
 
@@ -29,26 +36,42 @@ async function getMetricTS(metricId: string, frequency: string) {
     "fraction_of_large_active_delegates",
   ];
 
-  if (!availableMetrics.includes(metricId)) {
+  const isGoogleAnalyticMetric = availableGoogleMetrics.includes(metricId);
+  const isChainMetric = availableChainMetrics.includes(metricId);
+
+  let QRY: string;
+
+  if (isChainMetric) {
+    const { lookback, skipCrit } = frequencyToDateAndSQLcrit(
+      frequency,
+      "block_date"
+    );
+
+    QRY = `SELECT block_date AS day,
+                        TO_CHAR(block_date, 'YYYY-MM-DD') date,
+                        extract(epoch from block_date) as ts,
+                         value
+                  FROM   alltenant.dao_engagement_metrics
+                  WHERE  metric = '${metricId}'
+                     AND tenant = '${namespace}' 
+                     AND block_date >= (CURRENT_DATE - INTERVAL '${lookback} day')
+                     AND ${skipCrit}`;
+  } else if (isGoogleAnalyticMetric) {
+    const { lookback } = frequencyToDateAndSQLcrit(frequency, "date");
+
+    QRY = `SELECT date AS day,
+                        TO_CHAR(date, 'YYYY-MM-DD') date,
+                        extract(epoch from date) as ts,
+                         value
+                  FROM   google.analytics_${frequency}
+                  WHERE  metric_id = '${metricId}'
+                     AND tenant = '${namespace}' 
+                     AND date >= (CURRENT_DATE - INTERVAL '${lookback} day')`;
+  } else {
     throw new Error(
-      `Metric '${metricId}' not valid, expected one of '${availableMetrics.join(", ")}'`
+      `Metric '${metricId}' not valid, expected either a Google Analytics Metric ('${availableGoogleMetrics.join(", ")}) or Chain Metric ('${availableChainMetrics.join(", ")}')`
     );
   }
-
-  const { lookback, skipCrit } = frequencyToDateAndSQLcrit(
-    frequency,
-    "block_date"
-  );
-
-  const QRY = `SELECT block_date AS day,
-                      TO_CHAR(block_date, 'YYYY-MM-DD') date,
-                      extract(epoch from block_date) as ts,
-                       value
-                FROM   alltenant.dao_engagement_metrics
-                WHERE  metric = '${metricId}'
-                   AND tenant = '${namespace}' 
-                   AND block_date >= (CURRENT_DATE - INTERVAL '${lookback} day')
-                   AND ${skipCrit}`;
 
   const result = await prisma.$queryRawUnsafe<MetricValue[]>(QRY);
 

--- a/src/app/api/common/utils/frequencyHandling.ts
+++ b/src/app/api/common/utils/frequencyHandling.ts
@@ -1,0 +1,39 @@
+export function frequencyToDateAndSQLcrit(
+  frequency: string,
+  timeCol: string
+): {
+  lookback: number;
+  skipCrit: string;
+} {
+  const periodLowerCase = frequency.toLowerCase();
+
+  let lookback: number;
+  let skipCrit: string;
+
+  switch (periodLowerCase) {
+    case "24h":
+      lookback = 90;
+      skipCrit = "1=1";
+      break;
+    case "7d":
+      lookback = 180;
+      skipCrit = `extract(DOW from (${timeCol}) = extract(DOW from current_date)`;
+      break;
+    case "1m":
+      lookback = 365;
+      skipCrit = `extract(DAY from (${timeCol}) = 1`;
+      break;
+    case "3m":
+      lookback = 365;
+      skipCrit = `extract(DAY from ${timeCol}) = 1 AND mod(extract(MONTH from ${timeCol}), 3) = 0`;
+      break;
+    case "1y":
+      lookback = 365 * 2;
+      skipCrit = `extract(DAY from ${timeCol}) = 31 AND extract(MONTH from ${timeCol}) = 12`;
+      break;
+    default:
+      throw new Error("Invalid frequency value");
+  }
+
+  return { lookback, skipCrit };
+}


### PR DESCRIPTION
This PR upgrades the previously on-chain metrics, to now also expose Google Analytics.

Notice that we get numbers from GA4, but strings from On-chain.  The type has been updated to `any`.   Thats the only difference in the response.

I could see us needing to split these endpoints in the future.  I could do it now, instead of merging this, if there was a good reason to do it today.

The other peculiarity, is that `OnChain` metrics are just filtered daily metrics, while `GoogleAnalytics` is group-by using metric-specific group-by logic on the data side based on periodicity.  I could see one of these two methods prevailing in the long run, and we'll eventually deprecate the other.
 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor frequency handling functions, unify them, and update their usage in multiple routes.

### Detailed summary
- Added `frequencyToDateAndSQLcrit` function to handle frequency logic and SQL criteria generation.
- Updated `Token Balances` and `Metric` routes to use the new `frequencyToDateAndSQLcrit` function.
- Removed duplicate `frequencyToDates` function from routes.
- Improved error handling for invalid metrics in the `getMetricTS` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->