### PR TITLE
[RetroFunding API] Patch: autobalance ballot on delete

### DIFF
--- a/src/app/api/common/ballots/updateBallot.ts
+++ b/src/app/api/common/ballots/updateBallot.ts
@@ -68,53 +68,7 @@ async function updateBallotMetricForAddress({
     },
   });
 
-  // Autoreblance all other allocations
-  const allocations = await prisma.allocations.findMany({
-    where: {
-      address,
-      round: roundId,
-    },
-  });
-
-  const [amountToBalance, totalUnlocked] = allocations.reduce(
-    (acc, allocation) => {
-      acc[0] -=
-        allocation.locked || allocation.metric_id === data.metric_id
-          ? Number(allocation.allocation.toFixed(2))
-          : 0;
-      return [
-        acc[0] < 0 ? 0 : acc[0],
-        acc[1] +
-          (allocation.locked || allocation.metric_id === data.metric_id
-            ? 0
-            : Number(allocation.allocation.toFixed(2))),
-      ];
-    },
-    [100, 0]
-  );
-
-  await Promise.all(
-    allocations.map(async (allocation) => {
-      if (!allocation.locked && allocation.metric_id !== data.metric_id) {
-        await prisma.allocations.update({
-          where: {
-            address_round_metric_id: {
-              metric_id: allocation.metric_id,
-              round: roundId,
-              address,
-            },
-          },
-          data: {
-            ...allocation,
-            allocation: totalUnlocked
-              ? (Number(allocation.allocation.toFixed(2)) / totalUnlocked) *
-                amountToBalance
-              : 0,
-          },
-        });
-      }
-    })
-  );
+  await autobalanceAllocations(address, roundId, data.metric_id);
 
   // Return full ballot
   return fetchBallot(roundId, address);
@@ -139,13 +93,70 @@ async function deleteBallotMetricForAddress({
   roundId: number;
   address: string;
 }) {
-  return prisma.allocations.deleteMany({
+  await prisma.allocations.deleteMany({
     where: {
       metric_id: metricId,
       address,
       round: roundId,
     },
   });
+
+  await autobalanceAllocations(address, roundId, metricId);
+
+  return fetchBallot(roundId, address);
+}
+
+async function autobalanceAllocations(
+  address: string,
+  roundId: number,
+  procssedMeric: string
+) {
+  const allocations = await prisma.allocations.findMany({
+    where: {
+      address,
+      round: roundId,
+    },
+  });
+
+  const [amountToBalance, totalUnlocked] = allocations.reduce(
+    (acc, allocation) => {
+      acc[0] -=
+        allocation.locked || allocation.metric_id === procssedMeric
+          ? Number(allocation.allocation.toFixed(2))
+          : 0;
+      return [
+        acc[0] < 0 ? 0 : acc[0],
+        acc[1] +
+          (allocation.locked || allocation.metric_id === procssedMeric
+            ? 0
+            : Number(allocation.allocation.toFixed(2))),
+      ];
+    },
+    [100, 0]
+  );
+
+  await Promise.all(
+    allocations.map(async (allocation) => {
+      if (!allocation.locked && allocation.metric_id !== procssedMeric) {
+        await prisma.allocations.update({
+          where: {
+            address_round_metric_id: {
+              metric_id: allocation.metric_id,
+              round: roundId,
+              address,
+            },
+          },
+          data: {
+            ...allocation,
+            allocation: totalUnlocked
+              ? (Number(allocation.allocation.toFixed(2)) / totalUnlocked) *
+                amountToBalance
+              : 0,
+          },
+        });
+      }
+    })
+  );
 }
 
 const updateBallotOsMultiplierApi = async (

--- a/src/app/api/common/ballots/updateBallot.ts
+++ b/src/app/api/common/ballots/updateBallot.ts
@@ -109,7 +109,7 @@ async function deleteBallotMetricForAddress({
 async function autobalanceAllocations(
   address: string,
   roundId: number,
-  procssedMeric: string
+  metricToSkip: string
 ) {
   const allocations = await prisma.allocations.findMany({
     where: {
@@ -121,13 +121,13 @@ async function autobalanceAllocations(
   const [amountToBalance, totalUnlocked] = allocations.reduce(
     (acc, allocation) => {
       acc[0] -=
-        allocation.locked || allocation.metric_id === procssedMeric
+        allocation.locked || allocation.metric_id === metricToSkip
           ? Number(allocation.allocation.toFixed(2))
           : 0;
       return [
         acc[0] < 0 ? 0 : acc[0],
         acc[1] +
-          (allocation.locked || allocation.metric_id === procssedMeric
+          (allocation.locked || allocation.metric_id === metricToSkip
             ? 0
             : Number(allocation.allocation.toFixed(2))),
       ];
@@ -137,7 +137,7 @@ async function autobalanceAllocations(
 
   await Promise.all(
     allocations.map(async (allocation) => {
-      if (!allocation.locked && allocation.metric_id !== procssedMeric) {
+      if (!allocation.locked && allocation.metric_id !== metricToSkip) {
         await prisma.allocations.update({
           where: {
             address_round_metric_id: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add functionality for deleting and autobalancing allocations in a voting system.

### Detailed summary
- Added `deleteBallotMetricApi` function for deleting ballot metrics
- Implemented `deleteBallotMetricForAddress` function for deleting metrics for a specific address
- Introduced `autobalanceAllocations` function for rebalancing allocations
- Updated `updateBallotMetricForAddress` to use `metricToSkip` instead of `data.metric_id` for autobalancing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->