### PR TITLE
Temporary fix to the voting chart

### DIFF
--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
@@ -49,7 +49,10 @@ export default async function OPProposalApprovalPage({
 }: {
   proposal: Proposal;
 }) {
-  const proposalVotes = await fetchProposalVotes(proposal.id);
+  const proposalVotes = await fetchProposalVotes(proposal.id, {
+    limit: 500,
+    offset: 0,
+  });
   const nonVoters = await fetchVotersWhoHaveNotVotedForProposal(proposal.id);
 
   return (

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
@@ -50,7 +50,7 @@ export default async function OPProposalApprovalPage({
   proposal: Proposal;
 }) {
   const proposalVotes = await fetchProposalVotes(proposal.id, {
-    limit: 500,
+    limit: 250,
     offset: 0,
   });
   const nonVoters = await fetchVotersWhoHaveNotVotedForProposal(proposal.id);

--- a/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
@@ -56,7 +56,7 @@ async function fetchCurrentDelegators(addressOrENSName) {
 export default async function OPProposalPage({ proposal }) {
   const votableSupply = await fetchVotableSupply();
   const proposalVotes = await fetchProposalVotes(proposal.id, {
-    limit: 500,
+    limit: 250,
     offset: 0,
   });
   const nonVoters = await fetchVotersWhoHaveNotVotedForProposal(proposal.id);

--- a/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
@@ -55,7 +55,10 @@ async function fetchCurrentDelegators(addressOrENSName) {
 
 export default async function OPProposalPage({ proposal }) {
   const votableSupply = await fetchVotableSupply();
-  const proposalVotes = await fetchProposalVotes(proposal.id);
+  const proposalVotes = await fetchProposalVotes(proposal.id, {
+    limit: 500,
+    offset: 0,
+  });
   const nonVoters = await fetchVotersWhoHaveNotVotedForProposal(proposal.id);
 
   const formattedVotableSupply = Number(

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.tsx
@@ -21,28 +21,44 @@ export default function ProposalVotesBar({ proposal, votes }: Props) {
   });
 
   const hasVotes = votes.length > 0;
+  const totalVotes = votes.length;
 
   return (
     <div id="chartContainer" className="relative flex items-stretch gap-x-0.5">
       {hasVotes ? (
         <>
-          {Object.entries(voteCounts).map(([support, parsedVotes]) => (
-            <div
-              key={support} // use support as a unique key
-              style={{
-                flex: `${(proposal.proposalResults as any)[support.toLowerCase()]} 1 0%`,
-              }}
-              className="flex items-stretch gap-x-0.5 min-h-[10px]"
-            >
-              {parsedVotes?.map((vote: Vote, idx) => (
+          {totalVotes > 100
+            ? Object.entries(voteCounts).map(([support, parsedVotes]) => (
                 <div
-                  key={`${support}-${idx}`} // use a combination of support and idx as a unique key
-                  style={{ flex: `${vote.weight} 1 0%` }}
-                  className={`min-w-[1px] ${support === "FOR" ? "bg-[#41b579]" : support === "AGAINST" ? "bg-[#db5664]" : "bg-[#666666]"}`}
-                ></div>
+                  key={support} // use support as a unique key
+                  style={{
+                    flex: `${(proposal.proposalResults as any)[support.toLowerCase()]} 1 0%`,
+                  }}
+                  className="flex items-stretch gap-x-0.5 min-h-[10px]"
+                >
+                  <div
+                    style={{ flex: `1 1 0%` }}
+                    className={`min-w-[1px] ${support === "FOR" ? "bg-[#41b579]" : support === "AGAINST" ? "bg-[#db5664]" : "bg-[#666666]"}`}
+                  ></div>
+                </div>
+              ))
+            : Object.entries(voteCounts).map(([support, parsedVotes]) => (
+                <div
+                  key={support} // use support as a unique key
+                  style={{
+                    flex: `${(proposal.proposalResults as any)[support.toLowerCase()]} 1 0%`,
+                  }}
+                  className="flex items-stretch gap-x-0.5 min-h-[10px]"
+                >
+                  {parsedVotes?.map((vote: Vote, idx) => (
+                    <div
+                      key={`${support}-${idx}`} // use a combination of support and idx as a unique key
+                      style={{ flex: `${vote.weight} 1 0%` }}
+                      className={`min-w-[1px] ${support === "FOR" ? "bg-[#41b579]" : support === "AGAINST" ? "bg-[#db5664]" : "bg-[#666666]"}`}
+                    ></div>
+                  ))}
+                </div>
               ))}
-            </div>
-          ))}
         </>
       ) : (
         <div className="w-full bg-wash h-[10px]"></div>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
@@ -13,7 +13,7 @@ export default async function StandardProposalPage({
   proposal: Proposal;
 }) {
   const proposalVotes = await fetchProposalVotes(proposal.id, {
-    limit: 500,
+    limit: 250,
     offset: 0,
   });
   const nonVoters = await fetchVotersWhoHaveNotVotedForProposal(proposal.id);

--- a/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
@@ -12,8 +12,10 @@ export default async function StandardProposalPage({
 }: {
   proposal: Proposal;
 }) {
-  // TODO: Replace with governor-level check
-  const proposalVotes = await fetchProposalVotes(proposal.id);
+  const proposalVotes = await fetchProposalVotes(proposal.id, {
+    limit: 500,
+    offset: 0,
+  });
   const nonVoters = await fetchVotersWhoHaveNotVotedForProposal(proposal.id);
 
   return (

--- a/src/components/Proposals/ProposalPage/VotingTimelineChart/VotingTimelineChart.tsx
+++ b/src/components/Proposals/ProposalPage/VotingTimelineChart/VotingTimelineChart.tsx
@@ -166,7 +166,7 @@ const Chart = ({ proposal, votes }: { proposal: Proposal; votes: Vote[] }) => {
           axisLine={false}
           tickCount={6}
           interval={0}
-          width={40}
+          width={36}
           tickMargin={0}
           domain={[
             0,

--- a/src/components/Proposals/ProposalPage/VotingTimelineChart/VotingTimelineChart.tsx
+++ b/src/components/Proposals/ProposalPage/VotingTimelineChart/VotingTimelineChart.tsx
@@ -57,12 +57,13 @@ const tickFormatter = (timeStr: string, index: number) => {
 const yTickFormatter = (value: any) => {
   const roundedValue = Math.round(value);
   const isSciNotation = isScientificNotation(roundedValue.toString());
+
   return formatNumber(
     isSciNotation
       ? formatNumberWithScientificNotation(roundedValue)
       : BigInt(roundedValue),
     token.decimals,
-    4
+    roundedValue > 1_000_000 ? 2 : 4
   );
 };
 
@@ -165,7 +166,7 @@ const Chart = ({ proposal, votes }: { proposal: Proposal; votes: Vote[] }) => {
           axisLine={false}
           tickCount={6}
           interval={0}
-          width={36}
+          width={40}
           tickMargin={0}
           domain={[
             0,


### PR DESCRIPTION
Here’s the corrected version:

The problem: The voting chart displayed paginated results, so only the first page of votes was shown.

Short-term solution: Increase the page limit to 500.

Long-term solution: Update the underlying query to eliminate pagination.

<img width="1289" alt="Screenshot 2024-12-20 at 3 25 22 PM" src="https://github.com/user-attachments/assets/389907d7-957e-483c-b5cc-ba0aecb57390" />
