### PR TITLE
Support EIP-1271 signatures

### DIFF
--- a/src/app/api/common/ballots/submitBallot.ts
+++ b/src/app/api/common/ballots/submitBallot.ts
@@ -38,13 +38,6 @@ async function submitBallotForAddress({
     throw new Error("Invalid signature");
   }
 
-  // The signature column in the schema is VARCHAR(255). EIP-1271 signatures
-  // can be longer than that, so we truncate them to fit in the database.
-  let signature = data.signature;
-  if (signature.length > 255) {
-    signature = signature.substring(0, 252) + "...";
-  }
-
   const submission = await prisma.ballotSubmittions.upsert({
     where: {
       address_round: {
@@ -53,14 +46,14 @@ async function submitBallotForAddress({
       },
     },
     update: {
-      signature: signature,
+      signature: data.signature,
       payload,
       updated_at: new Date(),
     },
     create: {
       round: roundId,
       address,
-      signature: signature,
+      signature: data.signature,
       payload,
     },
   });

--- a/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
@@ -22,12 +22,12 @@ const r5BallotContentSchema = z.object({
 
 const r4BallotSubmissionSchema = z.object({
   ballot_content: r4BallotContentSchema,
-  signature: z.string().regex(/^0x[a-fA-F0-9]{130}$/),
+  signature: z.string().regex(/^0x[a-fA-F0-9]+$/),
 });
 
 const r5BallotSubmissionSchema = z.object({
   ballot_content: r5BallotContentSchema,
-  signature: z.string().regex(/^0x[a-fA-F0-9]{130}$/),
+  signature: z.string().regex(/^0x[a-fA-F0-9]+$/),
 });
 
 export type R4BallotSubmission = z.infer<typeof r4BallotSubmissionSchema>;


### PR DESCRIPTION
Ballot submission returns an error for smart contract wallets, because the regex enforces the signature to be 130 hex characters (65 bytes), but EIP-1271 signatures are often far longer than that.

This PR fixes the signature validation bug by removing the exact signature length validation.

~Unfortunately the `ballotSubmittions.signature` column in the schema is a VARCHAR(255) which limits the ability to store full signatures in the database. Not sure what the downstream effects of this are, but I've updated the upsert to truncate the signature to fit in the column. If that breaks something downstream, we'll have to update the schema itself (i think https://github.com/voteagora/queries is a private repo?).~