### PR TITLE
Always show 0% participation

### DIFF
--- a/src/components/Delegates/DelegateCardList/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCard.tsx
@@ -54,11 +54,9 @@ const DelegateCard = ({
               <span className="text-primary font-bold">
                 {formatNumber(delegate.votingPower.total)} {token.symbol}
               </span>
-              {votingStats && (
-                <span className="text-primary font-bold">
-                  {(votingStats?.last_10_props || 0) * 10}% Participation
-                </span>
-              )}
+              <span className="text-primary font-bold">
+                {(votingStats?.last_10_props || 0) * 10}% Participation
+              </span>
             </div>
             <p className="text-base leading-normal min-h-[48px] break-words text-secondary overflow-hidden line-clamp-2 px-4">
               {truncatedStatement}


### PR DESCRIPTION
Bug - Delegates who have NEVER voted, have null participation, rather than 0% participation.

Fixes: https://linear.app/agora-app/issue/AGORA-3235/bug-delegates-who-have-never-voted-have-null-participation-rather-than