### PR TITLE
Replaces all instances of hardcoded 'OP'

### DIFF
--- a/src/components/Dialogs/AdvancedDelegateDialog/SubdelegationRow.tsx
+++ b/src/components/Dialogs/AdvancedDelegateDialog/SubdelegationRow.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { useEnsName } from "wagmi";
 import { formatUnits } from "viem";
 import { useState, SetStateAction, useEffect, type Dispatch } from "react";
+import Tenant from "@/lib/tenant/tenant";
 
 function SubdelegationToRow({
   to,
@@ -21,6 +22,7 @@ function SubdelegationToRow({
   index: number;
   setOverFlowDelegation: Dispatch<SetStateAction<boolean>>;
 }) {
+  const { token } = Tenant.current();
   const [newAllowanceInput, setNewAllowanceInput] = useState("");
 
   const allowance = allowances[index];
@@ -146,7 +148,7 @@ function SubdelegationToRow({
             inputMode="numeric"
           />
           <div className="flex items-center pr-2 pl-1 w-[100px]">
-            <p>OP</p>
+            <p>{token.symbol}</p>
             <div className="bg-input w-[1px] h-6 mx-1"></div>
             <p>{percent}%</p>
           </div>

--- a/src/components/Proposals/ProposalCreation/AddTransactionsDetails.tsx
+++ b/src/components/Proposals/ProposalCreation/AddTransactionsDetails.tsx
@@ -9,6 +9,7 @@ import InputBox from "@/components/shared/InputBox";
 import { MultiButtons } from "@/components/shared/MultiButtons";
 import SimulateTransaction from "@/components/shared/SimulateTransaction";
 import { formatEther, parseUnits } from "viem";
+import Tenant from "@/lib/tenant/tenant";
 
 export default function AddTransactionsDetails({
   form,
@@ -17,6 +18,7 @@ export default function AddTransactionsDetails({
   form: Form;
   optionIndex: number;
 }) {
+  const { token } = Tenant.current();
   const addTransaction = (type: "Transfer" | "Custom") => {
     form.onChange.options(
       form.state.options.map((option, i) => {
@@ -112,10 +114,10 @@ export default function AddTransactionsDetails({
                   </VStack>
                   <VStack className="w-full">
                     <label className="text-xs text-tertiary font-semibold">
-                      Transfer amount requested (OP)
+                      Transfer amount requested ({token.symbol})
                     </label>
                     <InputBox
-                      placeholder={"3 000 000 OP"}
+                      placeholder={`3 000 000 ${token.symbol}`}
                       value={formatEther(transaction.transferAmount)}
                       type="number"
                       onChange={(next) =>

--- a/src/components/Proposals/ProposalCreation/ApprovalCriteriaRow.tsx
+++ b/src/components/Proposals/ProposalCreation/ApprovalCriteriaRow.tsx
@@ -5,8 +5,10 @@ import { HStack, VStack } from "@/components/Layout/Stack";
 import InputBox from "@/components/shared/InputBox";
 import { Switch } from "@/components/shared/Switch";
 import LabelWithInfo from "./LabelWithInfo";
+import Tenant from "@/lib/tenant/tenant";
 
 export default function ApprovalCriteriaRow({ form }: { form: Form }) {
+  const { token } = Tenant.current();
   return (
     <>
       <h4 className="pb-1 font-semibold">Approval parameters</h4>
@@ -16,12 +18,12 @@ export default function ApprovalCriteriaRow({ form }: { form: Form }) {
       </p>
       <HStack className="w-full mb-4" gap={4}>
         <VStack className="w-full">
-          <LabelWithInfo label="Budget (OP)">
+          <LabelWithInfo label={`Budget (${token.symbol})`}>
             This is the maximum number of tokens that can be transferred from
             all the options in this proposal.
           </LabelWithInfo>
           <InputBox
-            placeholder={"30 000 000 OP"}
+            placeholder={`3 000 000 ${token.symbol}`}
             value={form.state.budget}
             onChange={(next) => form.onChange.budget(next)}
             required
@@ -69,7 +71,7 @@ export default function ApprovalCriteriaRow({ form }: { form: Form }) {
               winner
             </LabelWithInfo>
             <InputBox
-              placeholder={"3 000 000 OP"}
+              placeholder={`3 000 000 ${token.symbol}`}
               value={form.state.threshold}
               type="number"
               onChange={(next) => form.onChange.threshold(next)}

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticProposalVotesCard.tsx
@@ -11,6 +11,7 @@ import { PaginatedResult } from "@/app/lib/pagination";
 import { Vote } from "@/app/api/common/votes/vote";
 import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalNonVoterList";
 import ProposalVotesFilter from "./ProposalVotesFilter";
+import Tenant from "@/lib/tenant/tenant";
 
 const OptimisticProposalVotesCard = ({
   proposal,
@@ -39,6 +40,7 @@ const OptimisticProposalVotesCard = ({
   fetchCurrentDelegators: (proposalId: string) => void;
   status: string;
 }) => {
+  const { token } = Tenant.current();
   const [isClicked, setIsClicked] = useState<boolean>(false);
   const [showVoters, setShowVoters] = useState(true);
   const handleClick = () => {
@@ -83,9 +85,9 @@ const OptimisticProposalVotesCard = ({
 
                 <p className="mt-1 font-normal text-secondary">
                   This proposal will automatically pass unless{" "}
-                  {disapprovalThreshold}% of the votable supply of OP is
-                  against. Currently {againstRelativeAmount}% (
-                  {againstLengthString} OP) is against.
+                  {disapprovalThreshold}% of the votable supply of{" "}
+                  {token.symbol} is against. Currently {againstRelativeAmount}%
+                  ({againstLengthString} {token.symbol}) is against.
                 </p>
               </div>
             )}


### PR DESCRIPTION
<img width="362" alt="Screenshot 2024-12-05 at 9 37 38 AM" src="https://github.com/user-attachments/assets/cee6d6e2-3215-4369-b67c-9f69c4a2d043">

Noticed that previous to this commit, the optimistic module on scroll said "OP". Now, we read token symbol from the tenant. See screenshot for new improvement. 

Went ahead and replaced all hardcoded 'OP' across the app.