### PR TITLE
Fixing OP delegation

### DIFF
--- a/src/components/Dialogs/AdvancedDelegateDialog/useAdvancedDelegation.tsx
+++ b/src/components/Dialogs/AdvancedDelegateDialog/useAdvancedDelegation.tsx
@@ -72,7 +72,7 @@ const useAdvancedDelegation = ({
       ],
       chainId: optimism.id,
     });
-  }, [isDelegatingToProxy, delegateToProxy, subdelegate]);
+  }, [isDelegatingToProxy, delegateToProxy, subdelegate, target, allocation]);
 
   useEffect(() => {
     if (delegateToProxyIsLoading || subdelegateIsLoading) {


### PR DESCRIPTION
Delegation values were cached during component initialization. This PR ensures that the values are refreshed with every update.