### PR TITLE
[Improvement] Hide Delegate Card Activity if Absolute # of proposals < 3

### DIFF
--- a/src/app/api/common/proposals/getProposals.ts
+++ b/src/app/api/common/proposals/getProposals.ts
@@ -17,6 +17,7 @@ import {
   findProposal,
   findProposalType,
   findProposalsQuery,
+  getProposalsCount,
 } from "@/lib/prismaUtils";
 
 async function getProposals({
@@ -156,6 +157,15 @@ async function getDraftProposalForSponsor(address: `0x${string}`) {
   });
 }
 
+async function getTotalProposalsCount(): Promise<number> {
+  const { namespace, contracts } = Tenant.current();
+  return getProposalsCount({
+    namespace,
+    contract: contracts.governor.address,
+  });
+}
+
+export const fetchProposalsCount = cache(getTotalProposalsCount);
 export const fetchDraftProposalForSponsor = cache(getDraftProposalForSponsor);
 export const fetchDraftProposals = cache(getDraftProposals);
 export const fetchProposals = cache(getProposals);

--- a/src/app/delegates/[addressOrENSName]/page.tsx
+++ b/src/app/delegates/[addressOrENSName]/page.tsx
@@ -2,6 +2,10 @@ import { Metadata, ResolvingMetadata } from "next";
 import DelegateCard from "@/components/Delegates/DelegateCard/DelegateCard";
 import ResourceNotFound from "@/components/shared/ResourceNotFound/ResourceNotFound";
 import { fetchDelegate } from "@/app/delegates/actions";
+import {
+  fetchProposals,
+  fetchProposalsCount,
+} from "@/app/api/common/proposals/getProposals";
 import { formatNumber } from "@/lib/tokenUtils";
 import {
   processAddressOrEnsName,
@@ -82,7 +86,10 @@ export default async function Page({
   params: { addressOrENSName: string };
 }) {
   const address = (await resolveENSName(addressOrENSName)) || addressOrENSName;
-  const delegate = await fetchDelegate(address);
+  const [delegate, totalProposals] = await Promise.all([
+    fetchDelegate(address),
+    fetchProposalsCount(),
+  ]);
 
   if (!delegate) {
     return (
@@ -93,7 +100,7 @@ export default async function Page({
   return (
     <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 justify-between mt-12 w-full max-w-full">
       <div className="flex flex-col static sm:sticky top-16 shrink-0 w-full sm:max-w-xs">
-        <DelegateCard delegate={delegate} />
+        <DelegateCard delegate={delegate} totalProposals={totalProposals} />
       </div>
       <div className="flex flex-col sm:ml-12 min-w-0 flex-1 max-w-full gap-8">
         <Suspense fallback={<DelegateStatementSkeleton />}>

--- a/src/app/proposals/actions.tsx
+++ b/src/app/proposals/actions.tsx
@@ -6,8 +6,18 @@ import {
   fetchVotesForProposal as apiFetchVotesForProposal,
   fetchVotersWhoHaveNotVotedForProposal as apiFetchVotersWhoHaveNotVotedForProposal,
 } from "@/app/api/common/votes/getVotes";
+import { getProposalsCount } from "@/lib/prismaUtils";
 import { PaginationParams } from "../lib/pagination";
 import { VotesSort } from "../api/common/votes/vote";
+import Tenant from "@/lib/tenant/tenant";
+
+export async function fetchProposalsCount() {
+  const { namespace, contracts } = Tenant.current();
+  return getProposalsCount({
+    namespace,
+    contract: contracts.governor.address,
+  });
+}
 
 export const fetchVotersWhoHaveNotVotedForProposal = (
   proposalId: string,

--- a/src/components/DelegateStatement/DelegateStatementForm.tsx
+++ b/src/components/DelegateStatement/DelegateStatementForm.tsx
@@ -13,6 +13,7 @@ import {
   fetchDelegate,
   submitDelegateStatement,
 } from "@/app/delegates/actions";
+import { fetchProposalsCount } from "@/app/proposals/actions";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { type DelegateStatementFormValues } from "./CurrentDelegateStatement";
@@ -34,6 +35,7 @@ export default function DelegateStatementForm({
   const messageSigner = useSignMessage();
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [delegate, setDelegate] = useState<Delegate | null>(null);
+  const [totalProposals, setTotalProposals] = useState<number>(0);
 
   const { data: scwAddress } = useSmartAccountAddress({ owner: address });
 
@@ -50,14 +52,18 @@ export default function DelegateStatementForm({
   });
 
   useEffect(() => {
-    async function _getDelegate() {
-      const _delegate = await fetchDelegate(address as string);
-      setDelegate(_delegate);
+    async function fetchData() {
+      if (address) {
+        const [_delegate, _totalProposals] = await Promise.all([
+          fetchDelegate(address as string),
+          fetchProposalsCount(),
+        ]);
+        setDelegate(_delegate);
+        setTotalProposals(_totalProposals);
+      }
     }
 
-    if (address) {
-      _getDelegate();
-    }
+    fetchData();
   }, [address]);
 
   async function onSubmit(values: DelegateStatementFormValues) {
@@ -135,7 +141,7 @@ export default function DelegateStatementForm({
     <div className="flex flex-col sm:flex-row-reverse items-center sm:items-start gap-16 justify-between mt-12 w-full max-w-full">
       {delegate && (
         <div className="flex flex-col static sm:sticky top-16 shrink-0 w-full sm:max-w-xs">
-          <DelegateCard delegate={delegate} />
+          <DelegateCard delegate={delegate} totalProposals={totalProposals} />
         </div>
       )}
       <div className="flex flex-col w-full">

--- a/src/components/Delegates/DelegateCard/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCard/DelegateCard.tsx
@@ -45,14 +45,22 @@ const InactiveHeader = ({ outOfTen }: { outOfTen: string }) => {
   );
 };
 
-export default function DelegateCard({ delegate }: { delegate: Delegate }) {
+export default function DelegateCard({
+  delegate,
+  totalProposals,
+}: {
+  delegate: Delegate;
+  totalProposals: number;
+}) {
   return (
     <div className="flex flex-col sticky top-16 flex-shrink-0 width-[20rem]">
-      {parseInt(delegate.lastTenProps) > 5 ? (
-        <ActiveHeader outOfTen={delegate.lastTenProps} />
-      ) : (
-        <InactiveHeader outOfTen={delegate.lastTenProps} />
-      )}
+      {totalProposals >= 3 ? (
+        parseInt(delegate.lastTenProps) > 5 ? (
+          <ActiveHeader outOfTen={delegate.lastTenProps} />
+        ) : (
+          <InactiveHeader outOfTen={delegate.lastTenProps} />
+        )
+      ) : null}
       <div className="flex flex-col bg-white border border-line shadow-newDefault rounded-xl">
         <div className="flex flex-col items-stretch p-4 border-b border-line">
           <DelegateProfileImage

--- a/src/lib/prismaUtils.ts
+++ b/src/lib/prismaUtils.ts
@@ -460,3 +460,40 @@ export function findStakedDeposits({
       throw new Error(`Unknown namespace: ${namespace}`);
   }
 }
+
+export function getProposalsCount({
+  namespace,
+  contract,
+}: {
+  namespace: TenantNamespace;
+  contract: string;
+}) {
+  const condition = {
+    where: {
+      contract,
+    },
+  };
+
+  switch (namespace) {
+    case TENANT_NAMESPACES.OPTIMISM:
+      return prisma.optimismProposals.count(condition);
+    case TENANT_NAMESPACES.ENS:
+      return prisma.ensProposals.count(condition);
+    case TENANT_NAMESPACES.ETHERFI:
+      return prisma.etherfiProposals.count(condition);
+    case TENANT_NAMESPACES.UNISWAP:
+      return prisma.uniswapProposals.count(condition);
+    case TENANT_NAMESPACES.CYBER:
+      return prisma.cyberProposals.count(condition);
+    case TENANT_NAMESPACES.SCROLL:
+      return prisma.scrollProposals.count(condition);
+    case TENANT_NAMESPACES.DERIVE:
+      return prisma.deriveProposals.count(condition);
+    case TENANT_NAMESPACES.PGUILD:
+      return prisma.pguildProposals.count(condition);
+    case TENANT_NAMESPACES.BOOST:
+      return prisma.boostProposals.count(condition);
+    default:
+      throw new Error(`Unknown namespace: ${namespace}`);
+  }
+}


### PR DESCRIPTION
Was playing around with Boost and noticed that I was an inactive delegate even though there were no proposals.
Added a quick helper to fetch totalPrposals efficiently, then toggle based on that. 

Boost, no inactive delegare card, because less than 3 proposals.

![CleanShot 2024-11-27 at 18 57 29@2x](https://github.com/user-attachments/assets/b95a0dbc-8321-44a4-b58d-06a660c6fdf2)

ENS, Inactive card is there, because more than 3 proposals
![CleanShot 2024-11-27 at 18 58 09@2x](https://github.com/user-attachments/assets/0dc3ea2a-c6ff-419b-85a1-67a60ab724f4)

OP, Inactive card is there, because more than 3 proposals
![CleanShot 2024-11-27 at 18 59 53@2x](https://github.com/user-attachments/assets/d7d94d85-1f5d-42b8-a9e1-95028eeaf5f2)

