### PR TITLE
[RetroFunding API]: Badgeholder restrictions

### DIFF
--- a/src/app/api/common/ballots/submitBallot.ts
+++ b/src/app/api/common/ballots/submitBallot.ts
@@ -31,8 +31,6 @@ async function submitBallotForAddress({
     signature: data.signature as `0x${string}`,
   });
 
-  // TODO: Validate ballot content
-
   if (!isSignatureValid) {
     throw new Error("Invalid signature");
   }

--- a/src/app/api/common/citizens/isCitizen.ts
+++ b/src/app/api/common/citizens/isCitizen.ts
@@ -2,11 +2,15 @@ import { Prisma } from "@prisma/client";
 import { cache } from "react";
 import prisma from "@/app/lib/prisma";
 import Tenant from "@/lib/tenant/tenant";
+import { addressOrEnsNameWrap } from "../utils/ensName";
 
-async function isCitizen(address: string) {
+const isCitizen = async (addressOrEnsName: string) =>
+  addressOrEnsNameWrap(isCitizenForAddress, addressOrEnsName);
+
+async function isCitizenForAddress({ address }: { address: string }) {
   const { slug } = Tenant.current();
 
-  return prisma.$queryRaw<
+  const citizen = await prisma.$queryRaw<
     {
       address: string;
     }[]
@@ -19,6 +23,8 @@ async function isCitizen(address: string) {
     AND LOWER(address) = LOWER(${address});
     `
   );
+
+  return citizen.length > 0;
 }
 
 export const fetchIsCitizen = cache(isCitizen);

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -254,7 +254,7 @@ async function getDelegates({
     delegates: delegates.map((delegate, index) => ({
       address: delegate.delegate,
       votingPower: delegate.voting_power?.toFixed(0),
-      citizen: _delegates[index].citizen.length > 0,
+      citizen: _delegates[index].citizen,
       statement: _delegates[index].statement,
     })),
     seed,
@@ -343,7 +343,7 @@ async function getDelegate(addressOrENSName: string): Promise<Delegate> {
   // Build out delegate JSON response
   return {
     address: address,
-    citizen: _isCitizen.length > 0,
+    citizen: _isCitizen,
     votingPower: totalVotingPower.toString(),
     votingPowerRelativeToVotableSupply: Number(
       totalVotingPower / BigInt(votableSupply || 0)

--- a/src/app/api/common/impactMetrics/getImpactMetrics.ts
+++ b/src/app/api/common/impactMetrics/getImpactMetrics.ts
@@ -40,7 +40,7 @@ async function getImpactMetricsApi(roundId: string) {
       m.name, 
       m.description, 
       m.url,
-      (
+      COALESCE((
         SELECT json_agg(
           json_build_object(
             'project_id', p.project_id,
@@ -53,8 +53,8 @@ async function getImpactMetricsApi(roundId: string) {
         FROM retro_funding.metrics_projects mp
         JOIN retro_funding.projects_data p ON mp.project_id = p.project_id
         WHERE mp.metric_id = m.metric_id
-      ) AS allocations_per_project,
-      (
+      ), '[]'::json) AS allocations_per_project,
+      COALESCE((
         SELECT json_agg(
           json_build_object(
             'comment_id', c.comment_id,
@@ -65,7 +65,7 @@ async function getImpactMetricsApi(roundId: string) {
             'votes_count', COALESCE(
               (SELECT SUM(v.vote) FROM retro_funding.metrics_comments_votes v WHERE v.comment_id = c.comment_id), 0
             ),
-            'votes', (
+            'votes', COALESCE((
               SELECT json_agg(
                 json_build_object(
                   'comment_id', v.comment_id,
@@ -75,12 +75,12 @@ async function getImpactMetricsApi(roundId: string) {
                   'updated_at', v.updated_at
                 )
               ) FROM retro_funding.metrics_comments_votes v WHERE v.comment_id = c.comment_id
-            )
+            ), '[]'::json)
           ) ORDER BY c.updated_at DESC
         )
         FROM retro_funding.metrics_comments c
         WHERE c.metric_id = m.metric_id
-      ) AS comments,
+      ),'[]'::json) AS comments,
       (
         SELECT COUNT(*)::int
         FROM (
@@ -146,7 +146,7 @@ async function getImpactMetricApi(impactMetricId: string, roundId: string) {
       m.name, 
       m.description, 
       m.url,
-      (
+      COALESCE((
         SELECT json_agg(
           json_build_object(
             'project_id', p.project_id,
@@ -159,8 +159,8 @@ async function getImpactMetricApi(impactMetricId: string, roundId: string) {
         FROM retro_funding.metrics_projects mp
         JOIN retro_funding.projects_data p ON mp.project_id = p.project_id
         WHERE mp.metric_id = m.metric_id
-      ) AS allocations_per_project,
-      (
+      ), '[]'::json) AS allocations_per_project,
+      COALESCE((
         SELECT json_agg(
           json_build_object(
             'comment_id', c.comment_id,
@@ -171,7 +171,7 @@ async function getImpactMetricApi(impactMetricId: string, roundId: string) {
             'votes_count', COALESCE(
               (SELECT SUM(v.vote) FROM retro_funding.metrics_comments_votes v WHERE v.comment_id = c.comment_id), 0
             ),
-            'votes', (
+            'votes', COALESCE((
               SELECT json_agg(
                 json_build_object(
                   'comment_id', v.comment_id,
@@ -181,12 +181,12 @@ async function getImpactMetricApi(impactMetricId: string, roundId: string) {
                   'updated_at', v.updated_at
                 )
               ) FROM retro_funding.metrics_comments_votes v WHERE v.comment_id = c.comment_id
-            )
+            ), '[]'::json)
           ) ORDER BY c.updated_at DESC
         )
         FROM retro_funding.metrics_comments c
         WHERE c.metric_id = m.metric_id
-      ) AS comments,
+      ),'[]'::json) AS comments,
       (
         SELECT COUNT(*)::int
         FROM (

--- a/src/app/api/common/impactMetrics/getImpactMetrics.ts
+++ b/src/app/api/common/impactMetrics/getImpactMetrics.ts
@@ -107,75 +107,112 @@ async function getImpactMetricsApi(roundId: string) {
   return impactMetrics;
 }
 
-async function getImpactMetricApi(impactMetricId: string) {
-  const impactMetric = await prisma.metrics_data.findFirst({
-    where: {
-      metric_id: impactMetricId,
-    },
-    include: {
-      metrics_comments: {
-        include: {
-          metrics_comments_votes: true,
-        },
-        orderBy: {
-          updated_at: "desc",
-        },
-      },
-      metrics_projects: {
-        orderBy: {
-          allocation: "desc",
-        },
-        include: {
-          projects_data: true,
-        },
-      },
-      metrics_views: true,
-    },
-  });
+async function getImpactMetricApi(impactMetricId: string, roundId: string) {
+  const impactMetric = await prisma.$queryRawUnsafe<
+    {
+      metric_id: number;
+      name: string;
+      description: string;
+      url: string;
+      allocations_per_project: {
+        project_id: number;
+        name: string;
+        image: string;
+        allocation: string;
+        is_os: boolean;
+      }[];
+      comments: {
+        comment_id: number;
+        comment: string;
+        address: string;
+        created_at: Date;
+        updated_at: Date;
+        votes_count: number;
+        votes: {
+          comment_id: number;
+          address: string;
+          vote: number;
+          created_at: Date;
+          updated_at: Date;
+        }[];
+      }[];
+      views: number;
+      added_to_ballot: number;
+    }[]
+  >(
+    `
+    SELECT 
+      m.metric_id, 
+      m.name, 
+      m.description, 
+      m.url,
+      (
+        SELECT json_agg(
+          json_build_object(
+            'project_id', p.project_id,
+            'name', p.project_name,
+            'image', p.project_image,
+            'allocation', mp.allocation::text,
+            'is_os', mp.is_os
+          ) ORDER BY mp.allocation DESC
+        )
+        FROM retro_funding.metrics_projects mp
+        JOIN retro_funding.projects_data p ON mp.project_id = p.project_id
+        WHERE mp.metric_id = m.metric_id
+      ) AS allocations_per_project,
+      (
+        SELECT json_agg(
+          json_build_object(
+            'comment_id', c.comment_id,
+            'comment', c.comment,
+            'address', c.address,
+            'created_at', c.created_at,
+            'updated_at', c.updated_at,
+            'votes_count', COALESCE(
+              (SELECT SUM(v.vote) FROM retro_funding.metrics_comments_votes v WHERE v.comment_id = c.comment_id), 0
+            ),
+            'votes', (
+              SELECT json_agg(
+                json_build_object(
+                  'comment_id', v.comment_id,
+                  'address', v.voter,
+                  'vote', v.vote,
+                  'created_at', v.created_at,
+                  'updated_at', v.updated_at
+                )
+              ) FROM retro_funding.metrics_comments_votes v WHERE v.comment_id = c.comment_id
+            )
+          ) ORDER BY c.updated_at DESC
+        )
+        FROM retro_funding.metrics_comments c
+        WHERE c.metric_id = m.metric_id
+      ) AS comments,
+      (
+        SELECT COUNT(*)::int
+        FROM (
+          SELECT v.address as v, b.address as b
+          FROM retro_funding.metrics_views v
+          LEFT JOIN agora.citizens b ON LOWER(v.address) = LOWER(b.address)
+          WHERE v.metric_id = m.metric_id AND b.retro_funding_round = $1
+        ) as views WHERE views.b IS NOT NULL
+      ) AS views,
+      (
+        SELECT COUNT(*)::int
+        FROM (
+          SELECT a.address as a, b.address as b
+          FROM retro_funding.allocations a
+          LEFT JOIN agora.citizens b ON LOWER(a.address) = LOWER(b.address)
+          WHERE a.metric_id = m.metric_id AND a.round = $1::numeric AND b.retro_funding_round = $1
+        ) as added_to_ballot WHERE added_to_ballot.b IS NOT NULL
+      ) AS added_to_ballot
+    FROM retro_funding.metrics_data m
+    WHERE m.metric_id = $2;
+    `,
+    roundId,
+    impactMetricId
+  );
 
-  if (!impactMetric) {
-    return null;
-  }
-
-  return {
-    metric_id: impactMetric.metric_id,
-    name: impactMetric.name,
-    description: impactMetric.description,
-    url: impactMetric.url,
-    allocations_per_project: impactMetric.metrics_projects.map((project) => {
-      return {
-        project_id: project.projects_data.project_id,
-        name: project.projects_data.project_name,
-        image: project.projects_data.project_image,
-        allocation: project.allocation,
-        is_os: project.is_os,
-      };
-    }),
-    comments: impactMetric.metrics_comments.map((comment) => {
-      return {
-        comment_id: comment.comment_id,
-        comment: comment.comment,
-        address: comment.address,
-        created_at: comment.created_at,
-        updated_at: comment.updated_at,
-        votes_count: comment.metrics_comments_votes.reduce(
-          (acc, vote) => acc + vote.vote,
-          0
-        ),
-        votes: comment.metrics_comments_votes.map((vote) => {
-          return {
-            comment_id: vote.comment_id,
-            address: vote.voter,
-            vote: vote.vote,
-            created_at: vote.created_at,
-            updated_at: vote.updated_at,
-          };
-        }),
-      };
-    }),
-    views: impactMetric.metrics_views.length,
-    added_to_ballot: 0,
-  };
+  return impactMetric[0] || null;
 }
 
 export const fetchImpactMetricsApi = cache(getImpactMetricsApi);

--- a/src/app/api/common/impactMetrics/getImpactMetrics.ts
+++ b/src/app/api/common/impactMetrics/getImpactMetrics.ts
@@ -2,69 +2,109 @@ import { cache } from "react";
 import prisma from "@/app/lib/prisma";
 
 async function getImpactMetricsApi(roundId: string) {
-  const impactMetrics = await prisma.metrics_data.findMany({
-    include: {
-      metrics_comments: {
-        include: {
-          metrics_comments_votes: true,
-        },
-        orderBy: {
-          updated_at: "desc",
-        },
-      },
-      metrics_projects: {
-        orderBy: {
-          allocation: "desc",
-        },
-        include: {
-          projects_data: true,
-        },
-      },
-      metrics_views: true,
-    },
-  });
+  const impactMetrics = await prisma.$queryRawUnsafe<
+    {
+      metric_id: number;
+      name: string;
+      description: string;
+      url: string;
+      allocations_per_project: {
+        project_id: number;
+        name: string;
+        image: string;
+        allocation: string;
+        is_os: boolean;
+      }[];
+      comments: {
+        comment_id: number;
+        comment: string;
+        address: string;
+        created_at: Date;
+        updated_at: Date;
+        votes_count: number;
+        votes: {
+          comment_id: number;
+          address: string;
+          vote: number;
+          created_at: Date;
+          updated_at: Date;
+        }[];
+      }[];
+      views: number;
+      added_to_ballot: number;
+    }[]
+  >(
+    `
+    SELECT 
+      m.metric_id, 
+      m.name, 
+      m.description, 
+      m.url,
+      (
+        SELECT json_agg(
+          json_build_object(
+            'project_id', p.project_id,
+            'name', p.project_name,
+            'image', p.project_image,
+            'allocation', mp.allocation::text,
+            'is_os', mp.is_os
+          ) ORDER BY mp.allocation DESC
+        )
+        FROM retro_funding.metrics_projects mp
+        JOIN retro_funding.projects_data p ON mp.project_id = p.project_id
+        WHERE mp.metric_id = m.metric_id
+      ) AS allocations_per_project,
+      (
+        SELECT json_agg(
+          json_build_object(
+            'comment_id', c.comment_id,
+            'comment', c.comment,
+            'address', c.address,
+            'created_at', c.created_at,
+            'updated_at', c.updated_at,
+            'votes_count', COALESCE(
+              (SELECT SUM(v.vote) FROM retro_funding.metrics_comments_votes v WHERE v.comment_id = c.comment_id), 0
+            ),
+            'votes', (
+              SELECT json_agg(
+                json_build_object(
+                  'comment_id', v.comment_id,
+                  'address', v.voter,
+                  'vote', v.vote,
+                  'created_at', v.created_at,
+                  'updated_at', v.updated_at
+                )
+              ) FROM retro_funding.metrics_comments_votes v WHERE v.comment_id = c.comment_id
+            )
+          ) ORDER BY c.updated_at DESC
+        )
+        FROM retro_funding.metrics_comments c
+        WHERE c.metric_id = m.metric_id
+      ) AS comments,
+      (
+        SELECT COUNT(*)::int
+        FROM (
+          SELECT v.address as v, b.address as b
+          FROM retro_funding.metrics_views v
+          LEFT JOIN agora.citizens b ON LOWER(v.address) = LOWER(b.address)
+          WHERE v.metric_id = m.metric_id AND b.retro_funding_round = $1
+        ) as views WHERE views.b IS NOT NULL
+      ) AS views,
+      (
+        SELECT COUNT(*)::int
+        FROM (
+          SELECT a.address as a, b.address as b
+          FROM retro_funding.allocations a
+          LEFT JOIN agora.citizens b ON LOWER(a.address) = LOWER(b.address)
+          WHERE a.metric_id = m.metric_id AND a.round = $1::numeric AND b.retro_funding_round = $1
+        ) as added_to_ballot WHERE added_to_ballot.b IS NOT NULL
+      ) AS added_to_ballot
+    FROM retro_funding.metrics_data m;
+    `,
+    roundId
+  );
 
-  return impactMetrics.map((impactMetric) => {
-    return {
-      metric_id: impactMetric.metric_id,
-      name: impactMetric.name,
-      description: impactMetric.description,
-      url: impactMetric.url,
-      allocations_per_project: impactMetric.metrics_projects.map((project) => {
-        return {
-          project_id: project.projects_data.project_id,
-          name: project.projects_data.project_name,
-          image: project.projects_data.project_image,
-          allocation: project.allocation,
-          is_os: project.is_os,
-        };
-      }),
-      comments: impactMetric.metrics_comments.map((comment) => {
-        return {
-          comment_id: comment.comment_id,
-          comment: comment.comment,
-          address: comment.address,
-          created_at: comment.created_at,
-          updated_at: comment.updated_at,
-          votes_count: comment.metrics_comments_votes.reduce(
-            (acc, vote) => acc + vote.vote,
-            0
-          ),
-          votes: comment.metrics_comments_votes.map((vote) => {
-            return {
-              comment_id: vote.comment_id,
-              address: vote.voter,
-              vote: vote.vote,
-              created_at: vote.created_at,
-              updated_at: vote.updated_at,
-            };
-          }),
-        };
-      }),
-      views: impactMetric.metrics_views.length,
-      added_to_ballot: 0,
-    };
-  });
+  return impactMetrics;
 }
 
 async function getImpactMetricApi(impactMetricId: string) {

--- a/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
@@ -21,13 +21,11 @@ export async function POST(
   request: NextRequest,
   route: { params: { roundId: string; ballotCasterAddressOrEns: string } }
 ) {
-  const isBadgeholderCheck = await fetchIsCitizen(
+  const isBadgeholder = await fetchIsCitizen(
     route.params.ballotCasterAddressOrEns
   );
 
-  console.log("isBadgeholderCheck", isBadgeholderCheck);
-
-  if (isBadgeholderCheck.length === 0) {
+  if (!isBadgeholder) {
     return new Response("Only badgeholder can submit a ballot", {
       status: 401,
     });

--- a/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { authenticateApiUser } from "@/app/lib/auth/serverAuth";
 import { traceWithUserId } from "@/app/api/v1/apiUtils";
 import { submitBallot } from "@/app/api/common/ballots/submitBallot";
 import { z } from "zod";
+import { fetchIsCitizen } from "@/app/api/common/citizens/isCitizen";
 
 const ballotContentSchema = z.object({
   allocations: z.array(z.record(z.string(), z.number())),
@@ -21,28 +21,37 @@ export async function POST(
   request: NextRequest,
   route: { params: { roundId: string; ballotCasterAddressOrEns: string } }
 ) {
-  const authResponse = await authenticateApiUser(request);
+  const isBadgeholderCheck = await fetchIsCitizen(
+    route.params.ballotCasterAddressOrEns
+  );
 
-  if (!authResponse.authenticated) {
-    return new Response(authResponse.failReason, { status: 401 });
+  console.log("isBadgeholderCheck", isBadgeholderCheck);
+
+  if (isBadgeholderCheck.length === 0) {
+    return new Response("Only badgeholder can submit a ballot", {
+      status: 401,
+    });
   }
 
-  return await traceWithUserId(authResponse.userId as string, async () => {
-    const { roundId, ballotCasterAddressOrEns } = route.params;
-    try {
-      const payload = await request.json();
-      const parsedPayload = ballotSubmissionSchema.parse(payload);
+  return await traceWithUserId(
+    route.params.ballotCasterAddressOrEns as string,
+    async () => {
+      const { roundId, ballotCasterAddressOrEns } = route.params;
+      try {
+        const payload = await request.json();
+        const parsedPayload = ballotSubmissionSchema.parse(payload);
 
-      const ballot = await submitBallot(
-        parsedPayload,
-        Number(roundId),
-        ballotCasterAddressOrEns
-      );
-      return NextResponse.json(ballot);
-    } catch (e: any) {
-      return new Response("Internal server error: " + e.toString(), {
-        status: 500,
-      });
+        const ballot = await submitBallot(
+          parsedPayload,
+          Number(roundId),
+          ballotCasterAddressOrEns
+        );
+        return NextResponse.json(ballot);
+      } catch (e: any) {
+        return new Response("Internal server error: " + e.toString(), {
+          status: 500,
+        });
+      }
     }
-  });
+  );
 }

--- a/src/app/api/v1/retrofunding/rounds/[roundId]/impactMetrics/[impactMetricId]/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/impactMetrics/[impactMetricId]/route.ts
@@ -24,7 +24,7 @@ export async function GET(
     try {
       const { roundId, ballotCasterAddressOrEns, impactMetricId } =
         route.params;
-      const impactMetrics = await fetchImpactMetricApi(impactMetricId);
+      const impactMetrics = await fetchImpactMetricApi(impactMetricId, roundId);
       return NextResponse.json(impactMetrics);
     } catch (e: any) {
       return new Response("Internal server error: " + e.toString(), {

--- a/src/app/lib/auth/serverAuth.ts
+++ b/src/app/lib/auth/serverAuth.ts
@@ -126,7 +126,7 @@ export async function getRolesForUser(
 ): Promise<string[]> {
   const defaultRoles = [ROLE_PUBLIC_READER];
   if (siweData) {
-    const isBadge = (await fetchIsCitizen(siweData.address)).length > 0;
+    const isBadge = await fetchIsCitizen(siweData.address);
     return isBadge ? [ROLE_BADGEHOLDER, ...defaultRoles] : defaultRoles;
   }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update functions related to impact metrics, delegates, and citizens. It includes changes in fetching impact metrics, validating citizens, and submitting ballots.

### Detailed summary
- Updated `getImpactMetricsApi` to fetch more detailed impact metrics.
- Refactored `isCitizen` to support address or ENS name.
- Modified `submitBallot` to check if the user is a badgeholder before submitting.
- Improved `getDelegate` and `getDelegates` functions to handle citizen validation.
- Updated `fetchIsCitizen` to support address or ENS name validation.

> The following files were skipped due to too many changes: `src/app/api/common/impactMetrics/getImpactMetrics.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->