### PR TITLE
[RetroFunding API] Patch: convert added_to_ballot count to % of badgeholders

### DIFF
--- a/src/app/api/common/impactMetrics/getImpactMetrics.ts
+++ b/src/app/api/common/impactMetrics/getImpactMetrics.ts
@@ -91,7 +91,7 @@ async function getImpactMetricsApi(roundId: string) {
         ) as views WHERE views.b IS NOT NULL
       ) AS views,
       (
-        SELECT COUNT(*)::int
+        SELECT ROUND((COUNT(*)::numeric / (SELECT COUNT(*)::int FROM agora.citizens WHERE retro_funding_round = $1) * 100)::numeric, 2)::float
         FROM (
           SELECT a.address as a, b.address as b
           FROM retro_funding.allocations a
@@ -197,7 +197,7 @@ async function getImpactMetricApi(impactMetricId: string, roundId: string) {
         ) as views WHERE views.b IS NOT NULL
       ) AS views,
       (
-        SELECT COUNT(*)::int
+        SELECT ROUND((COUNT(*)::numeric / (SELECT COUNT(*)::int FROM agora.citizens WHERE retro_funding_round = $1) * 100)::numeric, 2)::float
         FROM (
           SELECT a.address as a, b.address as b
           FROM retro_funding.allocations a


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the calculation of impact metrics percentage in `getImpactMetrics.ts`.

### Detailed summary
- Updated the calculation of impact metrics percentage to include rounding to 2 decimal places.
- Modified the SQL query to calculate the percentage based on the total count of citizens in a specific funding round.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->