### PR TITLE
[RetroFunding API] Patch: update rebalance logic for comment votes

### DIFF
--- a/src/app/api/common/comments/updateImpactMetricCommentVote.ts
+++ b/src/app/api/common/comments/updateImpactMetricCommentVote.ts
@@ -11,6 +11,19 @@ async function updateImpactMetricCommentVoteApi({
   address: string;
   vote: number;
 }): Promise<ImpactMetricCommentVote> {
+  const existingVote = await prisma.metrics_comments_votes.findUnique({
+    where: {
+      comment_id_voter: {
+        comment_id: commentId,
+        voter: address,
+      },
+    },
+  });
+
+  const voteValue = existingVote
+    ? Math.max(-1, Math.min(1, existingVote.vote + vote))
+    : vote;
+
   const commentVote = await prisma.metrics_comments_votes.upsert({
     where: {
       comment_id_voter: {
@@ -19,7 +32,7 @@ async function updateImpactMetricCommentVoteApi({
       },
     },
     update: {
-      vote,
+      vote: voteValue,
       updated_at: new Date(),
     },
     create: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `updateImpactMetricCommentVoteApi` function to handle impact metric comment votes more accurately.

### Detailed summary
- Added logic to retrieve existing vote for a comment and voter
- Calculated the new vote value based on existing vote and incoming vote
- Updated the `vote` field in the database with the new calculated value

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->