### PR TITLE
Fix voter card loading

### DIFF
--- a/src/components/Votes/VoterHoverCard.tsx
+++ b/src/components/Votes/VoterHoverCard.tsx
@@ -50,12 +50,10 @@ export default function VoterHoverCard({
     );
   }
 
-  if (delegate.statement === null) {
-    return <p className="text-center">No statement</p>;
-  }
-
   const truncatedStatement =
-    delegate.statement.payload?.delegateStatement?.slice(0, 120) || "";
+    delegate.statement === null
+      ? null
+      : delegate.statement.payload?.delegateStatement?.slice(0, 120) || "";
 
   return (
     <VStack gap={4} className="h-full w-[300px]">
@@ -63,26 +61,29 @@ export default function VoterHoverCard({
         <VStack gap={4} justifyContent="justify-center">
           <DelegateProfileImage
             address={address}
-            endorsed={!!delegate ? delegate.statement.endorsed : false}
-            votingPower={!!delegate ? delegate.votingPower.total : "0"}
+            endorsed={!!delegate.statement?.endorsed}
+            votingPower={delegate.votingPower.total}
           />
           <p
             className={`break-words text-secondary overflow-hidden line-clamp-2 text-ellipsis`}
           >
-            {truncatedStatement}
+            {truncatedStatement === null
+              ? "This delegate has not yet created a delegate statement."
+              : truncatedStatement}
           </p>
         </VStack>
       </Link>
       <div className="flex-grow" />
       <HStack alignItems="items-stretch" className={"justify-between"}>
-        <DelegateSocialLinks
-          warpcast={delegate?.statement.warpcast}
-          discord={delegate?.statement.discord}
-          twitter={delegate?.statement.twitter}
-        />
+        {delegate.statement !== null && (
+          <DelegateSocialLinks
+            warpcast={delegate.statement.warpcast}
+            discord={delegate.statement.discord}
+            twitter={delegate.statement.twitter}
+          />
+        )}
         <div>
-          {!!delegate &&
-            isConnected &&
+          {isConnected &&
             connectedAddress &&
             (isAdvancedUser ? (
               <AdvancedDelegateButton
@@ -92,7 +93,7 @@ export default function VoterHoverCard({
             ) : (
               <DelegateButton
                 full={
-                  !delegate?.statement.twitter && !delegate?.statement.discord
+                  !delegate.statement?.twitter && !delegate.statement?.discord
                 }
                 delegate={delegate}
               />

--- a/src/components/Votes/VoterHoverCard.tsx
+++ b/src/components/Votes/VoterHoverCard.tsx
@@ -74,7 +74,12 @@ export default function VoterHoverCard({
         </VStack>
       </Link>
       <div className="flex-grow" />
-      <HStack alignItems="items-stretch" className={"justify-between"}>
+      <HStack
+        alignItems="items-stretch"
+        className={
+          delegate.statement === null ? "justify-end" : "justify-between"
+        }
+      >
         {delegate.statement !== null && (
           <DelegateSocialLinks
             warpcast={delegate.statement.warpcast}

--- a/src/components/Votes/VoterHoverCard.tsx
+++ b/src/components/Votes/VoterHoverCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { VStack, HStack } from "@/components/Layout/Stack";
 import { DelegateProfileImage } from "../Delegates/DelegateCard/DelegateProfileImage";
 import Link from "next/link";
@@ -29,83 +29,78 @@ export default function VoterHoverCard({
   const { isConnected } = useAgoraContext();
   const { address: connectedAddress } = useAccount();
 
-  const fetchDelegateAndSet = useCallback(async (addressOrENSName: string) => {
-    const delegate = await fetchDelegate(addressOrENSName);
-    setDelegate(delegate);
-  }, []);
-
   useEffect(() => {
-    fetchDelegateAndSet(address);
-  }, [fetchDelegateAndSet, address]);
+    fetchDelegate(address).then(setDelegate);
+  }, [address]);
 
-  let truncatedStatement = "";
-  if (delegate?.statement?.payload) {
-    const delegateStatement = (
-      delegate?.statement?.payload as { delegateStatement: string }
-    ).delegateStatement;
-    truncatedStatement = delegateStatement.slice(0, 120);
+  console.log("delegate", delegate);
+
+  if (delegate === undefined) {
+    return (
+      <VStack gap={4} className="h-full w-[300px] p-2">
+        <VStack gap={4} justifyContent="justify-center">
+          <HStack gap={4} justifyContent="justify-start">
+            <div className="w-14 h-14 rounded-full bg-line animate-pulse" />
+            <VStack gap={2} justifyContent="justify-center">
+              <div className="w-24 h-4 rounded-md bg-line animate-pulse" />
+              <div className="w-12 h-4 rounded-md bg-line animate-pulse" />
+            </VStack>
+          </HStack>
+          <div className="w-full h-12 rounded-md bg-line animate-pulse" />
+        </VStack>
+      </VStack>
+    );
   }
 
+  if (delegate.statement === null) {
+    return null;
+  }
+
+  const truncatedStatement =
+    delegate.statement.payload?.delegateStatement?.slice(0, 120) || "";
+
   return (
-    <>
-      {!delegate?.statement ? (
-        <VStack gap={4} className="h-full w-[300px] p-2">
-          <VStack gap={4} justifyContent="justify-center">
-            <HStack gap={4} justifyContent="justify-start">
-              <div className="w-14 h-14 rounded-full bg-line animate-pulse" />
-              <VStack gap={2} justifyContent="justify-center">
-                <div className="w-24 h-4 rounded-md bg-line animate-pulse" />
-                <div className="w-12 h-4 rounded-md bg-line animate-pulse" />
-              </VStack>
-            </HStack>
-            <div className="w-full h-12 rounded-md bg-line animate-pulse" />
-          </VStack>
+    <VStack gap={4} className="h-full w-[300px]">
+      <Link href={`/delegates/${address}`}>
+        <VStack gap={4} justifyContent="justify-center">
+          <DelegateProfileImage
+            address={address}
+            endorsed={!!delegate ? delegate.statement.endorsed : false}
+            votingPower={!!delegate ? delegate.votingPower.total : "0"}
+          />
+          <p
+            className={`break-words text-secondary overflow-hidden line-clamp-2 text-ellipsis`}
+          >
+            {truncatedStatement}
+          </p>
         </VStack>
-      ) : (
-        <VStack gap={4} className="h-full w-[300px]">
-          <Link href={`/delegates/${address}`}>
-            <VStack gap={4} justifyContent="justify-center">
-              <DelegateProfileImage
-                address={address}
-                endorsed={!!delegate ? delegate.statement.endorsed : false}
-                votingPower={!!delegate ? delegate.votingPower.total : "0"}
+      </Link>
+      <div className="flex-grow" />
+      <HStack alignItems="items-stretch" className={"justify-between"}>
+        <DelegateSocialLinks
+          warpcast={delegate?.statement.warpcast}
+          discord={delegate?.statement.discord}
+          twitter={delegate?.statement.twitter}
+        />
+        <div>
+          {!!delegate &&
+            isConnected &&
+            connectedAddress &&
+            (isAdvancedUser ? (
+              <AdvancedDelegateButton
+                delegate={delegate}
+                delegators={delegators}
               />
-              <p
-                className={`break-words text-secondary overflow-hidden line-clamp-2 text-ellipsis`}
-              >
-                {truncatedStatement}
-              </p>
-            </VStack>
-          </Link>
-          <div className="flex-grow" />
-          <HStack alignItems="items-stretch" className={"justify-between"}>
-            <DelegateSocialLinks
-              warpcast={delegate?.statement.warpcast}
-              discord={delegate?.statement.discord}
-              twitter={delegate?.statement.twitter}
-            />
-            <div>
-              {!!delegate &&
-                isConnected &&
-                connectedAddress &&
-                (isAdvancedUser ? (
-                  <AdvancedDelegateButton
-                    delegate={delegate}
-                    delegators={delegators}
-                  />
-                ) : (
-                  <DelegateButton
-                    full={
-                      !delegate?.statement.twitter &&
-                      !delegate?.statement.discord
-                    }
-                    delegate={delegate}
-                  />
-                ))}
-            </div>
-          </HStack>
-        </VStack>
-      )}
-    </>
+            ) : (
+              <DelegateButton
+                full={
+                  !delegate?.statement.twitter && !delegate?.statement.discord
+                }
+                delegate={delegate}
+              />
+            ))}
+        </div>
+      </HStack>
+    </VStack>
   );
 }

--- a/src/components/Votes/VoterHoverCard.tsx
+++ b/src/components/Votes/VoterHoverCard.tsx
@@ -74,19 +74,12 @@ export default function VoterHoverCard({
         </VStack>
       </Link>
       <div className="flex-grow" />
-      <HStack
-        alignItems="items-stretch"
-        className={
-          delegate.statement === null ? "justify-end" : "justify-between"
-        }
-      >
-        {delegate.statement !== null && (
-          <DelegateSocialLinks
-            warpcast={delegate.statement.warpcast}
-            discord={delegate.statement.discord}
-            twitter={delegate.statement.twitter}
-          />
-        )}
+      <HStack alignItems="items-stretch" className="justify-between">
+        <DelegateSocialLinks
+          warpcast={delegate.statement?.warpcast}
+          discord={delegate.statement?.discord}
+          twitter={delegate.statement?.twitter}
+        />
         <div>
           {isConnected &&
             connectedAddress &&

--- a/src/components/Votes/VoterHoverCard.tsx
+++ b/src/components/Votes/VoterHoverCard.tsx
@@ -51,7 +51,7 @@ export default function VoterHoverCard({
   }
 
   if (delegate.statement === null) {
-    return <p className="text-center italic">No statement</p>;
+    return <p className="text-center">No statement</p>;
   }
 
   const truncatedStatement =

--- a/src/components/Votes/VoterHoverCard.tsx
+++ b/src/components/Votes/VoterHoverCard.tsx
@@ -33,8 +33,6 @@ export default function VoterHoverCard({
     fetchDelegate(address).then(setDelegate);
   }, [address]);
 
-  console.log("delegate", delegate);
-
   if (delegate === undefined) {
     return (
       <VStack gap={4} className="h-full w-[300px] p-2">
@@ -53,7 +51,7 @@ export default function VoterHoverCard({
   }
 
   if (delegate.statement === null) {
-    return null;
+    return <p className="text-center italic">No statement</p>;
   }
 
   const truncatedStatement =


### PR DESCRIPTION
Fixes https://linear.app/agora-app/issue/AGORA-3240/troubleshoot-fix-hover-card-that-never-loads

For the default message (when the statement is `null`), I just show `No statement` as in the screen recording below. But I'm not sure if there is a better message we can display here. All the content of a valid hover card seem to be dependent on `statement` being non-null so there is really nothing we can show as a fallback.

### Demo
https://github.com/user-attachments/assets/724d1f22-6843-4b49-9cf4-38a6cf614912

