### PR TITLE
Updated RPC, Bundler, Paymaster paths and chain defs 

### DIFF
--- a/src/hooks/useSmartAccountDerive.ts
+++ b/src/hooks/useSmartAccountDerive.ts
@@ -23,6 +23,10 @@ import { createLightAccount, LightAccount } from "@alchemy/aa-accounts";
 import { useEffect, useState } from "react";
 import Tenant from "@/lib/tenant/tenant";
 import { fetchPaymasterData } from "@/app/api/paymaster/fetchPaymasterData";
+import {
+  DERIVE_MAINNET_RPC,
+  DERIVE_TESTNET_RPC,
+} from "@/lib/tenant/configs/contracts/derive";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const DUMB_SIGNATURE =
@@ -70,7 +74,9 @@ const lyraBundlerClient = createBundlerClient({
 
 const bundlerTransport = http(ui.smartAccountConfig?.bundlerUrl);
 const nodeTransport = http(
-  `https://rpc-prod-testnet-0eakp60405.t.conduit.xyz/${process.env.NEXT_PUBLIC_CONDUIT_KEY}`
+  process.env.NEXT_PUBLIC_AGORA_ENV === "prod"
+    ? DERIVE_MAINNET_RPC
+    : DERIVE_TESTNET_RPC
 );
 
 const dummyPaymasterAndData = (): `0x${string}` => {

--- a/src/lib/tenant/configs/contracts/derive.ts
+++ b/src/lib/tenant/configs/contracts/derive.ts
@@ -13,10 +13,15 @@ import { createTokenContract } from "@/lib/tokenUtils";
 import { Chain } from "viem/chains";
 import { DELEGATION_MODEL } from "@/lib/constants";
 
-const DERIVE_TESTNET_RPC = "https://rpc-prod-testnet-0eakp60405.t.conduit.xyz";
-const DERIVE_PROD_RPC = `https://rpc-lyra-mainnet-0.t.conduit.xyz/${process.env.NEXT_PUBLIC_CONDUIT_KEY}`;
+export const DERIVE_TESTNET_RPC =
+  "https://rpc-prod-testnet-0eakp60405.t.conduit.xyz";
+export const DERIVE_MAINNET_RPC = "https://rpc.derive.xyz";
 
-const deriveMainnet: Chain = defineChain({
+const MAINNET_BLOCK_EXPLORER = "https://explorer.derive.xyz";
+const TESTNET_BLOCK_EXPLORER =
+  "https://explorer-prod-testnet-0eakp60405.t.conduit.xyz";
+
+export const deriveMainnet: Chain = defineChain({
   id: 957,
   name: "Derive",
   network: "derive",
@@ -27,23 +32,29 @@ const deriveMainnet: Chain = defineChain({
   },
   rpcUrls: {
     default: {
-      http: [DERIVE_PROD_RPC],
-      webSocket: [DERIVE_PROD_RPC.replace("http", "ws")],
+      http: [DERIVE_MAINNET_RPC],
+      webSocket: [DERIVE_MAINNET_RPC.replace("http", "ws")],
     },
     public: {
-      http: [DERIVE_PROD_RPC],
-      webSocket: [DERIVE_PROD_RPC.replace("http", "ws")],
+      http: [DERIVE_MAINNET_RPC],
+      webSocket: [DERIVE_MAINNET_RPC.replace("http", "ws")],
     },
   },
   blockExplorers: {
     default: {
-      name: "Derive Explorer",
-      url: "https://explorer.derive.xyz/",
+      name: "Blockscout",
+      url: MAINNET_BLOCK_EXPLORER,
     },
   },
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+    },
+  },
+  testnet: false,
 });
 
-const deriveTestnet: Chain = defineChain({
+export const deriveTestnet: Chain = defineChain({
   id: 901,
   name: "Derive",
   network: "derive",
@@ -65,7 +76,7 @@ const deriveTestnet: Chain = defineChain({
   blockExplorers: {
     default: {
       name: "Blockscout",
-      url: "https://explorer-prod-testnet-0eakp60405.t.conduit.xyz",
+      url: TESTNET_BLOCK_EXPLORER,
     },
   },
   contracts: {
@@ -105,9 +116,7 @@ export const deriveTenantConfig = ({
     ? "0xd828b681F717E5a03C41540Bc6A31b146b5C1Ac6"
     : "0x98Baf5c59689a3292b365ff5Fc03b475EfeC8776";
 
-  const rpcURL = isProd
-    ? `https://rpc-prod-testnet-0eakp60405.t.conduit.xyz/${process.env.NEXT_PUBLIC_CONDUIT_KEY}`
-    : DERIVE_TESTNET_RPC;
+  const rpcURL = isProd ? DERIVE_MAINNET_RPC : DERIVE_TESTNET_RPC;
 
   const provider = new JsonRpcProvider(rpcURL);
   const chain = isProd ? deriveMainnet : deriveTestnet;

--- a/src/lib/tenant/configs/ui/derive.ts
+++ b/src/lib/tenant/configs/ui/derive.ts
@@ -56,7 +56,7 @@ export const deriveTenantUIConfig = new TenantUI({
 
   smartAccountConfig: {
     bundlerUrl: isProd
-      ? "https://bundler-lyra-mainnet-0.t.conduit.xyz"
+      ? `https://bundler-lyra-mainnet-0.t.conduit.xyz/${process.env.NEXT_PUBLIC_CONDUIT_KEY}`
       : "https://bundler-prod-testnet-0eakp60405.t.conduit.xyz",
 
     entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",

--- a/src/lib/tenant/configs/ui/derive.ts
+++ b/src/lib/tenant/configs/ui/derive.ts
@@ -55,7 +55,10 @@ export const deriveTenantUIConfig = new TenantUI({
   ],
 
   smartAccountConfig: {
-    bundlerUrl: "https://bundler-prod-testnet-0eakp60405.t.conduit.xyz",
+    bundlerUrl: isProd
+      ? "https://bundler-lyra-mainnet-0.t.conduit.xyz"
+      : "https://bundler-prod-testnet-0eakp60405.t.conduit.xyz",
+
     entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
     factoryAddress: "0x000000893A26168158fbeaDD9335Be5bC96592E2",
     paymasterAddress: isProd

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,6 +4,10 @@ import { useMemo } from "react";
 import Tenant from "./tenant/tenant";
 import { TENANT_NAMESPACES } from "./constants";
 import { http, fallback } from "wagmi";
+import {
+  DERIVE_MAINNET_RPC,
+  DERIVE_TESTNET_RPC,
+} from "@/lib/tenant/configs/contracts/derive";
 
 const { token } = Tenant.current();
 
@@ -388,17 +392,13 @@ export const getTransportForChain = (chainId: number) => {
         http("https://rpc.scroll.io"),
       ]);
 
-    // derive
+    // derive mainnet
     case 957:
-      return fallback([
-        http(
-          `https://rpc-lyra-mainnet-0.t.conduit.xyz/${process.env.NEXT_PUBLIC_CONDUIT_KEY}`
-        ),
-      ]);
+      http(DERIVE_MAINNET_RPC);
 
-    //   lyra testnet
+    // derive testnet
     case 901:
-      return http(`https://rpc-prod-testnet-0eakp60405.t.conduit.xyz`);
+      return http(DERIVE_TESTNET_RPC);
 
     // for each new dao with a new chainId add them here
     default:

--- a/src/lib/viem.ts
+++ b/src/lib/viem.ts
@@ -1,41 +1,12 @@
-import {
-  createPublicClient,
-  createWalletClient,
-  custom,
-  defineChain,
-  http,
-} from "viem";
-import { cyber, lyra, mainnet, optimism, scroll, sepolia } from "viem/chains";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { cyber, mainnet, optimism, scroll, sepolia } from "viem/chains";
 
 import "viem/window";
 import { getTransportForChain } from "./utils";
-
-export const lyraTestnet = /*#__PURE__*/ defineChain({
-  id: 901,
-  name: "Derive Testnet",
-  network: "derive testnet",
-  nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
-  rpcUrls: {
-    default: {
-      http: [
-        `https://rpc-prod-testnet-0eakp60405.t.conduit.xyz/${process.env.NEXT_PUBLIC_CONDUIT_KEY}`,
-      ],
-    },
-    public: {
-      http: [
-        `https://rpc-prod-testnet-0eakp60405.t.conduit.xyz/${process.env.NEXT_PUBLIC_CONDUIT_KEY}`,
-      ],
-    },
-  },
-  blockExplorers: {
-    default: {
-      name: "Derive Testnet Scan",
-      url: "https://explorer-prod-testnet-0eakp60405.t.conduit.xyz/",
-    },
-  },
-
-  testnet: true,
-});
+import {
+  deriveMainnet,
+  deriveTestnet,
+} from "@/lib/tenant/configs/contracts/derive";
 
 export const getWalletClient = (chainId: number) => {
   switch (chainId) {
@@ -59,15 +30,16 @@ export const getWalletClient = (chainId: number) => {
         chain: cyber,
         transport: custom(window.ethereum!),
       });
-    case lyra.id:
+
+    case deriveTestnet.id:
       return createWalletClient({
-        chain: lyra,
+        chain: deriveTestnet,
         transport: custom(window.ethereum!),
       });
 
-    case lyraTestnet.id:
+    case deriveMainnet.id:
       return createWalletClient({
-        chain: lyraTestnet,
+        chain: deriveMainnet,
         transport: custom(window.ethereum!),
       });
 
@@ -116,15 +88,15 @@ export const getPublicClient = (chainId: number) => {
         transport,
       });
 
-    case lyra.id:
+    case deriveTestnet.id:
       return createPublicClient({
-        chain: lyra,
+        chain: deriveTestnet,
         transport: http(),
       });
 
-    case lyraTestnet.id:
+    case deriveMainnet.id:
       return createPublicClient({
-        chain: lyraTestnet,
+        chain: deriveMainnet,
         transport: http(),
       });
     default:


### PR DESCRIPTION
Pulled the latest version of Derive and updated all of Agora’s paths to match it. Note: still need to confirm that the conduit key is no longer needed.