### PR TITLE
Rename `votes` -> `voter_count`

### DIFF
--- a/src/app/api/analytics/vote/route.ts
+++ b/src/app/api/analytics/vote/route.ts
@@ -6,14 +6,14 @@ import { cache } from "react";
 
 type ProposalCount = {
   proposalId: number;
-  votes: number;
+  voter_count: number;
 };
 
 async function getProposalVoteCounts() {
   const { namespace } = Tenant.current();
 
   const QRY = `SELECT proposal_id,
-                    SUM(vote_count) votes
+                    SUM(voter_count) voter_count
                 FROM   alltenant.dao_engagement_votes
                 WHERE  tenant = '${namespace}'
                     GROUP  BY 1


### PR DESCRIPTION
...just trying to avoid massive confusion.

Happy to merge this after we merge the #323 , and presumably patch the usage of `votes` key in the same merge.

I need a manual DB migration to go simultaneously. 