### PR TITLE
Fixes PTC on admin

### DIFF
--- a/src/app/proposals/draft/utils/stages.ts
+++ b/src/app/proposals/draft/utils/stages.ts
@@ -107,6 +107,10 @@ export const getProposalTypeAddress = (
     );
   }
 
+  if (type === ProposalType.BASIC) {
+    return ("0x" + "0".repeat(40)) as `0x${string}`;
+  }
+
   const proposalTypes = (plmToggle.config as PLMConfig).proposalTypes;
   const proposalType = proposalTypes.find((pt) => pt?.type === type);
 

--- a/src/components/Admin/GovernorSettings.tsx
+++ b/src/components/Admin/GovernorSettings.tsx
@@ -138,7 +138,7 @@ export default function GovernorSettings() {
               <Button
                 variant="outline"
                 size="sm"
-                className="absolute right-[6px] rounded-sm bg-neutral"
+                className="absolute right-[6px] rounded-sm"
                 loading={isDisabledSetVotingPeriod}
                 disabled={
                   /* isInitializing || */ isDisabledSetVotingPeriod ||

--- a/src/components/Admin/ProposalType.tsx
+++ b/src/components/Admin/ProposalType.tsx
@@ -145,7 +145,9 @@ export default function ProposalType({
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 my-4">
         <div>
           <div className="flex justify-between items-center">
-            <p className="text-sm font-semibold">Proposal type {index + 1}</p>
+            <p className="text-sm font-semibold text-secondary">
+              Proposal type {index + 1}
+            </p>
             <Button
               size="icon"
               variant="ghost"

--- a/src/components/Admin/ProposalType.tsx
+++ b/src/components/Admin/ProposalType.tsx
@@ -22,6 +22,8 @@ import {
 } from "wagmi";
 import Tenant from "@/lib/tenant/tenant";
 import { TENANT_NAMESPACES } from "@/lib/constants";
+import { getVotingModuleTypeForProposalType } from "@/lib/utils";
+import { getProposalTypeAddress } from "@/app/proposals/draft/utils/stages";
 
 type Props = {
   proposalType: ProposalType;
@@ -87,32 +89,15 @@ export default function ProposalType({
     });
 
   const formValues = form.watch();
-  const setProposalTypeArgs = [
-    BigInt(index),
-    Math.round(formValues.quorum * 100),
-    Math.round(formValues.approval_threshold * 100),
-    formValues.name,
-  ];
-
-  // TODO: Replace this with a governor-level flag
-  // TODO: Aso add proposal type configurator version flag.
-  if (namespace === TENANT_NAMESPACES.CYBER) {
-    setProposalTypeArgs.push("0x" + "0".repeat(40));
-  }
-
-  const { data: setProposalTypeConfig, isError: setProposalTypeError } =
-    useSimulateContract({
-      address: contracts.proposalTypesConfigurator!.address as `0x${string}`,
-      abi: contracts.proposalTypesConfigurator!.abi,
-      functionName: "setProposalType",
-      args: setProposalTypeArgs,
-    });
 
   const {
     data: resultSetProposalType,
     writeContract: writeSetProposalType,
     isPending: isLoadingSetProposalType,
+    isError: isErrorSetProposalType,
+    error: setProposalTypeError,
   } = useWriteContract();
+
   const { isLoading: isLoadingSetProposalTypeTransaction } =
     useWaitForTransactionReceipt({
       hash: resultSetProposalType,
@@ -125,7 +110,34 @@ export default function ProposalType({
   const isDisabled = isLoading || name == "Optimistic";
 
   function onSubmit(values: z.infer<typeof proposalTypeSchema>) {
-    writeSetProposalType(setProposalTypeConfig!.request);
+    const name = values.name;
+    const votingModuleType = getVotingModuleTypeForProposalType({
+      quorum,
+      approval_threshold,
+      name,
+    });
+
+    const proposalTypeAddress = getProposalTypeAddress(votingModuleType);
+
+    if (!proposalTypeAddress) {
+      throw new Error("Proposal type address not found");
+    }
+
+    const setProposalTypeArgs = [
+      BigInt(index),
+      Math.round(formValues.quorum * 100),
+      Math.round(formValues.approval_threshold * 100),
+      formValues.name,
+      formValues.description || "",
+      proposalTypeAddress,
+    ];
+
+    writeSetProposalType({
+      address: contracts.proposalTypesConfigurator?.address as `0x${string}`,
+      abi: contracts.proposalTypesConfigurator?.abi,
+      functionName: "setProposalType",
+      args: setProposalTypeArgs,
+    });
   }
 
   return (
@@ -133,14 +145,12 @@ export default function ProposalType({
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 my-4">
         <div>
           <div className="flex justify-between items-center">
-            <p className="text-sm font-semibold text-primary">
-              Proposal type {index + 1}
-            </p>
+            <p className="text-sm font-semibold">Proposal type {index + 1}</p>
             <Button
               size="icon"
               variant="ghost"
               className="hover:bg-destructive/10 group w-9 h-9"
-              disabled={isDisabled || setProposalTypeError}
+              disabled={isDisabled || isErrorSetProposalType}
               onClick={() => {
                 writeDeleteProposalType(deleteProposalTypeConfig!.request);
               }}
@@ -252,7 +262,7 @@ export default function ProposalType({
           className="w-full"
           variant="outline"
           loading={isLoading}
-          disabled={isDisabled || setProposalTypeError}
+          disabled={isDisabled || isErrorSetProposalType}
         >
           Set proposal type
         </Button>

--- a/src/components/Admin/ProposalTypeSettings.tsx
+++ b/src/components/Admin/ProposalTypeSettings.tsx
@@ -9,10 +9,11 @@ import ProposalType from "./ProposalType";
 import { useReadContract } from "wagmi";
 import { useAccount } from "wagmi";
 import Tenant from "@/lib/tenant/tenant";
+import { TENANT_NAMESPACES } from "@/lib/constants";
 
 const RestrictedCallout = () => {
   const { address, isConnected } = useAccount();
-  const { contracts, slug } = Tenant.current();
+  const { contracts, namespace } = Tenant.current();
 
   const { data: managerAddress } = useReadContract({
     address: contracts.governor?.address as `0x${string}`,
@@ -40,7 +41,7 @@ const RestrictedCallout = () => {
   ];
 
   // OP is is v 0.1 of agora gov and uses a different PTC that is manager and not admin based
-  if (slug === "OP") {
+  if (namespace === TENANT_NAMESPACES.OPTIMISM) {
     addressesToRender.push({
       address: managerAddress,
       label: "Manager",

--- a/src/components/Admin/ProposalTypeSettings.tsx
+++ b/src/components/Admin/ProposalTypeSettings.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { OptimismProposalTypes } from "@prisma/client";
 import ProposalType from "./ProposalType";
 import { useReadContract } from "wagmi";
-import ContractList from "@/app/info/components/ContractList";
 import { useAccount } from "wagmi";
 import Tenant from "@/lib/tenant/tenant";
 
@@ -38,17 +37,29 @@ export default function ProposalTypeSettings({
     functionName: "admin",
   }) as { data: `0x${string}` };
 
+  const { data: timelockAddress } = useReadContract({
+    address: contracts.governor?.address as `0x${string}`,
+    abi: contracts.governor.abi,
+    functionName: "timelock",
+  }) as { data: `0x${string}` };
+
   return (
     <section className="gl_box bg-neutral">
       <h1 className="font-extrabold text-2xl text-primary">
         Proposal type settings
       </h1>
-      <p>Create and manage different types of proposals</p>
-      {!!adminAddress && address !== adminAddress && (
-        <div className="text-sm w-full rounded border-2 p-4 bg-negative/10 border-negative text-negative mt-4">
+      <p className="text-secondary">
+        Create and manage different types of proposals
+      </p>
+      {(!address || address !== adminAddress) && (
+        <div className="text-sm w-[800px] rounded border-2 p-4 bg-negative/10 border-negative text-negative mt-4">
           Only the governor admin address{" "}
           <span className="font-semibold px-1 py-0.5 rounded-lg bg-negative/20">
             {adminAddress}
+          </span>{" "}
+          or the governor timelock{" "}
+          <span className="font-semibold px-1 py-0.5 rounded-lg bg-negative/20">
+            {timelockAddress}
           </span>{" "}
           can create or update proposal types. You are not currently logged in
           as the admin.
@@ -82,7 +93,7 @@ export default function ProposalTypeSettings({
         >
           <Plus className="w-3.5 h-3.5 text-neutral" />
         </Button>
-        <p className="text-sm">Add another proposal type</p>
+        <p className="text-sm text-secondary">Add another proposal type</p>
       </div>
     </section>
   );

--- a/src/components/Admin/ProposalTypeSettings.tsx
+++ b/src/components/Admin/ProposalTypeSettings.tsx
@@ -6,6 +6,10 @@ import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { OptimismProposalTypes } from "@prisma/client";
 import ProposalType from "./ProposalType";
+import { useReadContract } from "wagmi";
+import ContractList from "@/app/info/components/ContractList";
+import { useAccount } from "wagmi";
+import Tenant from "@/lib/tenant/tenant";
 
 // TODO: Take init values from the chain
 export default function ProposalTypeSettings({
@@ -15,6 +19,9 @@ export default function ProposalTypeSettings({
   votableSupply: string;
   proposalTypes: OptimismProposalTypes[];
 }) {
+  const { address } = useAccount();
+  const { contracts } = Tenant.current();
+
   const fmtPropTypes = proposalTypes.map(
     ({ quorum, approval_threshold, name }) => ({
       name,
@@ -25,14 +32,28 @@ export default function ProposalTypeSettings({
 
   const [propTypes, setPropTypes] = useState(fmtPropTypes);
 
+  const { data: adminAddress } = useReadContract({
+    address: contracts.governor?.address as `0x${string}`,
+    abi: contracts.governor.abi,
+    functionName: "admin",
+  }) as { data: `0x${string}` };
+
   return (
     <section className="gl_box bg-neutral">
       <h1 className="font-extrabold text-2xl text-primary">
         Proposal type settings
       </h1>
-      <p className="text-secondary">
-        Create and manage different types of proposals
-      </p>
+      <p>Create and manage different types of proposals</p>
+      {!!adminAddress && address !== adminAddress && (
+        <div className="text-sm w-full rounded border-2 p-4 bg-negative/10 border-negative text-negative mt-4">
+          Only the governor admin address{" "}
+          <span className="font-semibold px-1 py-0.5 rounded-lg bg-negative/20">
+            {adminAddress}
+          </span>{" "}
+          can create or update proposal types. You are not currently logged in
+          as the admin.
+        </div>
+      )}
 
       {propTypes.map((proposalType, key) => (
         <Fragment key={key}>
@@ -61,7 +82,7 @@ export default function ProposalTypeSettings({
         >
           <Plus className="w-3.5 h-3.5 text-neutral" />
         </Button>
-        <p className="text-sm text-primary">Add another proposal type</p>
+        <p className="text-sm">Add another proposal type</p>
       </div>
     </section>
   );

--- a/src/lib/contracts/abis/ProposalTypesConfigurator.json
+++ b/src/lib/contracts/abis/ProposalTypesConfigurator.json
@@ -1,149 +1,560 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "contract IOptimismGovernor",
-        "name": "governor_",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidApprovalThreshold",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidQuorum",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "NotManager",
-    "type": "error"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "proposalTypeId",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint16",
-        "name": "quorum",
-        "type": "uint16"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint16",
-        "name": "approvalThreshold",
-        "type": "uint16"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "name",
-        "type": "string"
-      }
-    ],
-    "name": "ProposalTypeSet",
-    "type": "event"
-  },
-  {
-    "inputs": [],
+    "type": "function",
     "name": "PERCENT_DIVISOR",
-    "outputs": [
-      {
-        "internalType": "uint16",
-        "name": "",
-        "type": "uint16"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [],
-    "name": "governor",
     "outputs": [
       {
-        "internalType": "contract IOptimismGovernor",
         "name": "",
-        "type": "address"
+        "type": "uint16",
+        "internalType": "uint16"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
+    "type": "function",
+    "name": "addScopeForProposalType",
     "inputs": [
       {
-        "internalType": "uint256",
         "name": "proposalTypeId",
-        "type": "uint256"
-      }
-    ],
-    "name": "proposalTypes",
-    "outputs": [
+        "type": "uint8",
+        "internalType": "uint8"
+      },
       {
+        "name": "scope",
+        "type": "tuple",
+        "internalType": "struct IProposalTypesConfigurator.Scope",
         "components": [
           {
-            "internalType": "uint16",
-            "name": "quorum",
-            "type": "uint16"
+            "name": "key",
+            "type": "bytes24",
+            "internalType": "bytes24"
           },
           {
-            "internalType": "uint16",
-            "name": "approvalThreshold",
-            "type": "uint16"
+            "name": "encodedLimits",
+            "type": "bytes",
+            "internalType": "bytes"
           },
           {
-            "internalType": "string",
-            "name": "name",
-            "type": "string"
+            "name": "parameters",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          },
+          {
+            "name": "comparators",
+            "type": "uint8[]",
+            "internalType": "enum IProposalTypesConfigurator.Comparators[]"
+          },
+          {
+            "name": "proposalTypeId",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "internalType": "string"
           }
-        ],
-        "internalType": "struct IProposalTypesConfigurator.ProposalType",
-        "name": "",
-        "type": "tuple"
+        ]
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
+    "type": "function",
+    "name": "assignedScopes",
     "inputs": [
       {
-        "internalType": "uint256",
         "name": "proposalTypeId",
-        "type": "uint256"
+        "type": "uint8",
+        "internalType": "uint8"
       },
       {
-        "internalType": "uint16",
-        "name": "quorum",
-        "type": "uint16"
-      },
-      {
-        "internalType": "uint16",
-        "name": "approvalThreshold",
-        "type": "uint16"
-      },
-      {
-        "internalType": "string",
-        "name": "name",
-        "type": "string"
+        "name": "scopeKey",
+        "type": "bytes24",
+        "internalType": "bytes24"
       }
     ],
-    "name": "setProposalType",
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct IProposalTypesConfigurator.Scope[]",
+        "components": [
+          {
+            "name": "key",
+            "type": "bytes24",
+            "internalType": "bytes24"
+          },
+          {
+            "name": "encodedLimits",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "parameters",
+            "type": "bytes[]",
+            "internalType": "bytes[]"
+          },
+          {
+            "name": "comparators",
+            "type": "uint8[]",
+            "internalType": "enum IProposalTypesConfigurator.Comparators[]"
+          },
+          {
+            "name": "proposalTypeId",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "disableScope",
+    "inputs": [
+      {
+        "name": "scopeKey",
+        "type": "bytes24",
+        "internalType": "bytes24"
+      }
+    ],
     "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "governor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IAgoraGovernor"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_governor",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_proposalTypesInit",
+        "type": "tuple[]",
+        "internalType": "struct IProposalTypesConfigurator.ProposalType[]",
+        "components": [
+          {
+            "name": "quorum",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "approvalThreshold",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "module",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "exists",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "proposalTypes",
+    "inputs": [
+      {
+        "name": "proposalTypeId",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IProposalTypesConfigurator.ProposalType",
+        "components": [
+          {
+            "name": "quorum",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "approvalThreshold",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "module",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "exists",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "scopeExists",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "bytes24",
+        "internalType": "bytes24"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setProposalType",
+    "inputs": [
+      {
+        "name": "proposalTypeId",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "quorum",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "approvalThreshold",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "module",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setScopeForProposalType",
+    "inputs": [
+      {
+        "name": "proposalTypeId",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "key",
+        "type": "bytes24",
+        "internalType": "bytes24"
+      },
+      {
+        "name": "encodedLimit",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "parameters",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "comparators",
+        "type": "uint8[]",
+        "internalType": "enum IProposalTypesConfigurator.Comparators[]"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "validateProposalData",
+    "inputs": [
+      {
+        "name": "targets",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "calldatas",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "proposalTypeId",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "validateProposedTx",
+    "inputs": [
+      {
+        "name": "proposedTx",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "proposalTypeId",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "key",
+        "type": "bytes24",
+        "internalType": "bytes24"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "ProposalTypeSet",
+    "inputs": [
+      {
+        "name": "proposalTypeId",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "quorum",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "approvalThreshold",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ScopeCreated",
+    "inputs": [
+      {
+        "name": "proposalTypeId",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "scopeKey",
+        "type": "bytes24",
+        "indexed": true,
+        "internalType": "bytes24"
+      },
+      {
+        "name": "encodedLimit",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ScopeCreated",
+    "inputs": [
+      {
+        "name": "proposalTypeId",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "scopeKey",
+        "type": "bytes24",
+        "indexed": true,
+        "internalType": "bytes24"
+      },
+      {
+        "name": "encodedLimit",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ScopeDisabled",
+    "inputs": [
+      {
+        "name": "scopeKey",
+        "type": "bytes24",
+        "indexed": true,
+        "internalType": "bytes24"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AlreadyInit",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Invalid4ByteSelector",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidApprovalThreshold",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidGovernor",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidParamNotEqual",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidParamRange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidParameterConditions",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProposalType",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProposedTxForType",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidQuorum",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidScope",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAdminOrTimelock",
+    "inputs": []
   }
 ]

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,6 +8,7 @@ import {
   DERIVE_MAINNET_RPC,
   DERIVE_TESTNET_RPC,
 } from "@/lib/tenant/configs/contracts/derive";
+import { ProposalType } from "../app/proposals/draft/types";
 
 const { token } = Tenant.current();
 
@@ -403,5 +404,19 @@ export const getTransportForChain = (chainId: number) => {
     // for each new dao with a new chainId add them here
     default:
       return null;
+  }
+};
+
+export const getVotingModuleTypeForProposalType = (proposalType: {
+  quorum: number;
+  approval_threshold: number;
+  name: string;
+}) => {
+  if (proposalType.name.toLowerCase().includes("approval")) {
+    return ProposalType.APPROVAL;
+  } else if (proposalType.name.toLowerCase().includes("optimistic")) {
+    return ProposalType.OPTIMISTIC;
+  } else {
+    return ProposalType.BASIC;
   }
 };


### PR DESCRIPTION
## Description
The original issue was "[setting proposal type in the UI hangs](https://voteagora.atlassian.net/browse/ENG-685)" --> the issue was that trying to update values on a given proposal type via the admin panel would silently crash giving the illusion that it was hanging forever.

The issue was that the ABI for the current proposalTypesConfigurator is incorrect – it’s missing the last param for setProposalType – module. 

The fix is to update the ABI and pass the module address to `setProposalType` so it does not silently crash.

I also noticed that it fails if you are not the admin of the PTC. It's not obvious who the admin is, so I added another bit of UI to show who the admin is so you know which wallet to switch to.

### Tenants that support admin route
- boost (`0xA622279f76ddbed4f2CC986c09244262Dba8f4Ba`)
- cyber (`0xCe8fe86767fCc91DAD9195831AcE8D89ac604C2e`)
- derive (`0x648BFC4dB7e43e799a84d0f607aF0b4298F932DB`)
- op (`0xe538f6f407937ffDEe9B2704F9096c31c64e63A8`)
- pguild (`0x32B6d1CCbFB75aa0d52e036488b169597f0fE3d0`)
- scroll (`0xA622279f76ddbed4f2CC986c09244262Dba8f4Ba `)

### Steps to test

- Ensure branch is rebased (only Michael has to do this)
- Go to the [op deployment](https://agora-next-optimism-git-eng-721-voteagora.vercel.app/) (I'm targeting OP because it's the only deployment where I have access to the admin/manager)
- Navigate to /admin
- Make sure you are logged in to the correct admin address above (`0xe538f6f407937ffDEe9B2704F9096c31c64e63A8`)
- Try updating the name or number values for a proposal type. You should be able to successfully update the proposal type.


### Known issues
- [x] admin panel colors are off in derive
- [x] why does OP not have an admin? Are they on a different version of Agora governor? (Answer is yes, they are on an older governor and PTC that uses `manager` instead of `admin`