### PR TITLE
Improve speed of has-not-voted & voter-results queries

### DIFF
--- a/src/app/api/common/votes/getVotes.ts
+++ b/src/app/api/common/votes/getVotes.ts
@@ -206,9 +206,9 @@ async function getVotersWhoHaveNotVotedForProposal({
   const queryFunction = (skip: number, take: number) => {
     const notVotedQuery = `
           with has_voted as (
-              SELECT voter FROM ${namespace}.vote_cast_events WHERE proposal_id = $1 and contract = $2
+              SELECT voter FROM ${namespace}.vote_cast_events WHERE proposal_id = $1 and contract = $3
               UNION ALL
-              SELECT voter FROM ${namespace}.vote_cast_with_params_events WHERE proposal_id = $1 and contract = $2
+              SELECT voter FROM ${namespace}.vote_cast_with_params_events WHERE proposal_id = $1 and contract = $3
             ),
             relevant_delegates as (
               SELECT * FROM ${namespace}.delegates where contract = $2
@@ -224,12 +224,13 @@ async function getVotersWhoHaveNotVotedForProposal({
               del.delegate = ds.address
               AND ds.dao_slug = 'OP'
             ORDER BY del.voting_power DESC
-            OFFSET $3 LIMIT $4;`;
+            OFFSET $4 LIMIT $5;`;
 
     return prisma.$queryRawUnsafe<VotePayload[]>(
       notVotedQuery,
       proposalId,
       contracts.token.address.toLowerCase(),
+      contracts.governor.address.toLowerCase(),
       skip,
       take
     );

--- a/src/app/api/common/votes/getVotes.ts
+++ b/src/app/api/common/votes/getVotes.ts
@@ -41,11 +41,11 @@ async function getVotesForDelegateForAddress({
   const { namespace, contracts } = Tenant.current();
 
   let eventsViewName;
-  
+
   if (namespace == TENANT_NAMESPACES.OPTIMISM) {
-    eventsViewName = 'vote_cast_with_params_events_v2'
+    eventsViewName = "vote_cast_with_params_events_v2";
   } else {
-    eventsViewName = 'vote_cast_with_params_events'
+    eventsViewName = "vote_cast_with_params_events";
   }
 
   const queryFunction = (skip: number, take: number) => {
@@ -214,9 +214,9 @@ async function getVotersWhoHaveNotVotedForProposal({
   let eventsViewName;
 
   if (namespace == TENANT_NAMESPACES.OPTIMISM) {
-    eventsViewName = 'vote_cast_with_params_events_v2'
+    eventsViewName = "vote_cast_with_params_events_v2";
   } else {
-    eventsViewName = 'vote_cast_with_params_events'
+    eventsViewName = "vote_cast_with_params_events";
   }
 
   const queryFunction = (skip: number, take: number) => {
@@ -285,9 +285,9 @@ async function getVotesForProposal({
   let eventsViewName;
 
   if (namespace == TENANT_NAMESPACES.OPTIMISM) {
-    eventsViewName = 'vote_cast_with_params_events_v2'
+    eventsViewName = "vote_cast_with_params_events_v2";
   } else {
-    eventsViewName = 'vote_cast_with_params_events'
+    eventsViewName = "vote_cast_with_params_events";
   }
 
   const queryFunction = (skip: number, take: number) => {

--- a/src/app/api/common/votes/getVotes.ts
+++ b/src/app/api/common/votes/getVotes.ts
@@ -68,12 +68,12 @@ async function getVotesForDelegateForAddress({
           FROM (
             SELECT
               *
-              FROM ${namespace + ".vote_cast_events"}
+              FROM ${namespace}.vote_cast_events
               WHERE voter = $1 AND contract = $2
             UNION ALL
               SELECT
                 *
-              FROM ${namespace + ".vote_cast_with_params_events"}
+              FROM ${namespace}.vote_cast_with_params_events
               WHERE voter = $1 AND contract = $2
           ) t
           GROUP BY 2,3,4,8
@@ -85,7 +85,7 @@ async function getVotesForDelegateForAddress({
               proposals.proposal_data,
               proposals.proposal_type::config.proposal_type AS proposal_type
             FROM
-              ${namespace + ".proposals_v2"} proposals
+              ${namespace}.proposals_v2 proposals
             WHERE
               proposals.proposal_id = av.proposal_id AND proposals.contract = $2) p ON TRUE
         ) q
@@ -293,12 +293,12 @@ async function getVotesForProposal({
         FROM (
           SELECT
             *
-          FROM ${namespace + ".vote_cast_events"}
+          FROM ${namespace}.vote_cast_events
           WHERE proposal_id = $1 AND contract = $2
           UNION ALL
           SELECT
             *
-          FROM ${namespace + ".vote_cast_with_params_events"}
+          FROM ${namespace}.vote_cast_with_params_events
           WHERE proposal_id = $1 AND contract = $2
         ) t
         GROUP BY 2,3,4,8
@@ -309,7 +309,7 @@ async function getVotesForProposal({
             proposals.description,
             proposals.proposal_data,
             proposals.proposal_type::config.proposal_type AS proposal_type
-          FROM ${namespace + ".proposals_v2"} proposals
+          FROM ${namespace}.proposals_v2 proposals
           WHERE proposals.proposal_id = $1 AND proposals.contract = $2) p ON TRUE
       ) q
       ORDER BY ${sort} DESC

--- a/src/app/api/common/votes/getVotes.ts
+++ b/src/app/api/common/votes/getVotes.ts
@@ -64,8 +64,7 @@ async function getVotesForDelegateForAddress({
             SUM(weight::numeric) as weight,
             STRING_AGG(distinct reason, '\n --------- \n') as reason,
             MAX(block_number) as block_number,
-            params,
-            contract
+            params
           FROM (
             SELECT
               *
@@ -77,7 +76,7 @@ async function getVotesForDelegateForAddress({
               FROM ${namespace + ".vote_cast_with_params_events"}
               WHERE voter = $1 AND contract = $2
           ) t
-          GROUP BY 2,3,4,8,9
+          GROUP BY 2,3,4,8
           ) av
           LEFT JOIN LATERAL (
             SELECT
@@ -88,7 +87,7 @@ async function getVotesForDelegateForAddress({
             FROM
               ${namespace + ".proposals_v2"} proposals
             WHERE
-              proposals.proposal_id = av.proposal_id AND proposals.contract = av.contract) p ON TRUE
+              proposals.proposal_id = av.proposal_id AND proposals.contract = $2) p ON TRUE
         ) q
         ORDER BY block_number DESC
         OFFSET $3
@@ -290,8 +289,7 @@ async function getVotesForProposal({
           SUM(weight::numeric) as weight,
           STRING_AGG(distinct reason, '\n --------- \n') as reason,
           MAX(block_number) as block_number,
-          params,
-          contract
+          params
         FROM (
           SELECT
             *
@@ -303,7 +301,7 @@ async function getVotesForProposal({
           FROM ${namespace + ".vote_cast_with_params_events"}
           WHERE proposal_id = $1 AND contract = $2
         ) t
-        GROUP BY 2,3,4,8,9
+        GROUP BY 2,3,4,8
         ) av
         LEFT JOIN LATERAL (
           SELECT
@@ -312,7 +310,7 @@ async function getVotesForProposal({
             proposals.proposal_data,
             proposals.proposal_type::config.proposal_type AS proposal_type
           FROM ${namespace + ".proposals_v2"} proposals
-          WHERE proposals.proposal_id = $1 AND proposals.contract = av.contract) p ON TRUE
+          WHERE proposals.proposal_id = $1 AND proposals.contract = $2) p ON TRUE
       ) q
       ORDER BY ${sort} DESC
       OFFSET $3


### PR DESCRIPTION
This PR improves the speed of the has-not-voted modal.

This is the view at time of PR from PROD:

<img width="211" alt="image" src="https://github.com/user-attachments/assets/c823110a-49e2-4648-ac5d-6c1031b3fbf0" />

This is the view after the PR from local:

<img width="310" alt="image" src="https://github.com/user-attachments/assets/6404e5ef-5f44-41c9-bde3-79afc004dd5f" />

# Testing Plan
- [x] Visually inspect the pics above
- [x] Confirm performance difference in chrome console in prod
- [ ] Compare two CSVs of old and new query results without pagination
- [ ] Confirm the modal loads on Optimism, Uniswap, ENS and Scroll


