### PR TITLE
Ensure isBadgeholder on ballot submission

### DIFF
--- a/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
+++ b/src/app/api/v1/retrofunding/rounds/[roundId]/ballots/[ballotCasterAddressOrEns]/submit/route.ts
@@ -37,7 +37,7 @@ export async function POST(
   request: NextRequest,
   route: { params: { roundId: string; ballotCasterAddressOrEns: string } }
 ) {
-  const isBadgeholder = await fetchBadgeholder(
+  const { isBadgeholder } = await fetchBadgeholder(
     route.params.ballotCasterAddressOrEns
   );
 


### PR DESCRIPTION
The ballet submission address is not validated to be a badgeholder, because the `isBadgeholder` variable isn't extracted from the `fetchBadgeholder`. This allows anyone with a valid signature to submit ballots.