### PR TITLE
[RetroFunding API]: Improve ballots response

### DIFF
--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -951,6 +951,15 @@ components:
           enum:
             - PENDING
             - SUBMITTED
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        published_at:
+          type: string
+          format: date-time
         allocations:
           type: array
           items:

--- a/src/app/api/common/ballots/ballot.d.ts
+++ b/src/app/api/common/ballots/ballot.d.ts
@@ -7,6 +7,7 @@ export type Ballot = {
   os_multiplier: Ballots["os_multiplier"];
   updated_at: Ballots["updated_at"];
   created_at: Ballots["created_at"];
+  published_at: Date;
   allocations: Allocation[];
   allocation: number;
   status: "SUBMITTED" | "PENDING";
@@ -30,6 +31,7 @@ export type BallotResponse = {
   os_multiplier: number;
   updated_at: Date;
   created_at: Date;
+  published_at: Date;
   allocations: {
     metric_id: string;
     allocation: number;

--- a/src/app/api/common/ballots/ballot.d.ts
+++ b/src/app/api/common/ballots/ballot.d.ts
@@ -43,7 +43,7 @@ export type BallotResponse = {
     image: string;
     is_os: boolean;
     allocation: number;
-    allocation_per_metric: {
+    allocations_per_metric: {
       metric_id: string;
       allocation: number;
     }[];

--- a/src/app/api/common/ballots/ballotAllocations.ts
+++ b/src/app/api/common/ballots/ballotAllocations.ts
@@ -124,6 +124,7 @@ export function calculateAllocations(
     os_only: ballot[0].os_only,
     updated_at: ballot[0].updated_at,
     created_at: ballot[0].created_at,
+    published_at: ballot[0].published_at,
     allocations: ballot.map((b) => ({
       metric_id: b.metric_id,
       allocation: Number(b.allocation),

--- a/src/app/api/common/ballots/ballotAllocations.ts
+++ b/src/app/api/common/ballots/ballotAllocations.ts
@@ -82,7 +82,7 @@ export function calculateAllocations(
       name: data.name,
       image: data.image,
       is_os: data.is_os,
-      allocation_per_metric: data.allocations_per_metric,
+      allocations_per_metric: data.allocations_per_metric,
       allocation: data.allocations_per_metric.reduce(
         (acc, a) => acc + a.allocation,
         0
@@ -103,7 +103,7 @@ export function calculateAllocations(
     return {
       ...a,
       allocation: cappedAllocation * TOTAL_FUNDING,
-      allocations_per_metric: a.allocation_per_metric.map((apm) => {
+      allocations_per_metric: a.allocations_per_metric.map((apm) => {
         return {
           ...apm,
           allocation:

--- a/src/app/api/common/ballots/getBallots.ts
+++ b/src/app/api/common/ballots/getBallots.ts
@@ -29,6 +29,11 @@ async function getBallotsApi({
             ) THEN 'SUBMITTED'
             ELSE 'PENDING'
           END AS status,
+          (
+            SELECT updated_at
+            FROM retro_funding.ballot_submittions bs 
+            WHERE bs.address = b.address AND bs.round = b.round
+          ) as published_at,
           COALESCE(
             (SELECT json_agg(a.* ORDER BY a.allocation DESC) 
             FROM retro_funding.allocations a 

--- a/src/app/api/common/ballots/getBallots.ts
+++ b/src/app/api/common/ballots/getBallots.ts
@@ -80,6 +80,11 @@ async function getBallotForAddress({
           END AS status,
       b.created_at,
       b.updated_at,
+      (
+        SELECT updated_at
+        FROM retro_funding.ballot_submittions bs 
+        WHERE bs.address = b.address AND bs.round = b.round
+      ) as published_at,
       os_only, 
       os_multiplier, 
       a.metric_id, 

--- a/src/app/api/common/ballots/getBallots.ts
+++ b/src/app/api/common/ballots/getBallots.ts
@@ -5,7 +5,6 @@ import { Ballots } from "@prisma/client";
 import { Ballot } from "./ballot";
 import prisma from "@/app/lib/prisma";
 import { calculateAllocations } from "./ballotAllocations";
-import { time_this_sync } from "@/app/lib/logging";
 
 async function getBallotsApi({
   roundId,
@@ -126,11 +125,7 @@ async function getBallotForAddress({
     };
   }
 
-  return [
-    time_this_sync(() => calculateAllocations(ballot), {
-      "Algorythm: ": "calculateAllocations",
-    }),
-  ];
+  return [calculateAllocations(ballot)];
 }
 
 export const fetchBallots = cache(getBallotsApi);

--- a/src/app/api/common/ballots/getBallots.ts
+++ b/src/app/api/common/ballots/getBallots.ts
@@ -5,6 +5,7 @@ import { Ballots } from "@prisma/client";
 import { Ballot } from "./ballot";
 import prisma from "@/app/lib/prisma";
 import { calculateAllocations } from "./ballotAllocations";
+import { time_this_sync } from "@/app/lib/logging";
 
 async function getBallotsApi({
   roundId,
@@ -125,7 +126,11 @@ async function getBallotForAddress({
     };
   }
 
-  return [calculateAllocations(ballot)];
+  return [
+    time_this_sync(() => calculateAllocations(ballot), {
+      "Algorythm: ": "calculateAllocations",
+    }),
+  ];
 }
 
 export const fetchBallots = cache(getBallotsApi);

--- a/src/app/api/common/ballots/updateBallot.ts
+++ b/src/app/api/common/ballots/updateBallot.ts
@@ -2,7 +2,6 @@ import { cache } from "react";
 import { addressOrEnsNameWrap } from "../utils/ensName";
 import prisma from "@/app/lib/prisma";
 import { fetchBallot } from "./getBallots";
-import { time_this } from "@/app/lib/logging";
 
 type BallotContent = {
   metric_id: string;
@@ -94,31 +93,27 @@ async function updateBallotMetricForAddress({
     [100, 0]
   );
 
-  await time_this(
-    async () =>
-      await Promise.all(
-        allocations.map(async (allocation) => {
-          if (!allocation.locked && allocation.metric_id !== data.metric_id) {
-            await prisma.allocations.update({
-              where: {
-                address_round_metric_id: {
-                  metric_id: allocation.metric_id,
-                  round: roundId,
-                  address,
-                },
-              },
-              data: {
-                ...allocation,
-                allocation: totalUnlocked
-                  ? (Number(allocation.allocation.toFixed(2)) / totalUnlocked) *
-                    amountToBalance
-                  : 0,
-              },
-            });
-          }
-        })
-      ),
-    { Queries: "Autorebalance all other allocations" }
+  await Promise.all(
+    allocations.map(async (allocation) => {
+      if (!allocation.locked && allocation.metric_id !== data.metric_id) {
+        await prisma.allocations.update({
+          where: {
+            address_round_metric_id: {
+              metric_id: allocation.metric_id,
+              round: roundId,
+              address,
+            },
+          },
+          data: {
+            ...allocation,
+            allocation: totalUnlocked
+              ? (Number(allocation.allocation.toFixed(2)) / totalUnlocked) *
+                amountToBalance
+              : 0,
+          },
+        });
+      }
+    })
   );
 
   // Return full ballot


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `published_at` field in the `Ballot` object and updates related functions to handle it.

### Detailed summary
- Added `published_at` field to `Ballot` object
- Updated SQL query to fetch `published_at` for ballots
- Updated `BallotResponse` type to include `published_at`
- Renamed `allocation_per_metric` to `allocations_per_metric`
- Updated functions to handle `published_at` field in `Ballot` object

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->