### PR TITLE
Patch 🐛  24h for 3d

### DIFF
--- a/src/app/api/analytics/metric/[metric_id]/[frequency]/route.ts
+++ b/src/app/api/analytics/metric/[metric_id]/[frequency]/route.ts
@@ -19,7 +19,7 @@ async function getMetricTS(
   const { namespace } = Tenant.current();
 
   if (frequency == "latest") {
-    const { result } = await getMetricTS(metricId, "24h");
+    const { result } = await getMetricTS(metricId, "3d");
     const lastObject = result[result.length - 1];
     return { result: [lastObject] };
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the time frame for fetching the latest metric data from 24 hours to 3 days.

### Detailed summary
- Updated the time frame from "24h" to "3d" when fetching the latest metric data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->