### PR TITLE
[RetroFunding API] sort allocations_per_metric by allocation desc

### DIFF
--- a/src/app/api/common/ballots/ballotAllocations.ts
+++ b/src/app/api/common/ballots/ballotAllocations.ts
@@ -103,16 +103,18 @@ export function calculateAllocations(
     return {
       ...a,
       allocation: cappedAllocation * TOTAL_FUNDING,
-      allocations_per_metric: a.allocations_per_metric.map((apm) => {
-        return {
-          ...apm,
-          allocation:
-            Math.round(
-              (100 * (TOTAL_FUNDING * (apm.allocation * cappedAllocation))) /
-                a.allocation
-            ) / 100, // prevent floating point errors
-        };
-      }),
+      allocations_per_metric: a.allocations_per_metric
+        .map((apm) => {
+          return {
+            ...apm,
+            allocation:
+              Math.round(
+                (100 * (TOTAL_FUNDING * (apm.allocation * cappedAllocation))) /
+                  a.allocation
+              ) / 100, // prevent floating point errors
+          };
+        })
+        .sort((a, b) => b.allocation - a.allocation),
     };
   });
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to sort `allocations_per_metric` array in `ballotAllocations.ts` in descending order based on `allocation`.

### Detailed summary
- Sorts `allocations_per_metric` array by `allocation` in descending order.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->