### PR TITLE
[RetroFunding API] Patch: only badgeholders can create comments & vote on comments

### DIFF
--- a/src/app/api/v1/retrofunding/rounds/[roundId]/impactMetrics/[impactMetricId]/comments/[commentId]/votes/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/impactMetrics/[impactMetricId]/comments/[commentId]/votes/route.ts
@@ -52,6 +52,12 @@ export async function PUT(
     });
   }
 
+  if (!authResponse.scope?.includes("badgeholder")) {
+    return new Response("Only badgeholder can vote on a comment", {
+      status: 401,
+    });
+  }
+
   return await traceWithUserId(authResponse.userId, async () => {
     const { commentId } = route.params;
 

--- a/src/app/api/v1/retrofunding/rounds/[roundId]/impactMetrics/[impactMetricId]/comments/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/impactMetrics/[impactMetricId]/comments/route.ts
@@ -80,6 +80,12 @@ export async function PUT(
     });
   }
 
+  if (!authResponse.scope?.includes("badgeholder")) {
+    return new Response("Only badgeholder can vote on a comment", {
+      status: 401,
+    });
+  }
+
   return await traceWithUserId(authResponse.userId, async () => {
     const { roundId, impactMetricId } = route.params;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to restrict voting on comments to only badgeholders. 

### Detailed summary
- Added a check to ensure only badgeholders can vote on comments in `route.ts` files for impact metrics and comments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->