### PR TITLE
Upgrade votable supply to be token-contract aware - derive only

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2686,10 +2686,11 @@ view deriveStakedDeposits {
 }
 
 view deriveVotableSupply {
-  votable_supply String @unique
+  address String @unique
+  votable_supply String
 
   @@schema("derive")
-  @@map("votable_supply")
+  @@map("votable_supply_v2")
 }
 
 /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.

--- a/src/app/api/common/metrics/getMetrics.ts
+++ b/src/app/api/common/metrics/getMetrics.ts
@@ -20,7 +20,10 @@ async function getMetrics() {
       totalSupply = 0;
     }
 
-    const votableSupply = await findVotableSupply({ namespace });
+    const votableSupply = await findVotableSupply({
+      namespace,
+      address: contracts.token.address,
+    });
 
     return {
       votableSupply: votableSupply?.votable_supply || "0",

--- a/src/app/api/common/quorum/getQuorum.ts
+++ b/src/app/api/common/quorum/getQuorum.ts
@@ -37,7 +37,10 @@ async function getQuorumForProposal(proposal: ProposalPayload) {
 
       // If no quorum is set, calculate it based on votable supply
       if (!quorum) {
-        votableSupply = await findVotableSupply({ namespace });
+        votableSupply = await findVotableSupply({
+          namespace,
+          address: contracts.token.address,
+        });
         return (BigInt(Number(votableSupply?.votable_supply)) * 30n) / 100n;
       }
       return quorum;
@@ -49,7 +52,10 @@ async function getQuorumForProposal(proposal: ProposalPayload) {
       // https://voteagora.slack.com/archives/C07ATDL9P8F/p1723657375357649?thread_ts=1723579392.179389&cid=C07ATDL9P8F
       // https://voteagora.slack.com/archives/C07ATDL9P8F/p1723657834565499
 
-      votableSupply = await findVotableSupply({ namespace });
+      votableSupply = await findVotableSupply({
+        namespace,
+        address: contracts.token.address,
+      });
       return (BigInt(Number(votableSupply?.votable_supply)) * 30n) / 100n;
 
     default: // TENANT_NAMESPACES.PGUILD - yes, TENANT_NAMESPACES.SCROLL?
@@ -59,7 +65,10 @@ async function getQuorumForProposal(proposal: ProposalPayload) {
         );
       } catch {
         // this is a hack, because... // https://linear.app/agora-app/issue/AGORA-3246/quorum-isnt-known-for-proposal-before-its-snapshot
-        quorum = await findVotableSupply({ namespace });
+        quorum = await findVotableSupply({
+          namespace,
+          address: contracts.token.address,
+        });
       }
 
       return BigInt(Number(quorum));

--- a/src/app/api/common/votableSupply/getVotableSupply.ts
+++ b/src/app/api/common/votableSupply/getVotableSupply.ts
@@ -3,9 +3,10 @@ import { cache } from "react";
 import { findVotableSupply } from "@/lib/prismaUtils";
 
 async function getVotableSupply() {
-  const { namespace } = Tenant.current();
+  const { namespace, contracts } = Tenant.current();
+  const address = contracts.token.address;
   try {
-    const votableSupply = await findVotableSupply({ namespace });
+    const votableSupply = await findVotableSupply({ namespace, address });
     return votableSupply?.votable_supply || "0";
   } catch (error) {
     console.log("Error fetching votable supply:", error);

--- a/src/lib/prismaUtils.ts
+++ b/src/lib/prismaUtils.ts
@@ -85,9 +85,18 @@ export function findAdvancedDelegatee({
 
 export function findVotableSupply({
   namespace,
+  address,
 }: {
   namespace: TenantNamespace;
+  address: string;
 }) {
+  const condition = {
+    where: { address },
+    select: {
+      votable_supply: true,
+    },
+  };
+
   switch (namespace) {
     case TENANT_NAMESPACES.OPTIMISM:
       return prisma.optimismVotableSupply.findFirst({});
@@ -102,7 +111,7 @@ export function findVotableSupply({
     case TENANT_NAMESPACES.SCROLL:
       return prisma.scrollVotableSupply.findFirst({});
     case TENANT_NAMESPACES.DERIVE:
-      return prisma.deriveVotableSupply.findFirst({});
+      return prisma.deriveVotableSupply.findFirst(condition);
     case TENANT_NAMESPACES.PGUILD:
       return prisma.pguildVotableSupply.findFirst({});
     case TENANT_NAMESPACES.BOOST:


### PR DESCRIPTION
This PR upgrades `deriveVotableSupply` to be contract aware.

We need to do this for all other tenants still, but that can be safely handled in a future PR.