### PR TITLE
Fix OP admin voting settings issues

### DIFF
--- a/src/components/Admin/GovernorSettings.tsx
+++ b/src/components/Admin/GovernorSettings.tsx
@@ -49,29 +49,37 @@ export default function GovernorSettings() {
   useEffect(() => {
     if (data) {
       setVotingPeriod(
-        (Number(initVotingPeriod!.result) * secondsPerBlock) / SECONDS_IN_HOUR
+        (
+          (Number(initVotingPeriod!.result) * secondsPerBlock) /
+          SECONDS_IN_HOUR
+        ).toString()
       );
       setVotingDelay(
-        (Number(initVotingDelay!.result) * secondsPerBlock) / SECONDS_IN_HOUR
+        (
+          (Number(initVotingDelay!.result) * secondsPerBlock) /
+          SECONDS_IN_HOUR
+        ).toString()
       );
       setManager(String(initManager!.result));
     }
   }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [manager, setManager] = useState("0x...");
-  const [votingPeriod, setVotingPeriod] = useState<number>();
+  const [votingPeriod, setVotingPeriod] = useState("");
+
+  function convertToBlocks(valueInHours: string) {
+    return BigInt(
+      Math.floor((Number(valueInHours) * SECONDS_IN_HOUR) / secondsPerBlock)
+    );
+  }
 
   const { data: setVotingPeriodConfig, isError: setVotingPeriodError } =
     useSimulateContract({
       ...govContract,
       functionName: "setVotingPeriod",
-      args: [
-        (votingPeriod
-          ? BigInt(Math.floor((votingPeriod || 0) * SECONDS_IN_HOUR)) /
-            BigInt(secondsPerBlock)
-          : BigInt(secondsPerBlock)) / BigInt(secondsPerBlock),
-      ],
+      args: [votingPeriod === "" ? 0n : convertToBlocks(votingPeriod)],
     });
+
   const {
     data: resultSetVotingPeriod,
     writeContract: writeSetVotingPeriod,
@@ -84,15 +92,12 @@ export default function GovernorSettings() {
   const isDisabledSetVotingPeriod =
     isLoadingSetVotingPeriod || isLoadingSetVotingPeriodTransaction;
 
-  const [votingDelay, setVotingDelay] = useState<number>();
+  const [votingDelay, setVotingDelay] = useState("");
   const { data: setVotingDelayConfig, isError: setVotingDelayError } =
     useSimulateContract({
       ...govContract,
       functionName: "setVotingDelay",
-      args: [
-        BigInt(Math.floor((votingDelay || 0) * SECONDS_IN_HOUR)) /
-          BigInt(secondsPerBlock),
-      ],
+      args: [votingDelay === "" ? 0n : convertToBlocks(votingDelay)],
     });
   const {
     data: resultSetVotingDelay,
@@ -122,7 +127,7 @@ export default function GovernorSettings() {
               <Input
                 min={0}
                 value={votingPeriod}
-                onChange={(e) => setVotingPeriod(Number(e.target.value))}
+                onChange={(e) => setVotingPeriod(e.target.value)}
                 disabled={/* isInitializing || */ isDisabledSetVotingPeriod}
                 step={0.01}
                 type="number"
@@ -137,7 +142,8 @@ export default function GovernorSettings() {
                 loading={isDisabledSetVotingPeriod}
                 disabled={
                   /* isInitializing || */ isDisabledSetVotingPeriod ||
-                  setVotingPeriodError
+                  setVotingPeriodError ||
+                  votingPeriod === ""
                 }
                 onClick={() => {
                   writeSetVotingPeriod(setVotingPeriodConfig!.request);
@@ -153,7 +159,7 @@ export default function GovernorSettings() {
               <Input
                 min={0}
                 value={votingDelay}
-                onChange={(e) => setVotingDelay(Number(e.target.value))}
+                onChange={(e) => setVotingDelay(e.target.value)}
                 disabled={/* isInitializing || */ isDisabledSetVotingDelay}
                 step={0.01}
                 type="number"
@@ -168,7 +174,8 @@ export default function GovernorSettings() {
                 loading={isDisabledSetVotingDelay}
                 disabled={
                   /* isInitializing || */ isDisabledSetVotingDelay ||
-                  setVotingDelayError
+                  setVotingDelayError ||
+                  votingDelay === ""
                 }
                 onClick={() => {
                   writeSetVotingDelay(setVotingDelayConfig!.request);


### PR DESCRIPTION
Fixes both bugs reported in https://linear.app/agora-app/issue/AGORA-3309/bug-in-time-to-block-conversion-and-input-field-in-op-admin-voting :

If the user puts in 1 "hours", for "Voting Period", it broadcasts a message equal to 900, which is 30 minutes.  If the user puts in 1, it should broadcast 1800.

Additionally, in either field (Voting period or Voting delay).  The text box is awkward if you press backspace.  It won't let you clear the field.  The behaviour should be to allow the user to clear the field, in order to type a new number.  Perhaps gray out the button, if the field is empty.

### Demo

https://github.com/user-attachments/assets/c5335c6e-43e2-48a8-b000-3e5ca055fa14