### PR TITLE
Add latest to set of options available for `/balances` and `/analytics/metric`

### DIFF
--- a/src/app/api/analytics/metric/[metric_id]/[frequency]/route.ts
+++ b/src/app/api/analytics/metric/[metric_id]/[frequency]/route.ts
@@ -12,8 +12,17 @@ type MetricValue = {
   value: any;
 };
 
-async function getMetricTS(metricId: string, frequency: string) {
+async function getMetricTS(
+  metricId: string,
+  frequency: string
+): Promise<{ result: MetricValue[] }> {
   const { namespace } = Tenant.current();
+
+  if (frequency == "latest") {
+    const { result } = await getMetricTS(metricId, "24h");
+    const lastObject = result[result.length - 1];
+    return { result: [lastObject] };
+  }
 
   let availableGoogleMetrics = [
     "activeUsers",
@@ -73,9 +82,9 @@ async function getMetricTS(metricId: string, frequency: string) {
     );
   }
 
-  const result = await prisma.$queryRawUnsafe<MetricValue[]>(QRY);
+  const data: MetricValue[] = await prisma.$queryRawUnsafe<MetricValue[]>(QRY);
 
-  return { result };
+  return { result: data };
 }
 
 const fetchMetricTS = cache(getMetricTS);

--- a/src/app/api/balances/[frequency]/route.ts
+++ b/src/app/api/balances/[frequency]/route.ts
@@ -12,7 +12,15 @@ type TokenBalance = {
   balance_usd: number;
 };
 
-async function getTreasuryBalanceTS(frequency: string) {
+async function getTreasuryBalanceTS(
+  frequency: string
+): Promise<{ result: TokenBalance[] }> {
+  if (frequency == "latest") {
+    const { result } = await getTreasuryBalanceTS("24h");
+    const lastObject = result[result.length - 1];
+    return { result: [lastObject] };
+  }
+
   const { contracts } = Tenant.current();
 
   const { lookback, skipCrit } = frequencyToDateAndSQLcrit(frequency, "day");


### PR DESCRIPTION
The approach here, is basically just crop what gets sent in the 24h request.  We can speed these up after, without involving front-end.  

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `getTreasuryBalanceTS` and `getMetricTS` functions to return a promise with a specific result object when the frequency is "latest".

### Detailed summary
- Updated `getTreasuryBalanceTS` to return a promise with `{ result: TokenBalance[] }` when frequency is "latest"
- Updated `getMetricTS` to return a promise with `{ result: MetricValue[] }` when frequency is "latest"
- Refactored return statements to include the specific data type for clarity

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->