### PR TITLE
ENG-874 -  Ignore active proposals in % Participation

### DIFF
--- a/src/app/delegates/[addressOrENSName]/page.tsx
+++ b/src/app/delegates/[addressOrENSName]/page.tsx
@@ -2,10 +2,7 @@ import { Metadata, ResolvingMetadata } from "next";
 import DelegateCard from "@/components/Delegates/DelegateCard/DelegateCard";
 import ResourceNotFound from "@/components/shared/ResourceNotFound/ResourceNotFound";
 import { fetchDelegate } from "@/app/delegates/actions";
-import {
-  fetchProposals,
-  fetchProposalsCount,
-} from "@/app/api/common/proposals/getProposals";
+import { fetchVoterStats } from "@/app/api/common/delegates/getDelegates";
 import { formatNumber } from "@/lib/tokenUtils";
 import {
   processAddressOrEnsName,
@@ -23,6 +20,10 @@ import DelegationsContainerWrapper, {
 import VotesContainerWrapper, {
   VotesContainerSkeleton,
 } from "@/components/Delegates/DelegateVotes/VotesContainerWrapper";
+import { getPublicClient } from "@/lib/viem";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 export async function generateMetadata(
   { params }: { params: { addressOrENSName: string } },
@@ -85,10 +86,15 @@ export default async function Page({
 }: {
   params: { addressOrENSName: string };
 }) {
+  const { contracts } = Tenant.current();
   const address = (await resolveENSName(addressOrENSName)) || addressOrENSName;
-  const [delegate, totalProposals] = await Promise.all([
+  const publicClient = getPublicClient(contracts.governor.chain.id);
+  const blockNumber = await publicClient.getBlockNumber({
+    cacheTime: 0,
+  });
+  const [delegate, voterStats] = await Promise.all([
     fetchDelegate(address),
-    fetchProposalsCount(),
+    fetchVoterStats(address, Number(blockNumber)),
   ]);
 
   if (!delegate) {
@@ -100,7 +106,11 @@ export default async function Page({
   return (
     <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 justify-between mt-12 w-full max-w-full">
       <div className="flex flex-col static sm:sticky top-16 shrink-0 w-full sm:max-w-xs">
-        <DelegateCard delegate={delegate} totalProposals={totalProposals} />
+        <DelegateCard
+          delegate={delegate}
+          totalProposals={Number(voterStats.total_proposals)}
+          lastTenProps={Number(voterStats.last_10_props)}
+        />
       </div>
       <div className="flex flex-col sm:ml-12 min-w-0 flex-1 max-w-full gap-8">
         <Suspense fallback={<DelegateStatementSkeleton />}>

--- a/src/app/delegates/actions.ts
+++ b/src/app/delegates/actions.ts
@@ -28,8 +28,8 @@ export async function fetchDelegate(address: string) {
   return apiFetchDelegate(address);
 }
 
-export async function fetchVoterStats(address: string) {
-  return apiFetchVoterStats(address);
+export async function fetchVoterStats(address: string, blockNumber?: number) {
+  return apiFetchVoterStats(address, blockNumber);
 }
 
 export async function fetchDelegateStatement(address: string) {

--- a/src/components/Delegates/DelegateCard/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCard/DelegateCard.tsx
@@ -64,24 +64,26 @@ const InactiveHeader = ({
 export default function DelegateCard({
   delegate,
   totalProposals,
+  lastTenProps,
 }: {
   delegate: Delegate;
   totalProposals: number;
+  lastTenProps: number;
 }) {
   const percentParticipation =
-    (parseInt(delegate.lastTenProps) / Math.min(10, totalProposals)) * 100 || 0;
+    (lastTenProps / Math.min(10, totalProposals)) * 100 || 0;
   return (
     <div className="flex flex-col sticky top-16 flex-shrink-0 width-[20rem]">
       {totalProposals >= 3 ? (
         percentParticipation > 50 ? (
           <ActiveHeader
-            outOfTen={delegate.lastTenProps}
+            outOfTen={lastTenProps.toString()}
             totalProposals={totalProposals}
             percentParticipation={percentParticipation}
           />
         ) : (
           <InactiveHeader
-            outOfTen={delegate.lastTenProps}
+            outOfTen={lastTenProps.toString()}
             totalProposals={totalProposals}
             percentParticipation={percentParticipation}
           />
@@ -104,24 +106,6 @@ export default function DelegateCard({
               title="Voting power"
               detail={formatNumber(delegate.votingPower.total)}
             />
-            {/* <PanelRow
-              title="Proposals Voted"
-              detail={
-                !delegate.proposalsVotedOn
-                  ? "N/A"
-                  : `${delegate.proposalsVotedOn} (${bpsToString(
-                      delegate.votingParticipation * 100
-                    )})`
-              }
-            /> */}
-            {/* <PanelRow
-              title="Recent activity"
-              detail={
-                delegate.lastTenProps
-                  ? `${delegate.lastTenProps} of 10 last props`
-                  : "N/A"
-              }
-            /> */}
             <PanelRow
               title="Delegated addresses"
               detail={delegate.numOfDelegators.toString()}

--- a/src/hooks/useVotingStats.tsx
+++ b/src/hooks/useVotingStats.tsx
@@ -1,9 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchVoterStats } from "@/app/delegates/actions";
+import { useBlockNumber } from "wagmi";
 
 export const useVotingStats = ({ address }: { address: `0x${string}` }) => {
+  const { data: blockNumber } = useBlockNumber();
+
   return useQuery({
+    // deliberately not including blockNumber in the query key
+    // because we don't want to re-fetch on every block number
     queryKey: ["voting-stats", address],
-    queryFn: () => fetchVoterStats(address),
+    queryFn: () => fetchVoterStats(address, Number(blockNumber)),
+    enabled: !!blockNumber,
   });
 };


### PR DESCRIPTION
Resolves issue where 10 concurrent proposals wipes out voter participation, since we are using past 10 proposals to calculate participation percentage. The fix here introduces a change to the way we calculate participation. We now only count your participation over the last ten proposals that have ended -- meaning the endBlock is in the past. 

In this PR we start migrating away from the voter_stats view, all participation based calculations now rely on a new query from agora-next - NOT a materialized view like voter_stats. We still need voter_stats for things like a count of for, against, abstain, but we may phase this view out over time since it is extremely slow.