### PR TITLE
Add cancel button

### DIFF
--- a/src/app/proposals/components/ProposalStateAdmin.tsx
+++ b/src/app/proposals/components/ProposalStateAdmin.tsx
@@ -32,7 +32,7 @@ export const ProposalStateAdmin = ({ proposal }: Props) => {
   // Only check admin for active proposals for Agora and Bravo governors.
   // This check is used to hide the entire admin bar, not just the Cancel button.
   const isCancellable =
-    proposal.status === PROPOSAL_STATUS.ACTIVE &&
+    (proposal.status === PROPOSAL_STATUS.ACTIVE || proposal.status === PROPOSAL_STATUS.QUEUED) &&
     (namespace === TENANT_NAMESPACES.CYBER ||
       namespace === TENANT_NAMESPACES.SCROLL ||
       namespace === TENANT_NAMESPACES.OPTIMISM ||
@@ -76,7 +76,7 @@ export const ProposalStateAdmin = ({ proposal }: Props) => {
         }
 
       case PROPOSAL_STATUS.QUEUED:
-        return "This proposal can be executed after the timelock passes.";
+        return "This proposal can be executed after the timelock passes, or cancelled by the admin.";
     }
   };
 
@@ -167,7 +167,12 @@ const queuedStateActions = ({ proposal, namespace }: ActionProps) => {
       return <AgoraGovExecute proposal={proposal} />;
 
     case TENANT_NAMESPACES.OPTIMISM:
-      return <AgoraOptimismGovExecute proposal={proposal} />;
+      return <div className="flex flex-row gap-2">
+                <AgoraOptimismGovCancel proposal={proposal} />
+                <AgoraOptimismGovExecute proposal={proposal} />
+             </div>;
+
+      return <AgoraOptimismGovCancel proposal={proposal} />;
 
     case TENANT_NAMESPACES.ENS:
       return <OZGovExecute proposal={proposal} />;

--- a/src/app/proposals/components/ProposalStateAdmin.tsx
+++ b/src/app/proposals/components/ProposalStateAdmin.tsx
@@ -175,8 +175,6 @@ const queuedStateActions = ({ proposal, namespace }: ActionProps) => {
         </div>
       );
 
-      return <AgoraOptimismGovCancel proposal={proposal} />;
-
     case TENANT_NAMESPACES.ENS:
       return <OZGovExecute proposal={proposal} />;
 

--- a/src/app/proposals/components/ProposalStateAdmin.tsx
+++ b/src/app/proposals/components/ProposalStateAdmin.tsx
@@ -32,7 +32,8 @@ export const ProposalStateAdmin = ({ proposal }: Props) => {
   // Only check admin for active proposals for Agora and Bravo governors.
   // This check is used to hide the entire admin bar, not just the Cancel button.
   const isCancellable =
-    (proposal.status === PROPOSAL_STATUS.ACTIVE || proposal.status === PROPOSAL_STATUS.QUEUED) &&
+    (proposal.status === PROPOSAL_STATUS.ACTIVE ||
+      proposal.status === PROPOSAL_STATUS.QUEUED) &&
     (namespace === TENANT_NAMESPACES.CYBER ||
       namespace === TENANT_NAMESPACES.SCROLL ||
       namespace === TENANT_NAMESPACES.OPTIMISM ||
@@ -167,10 +168,12 @@ const queuedStateActions = ({ proposal, namespace }: ActionProps) => {
       return <AgoraGovExecute proposal={proposal} />;
 
     case TENANT_NAMESPACES.OPTIMISM:
-      return <div className="flex flex-row gap-2">
-                <AgoraOptimismGovCancel proposal={proposal} />
-                <AgoraOptimismGovExecute proposal={proposal} />
-             </div>;
+      return (
+        <div className="flex flex-row gap-2">
+          <AgoraOptimismGovCancel proposal={proposal} />
+          <AgoraOptimismGovExecute proposal={proposal} />
+        </div>
+      );
 
       return <AgoraOptimismGovCancel proposal={proposal} />;
 


### PR DESCRIPTION
This PR adds a cancelation button in-line with the execute button, for a queued proposal awaiting the timelock to pass prior to execution.

# Before

![image](https://github.com/user-attachments/assets/1657f2c1-613d-4585-8566-3a155d20bffc)


# After

<img width="905" alt="image" src="https://github.com/user-attachments/assets/a9adb7a6-1192-4c31-af5b-ef7a1efedf36" />
