### PR TITLE
Cap delegate list to 10

### DIFF
--- a/src/app/api/analytics/top/delegates/route.ts
+++ b/src/app/api/analytics/top/delegates/route.ts
@@ -31,8 +31,8 @@ async function getTopDelegateWeights() {
                 SELECT delegate AS address,
                        round(fraction_of_voting_power * 100.0,3) AS weight
                 FROM   weightings
-                WHERE  fraction_of_voting_power > 0.01
-                ORDER  BY fraction_of_voting_power DESC; `;
+                ORDER  BY fraction_of_voting_power DESC
+                LIMIT 10; `;
 
   const result = await prisma.$queryRawUnsafe<AddressWeight[]>(QRY);
 


### PR DESCRIPTION
Need to test locally... on it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the SQL query in `route.ts` to include a `LIMIT 10` clause for fetching the top delegates based on their weight.

### Detailed summary
- Updated SQL query to include `LIMIT 10` for fetching top delegates.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->