### PR TITLE
Always show 0% participation

### DIFF
--- a/src/components/Delegates/DelegateCardList/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCard.tsx
@@ -23,6 +23,7 @@ const DelegateCard = ({
 }) => {
   const { token } = Tenant.current();
   const { advancedDelegators } = useConnectedDelegate();
+
   const { data: votingStats, isPending: isVotingStatsPending } = useVotingStats(
     {
       address: delegate.address as `0x${string}`,

--- a/src/components/Delegates/DelegateCardList/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCard.tsx
@@ -23,7 +23,6 @@ const DelegateCard = ({
 }) => {
   const { token } = Tenant.current();
   const { advancedDelegators } = useConnectedDelegate();
-
   const { data: votingStats, isPending: isVotingStatsPending } = useVotingStats(
     {
       address: delegate.address as `0x${string}`,

--- a/src/components/Delegates/DelegateCardList/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCard.tsx
@@ -23,7 +23,7 @@ const DelegateCard = ({
 }) => {
   const { token } = Tenant.current();
   const { advancedDelegators } = useConnectedDelegate();
-  const { data: votingStats, isLoading: isVotingStatsLoading } = useVotingStats(
+  const { data: votingStats, isPending: isVotingStatsPending } = useVotingStats(
     {
       address: delegate.address as `0x${string}`,
     }
@@ -54,7 +54,7 @@ const DelegateCard = ({
               <span className="text-primary font-bold">
                 {formatNumber(delegate.votingPower.total)} {token.symbol}
               </span>
-              {votingStats && (
+              {!isVotingStatsPending && (
                 <span className="text-primary font-bold">
                   {(votingStats?.last_10_props || 0) * 10}% Participation
                 </span>


### PR DESCRIPTION
Bug - Delegates who have NEVER voted, have null participation, rather than 0% participation.

Fixes: https://linear.app/agora-app/issue/AGORA-3235/bug-delegates-who-have-never-voted-have-null-participation-rather-than

Supersedes https://github.com/voteagora/agora-next/pull/600
Two improvements on top of the old PR:
• Pushed from voteagor repo instead of my own fork
• FIxes "one problem is that while the data is loading it shows "0% participation" -- it doesn't look that bad, I pulled it down and ran it. Might be confusing though" (https://github.com/voteagora/agora-next/pull/600#discussion_r1840895551)