### PR TITLE
Andrei/votes lazy load

### DIFF
--- a/src/app/info/components/ChartGovernanceTopDelegates.tsx
+++ b/src/app/info/components/ChartGovernanceTopDelegates.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
 import useTenantColorScheme from "@/hooks/useTenantColorScheme";
-import HumanAddress from "@/components/shared/HumanAddress";
+import ENSName from "@/components/shared/ENSName";
 
 type ChartData = {
   address: string;
@@ -67,10 +67,10 @@ const ChartGovernanceTopDelegates = ({ getData }: Props) => {
                 style={{ backgroundColor: primary }}
               />
               <div className="flex flex-col">
-                <h3 className="text-xs font-semibold text-gray-4f">
-                  <HumanAddress address={item.address} />
+                <h3 className="text-xs font-semibold text-secondary">
+                  <ENSName address={item.address} />
                 </h3>
-                <p className="text-xs font-medium text-gray-4f">
+                <p className="text-xs font-medium text-secondary">
                   {Number(item.weight).toFixed(2)}%
                 </p>
               </div>

--- a/src/app/proposals/sponsor/[id]/page.tsx
+++ b/src/app/proposals/sponsor/[id]/page.tsx
@@ -54,7 +54,7 @@ const ProposalSponsorPage = async ({ params }: { params: { id: string } }) => {
                   height={42}
                 />
 
-                <p className="font-semibold">
+                <p className="font-semibold text-primary">
                   <ENSName address={draftProposal.author_address} /> would like
                   your help to submit this proposal
                 </p>
@@ -67,8 +67,13 @@ const ProposalSponsorPage = async ({ params }: { params: { id: string } }) => {
               <p className="text-[#B16B19]/70 mt-2">
                 If you choose to do so, this proposal will be marked as
                 &apos;submitted by{" "}
-                <ENSName address={draftProposal.sponsor_address || ""} />,
-                authored by <ENSName address={draftProposal.author_address} />
+                <span className="text-primary">
+                  <ENSName address={draftProposal.sponsor_address || ""} />
+                </span>
+                , authored by{" "}
+                <span className="text-primary">
+                  <ENSName address={draftProposal.author_address} />
+                </span>
                 &apos;
               </p>
             </div>

--- a/src/app/staking/[addressOrENSName]/deposits/Deposit.tsx
+++ b/src/app/staking/[addressOrENSName]/deposits/Deposit.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
-import HumanAddress from "@/components/shared/HumanAddress";
 import React, { useEffect, useRef, useState } from "react";
 import { StakedDeposit } from "@/lib/types";
 import type { Delegate } from "@/app/api/common/delegates/delegate";
@@ -10,9 +9,9 @@ import Link from "next/link";
 import Tenant from "@/lib/tenant/tenant";
 import {
   useAccount,
-  useWriteContract,
   useSimulateContract,
   useWaitForTransactionReceipt,
+  useWriteContract,
 } from "wagmi";
 
 import { useRouter } from "next/navigation";
@@ -22,6 +21,7 @@ import { TOKEN_BALANCE_QK, useTokenBalance } from "@/hooks/useTokenBalance";
 import { DEPOSITOR_TOTAL_STAKED_QK } from "@/hooks/useDepositorTotalStaked";
 import { INDEXER_DELAY } from "@/lib/constants";
 import { TOKEN_ALLOWANCE_QK } from "@/hooks/useTokenAllowance";
+import ENSName from "@/components/shared/ENSName";
 
 interface DepositProps {
   deposit: StakedDeposit;
@@ -116,8 +116,8 @@ export const Deposit = ({
           <div className="text-xs font-medium text-gray-700">
             Vote delegated to
           </div>
-          <div className="font-medium">
-            <HumanAddress address={deposit.delegatee} />
+          <div className="font-medium text-primary">
+            <ENSName address={deposit.delegatee} />
           </div>
         </div>
 

--- a/src/app/staking/components/delegates/DelegateProfileImage.tsx
+++ b/src/app/staking/components/delegates/DelegateProfileImage.tsx
@@ -1,8 +1,8 @@
 import { useEnsName } from "wagmi";
 import { HStack, VStack } from "@/components/Layout/Stack";
 import ENSAvatar from "@/components/shared/ENSAvatar";
-import HumanAddress from "@/components/shared/HumanAddress";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
+import ENSName from "@/components/shared/ENSName";
 
 interface DelegateProfileImageProps {
   address: string;
@@ -26,8 +26,8 @@ export const DelegateProfileImage = ({
       </div>
 
       <VStack>
-        <div className="text-base font-semibold">
-          <HumanAddress address={address} />
+        <div className="text-primary font-semibold">
+          <ENSName address={address} />
         </div>
         {votingPower && (
           <div className="text-xs font-semibold text-gray-800">

--- a/src/components/Delegates/DelegateCard/DelegateProfileImage.tsx
+++ b/src/components/Delegates/DelegateCard/DelegateProfileImage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import ENSAvatar from "../../shared/ENSAvatar";
-import HumanAddress from "@/components/shared/HumanAddress";
 import CopyableHumanAddress from "../../shared/CopyableHumanAddress";
 import { useEnsName } from "wagmi";
 import { formatNumber } from "@/lib/tokenUtils";
@@ -18,6 +17,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { UIEndorsedConfig } from "@/lib/tenant/tenantUI";
+import ENSName from "@/components/shared/ENSName";
 
 interface Props {
   address: string;
@@ -92,11 +92,11 @@ export function DelegateProfileImage({
       </div>
 
       <div className="flex flex-col">
-        <div className="text-base flex flex-row gap-1 font-semibold hover:opacity-90">
+        <div className="text-primary flex flex-row gap-1 font-semibold hover:opacity-90">
           {copyable ? (
             <CopyableHumanAddress address={address} />
           ) : (
-            <HumanAddress address={address} />
+            <ENSName address={address} />
           )}
           {endorsed && hasEndorsedFilter && endorsedToggle && (
             <TooltipProvider delayDuration={0}>

--- a/src/components/Delegates/DelegateCard/SCWProfileImage.tsx
+++ b/src/components/Delegates/DelegateCard/SCWProfileImage.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import ENSAvatar from "../../shared/ENSAvatar";
-import HumanAddress from "@/components/shared/HumanAddress";
 import { formatNumber } from "@/lib/tokenUtils";
 import React from "react";
 import Tenant from "@/lib/tenant/tenant";
@@ -9,6 +7,7 @@ import { useTokenBalance } from "@/hooks/useTokenBalance";
 import CopyableHumanAddress from "@/components/shared/CopyableHumanAddress";
 import { CubeIcon } from "@/icons/CubeIcon";
 import { rgbStringToHex } from "@/app/lib/utils/color";
+import ENSName from "@/components/shared/ENSName";
 
 interface Props {
   address: string;
@@ -33,11 +32,11 @@ export function SCWProfileImage({ address, copyable = false }: Props) {
           </div>
         </div>
         <div className="flex flex-col">
-          <div className="text-base flex flex-row gap-1 font-semibold hover:opacity-90">
+          <div className="text-primary flex flex-row gap-1 font-semibold hover:opacity-90">
             {copyable ? (
               <CopyableHumanAddress address={address} />
             ) : (
-              <HumanAddress address={address} />
+              <ENSName address={address} />
             )}
           </div>
           {tokenBalance && (

--- a/src/components/Delegates/Delegations/DelegationFromRow.tsx
+++ b/src/components/Delegates/Delegations/DelegationFromRow.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { Delegation } from "@/app/api/common/delegations/delegation";
-import HumanAddress from "@/components/shared/HumanAddress";
 import { TableCell, TableRow } from "@/components/ui/table";
-import { TokenAmountDisplay } from "@/lib/utils";
+import { getBlockScanUrl, TokenAmountDisplay } from "@/lib/utils";
 import { format } from "date-fns";
 import Link from "next/link";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
-import { getBlockScanUrl } from "@/lib/utils";
+import ENSName from "@/components/shared/ENSName";
 
 export default function DelegationFromRow({
   delegation,
@@ -28,7 +27,7 @@ export default function DelegationFromRow({
           href={`/delegates/${delegation.from}`}
           title={`Address ${delegation.from}`}
         >
-          <HumanAddress address={delegation.from} />
+          <ENSName address={delegation.from} />
         </Link>
       </TableCell>
       <TableCell>

--- a/src/components/Delegates/Delegations/DelegationToRow.tsx
+++ b/src/components/Delegates/Delegations/DelegationToRow.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { Delegation } from "@/app/api/common/delegations/delegation";
-import HumanAddress from "@/components/shared/HumanAddress";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { getBlockScanUrl, TokenAmountDisplay } from "@/lib/utils";
 import { format } from "date-fns";
 import Link from "next/link";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
+import ENSName from "@/components/shared/ENSName";
 
 export default function DelegationToRow({
   delegation,
@@ -27,7 +27,7 @@ export default function DelegationToRow({
           href={`/delegates/${delegation.to}`}
           title={`Address ${delegation.to}`}
         >
-          <HumanAddress address={delegation.to} />
+          <ENSName address={delegation.to} />
         </Link>
       </TableCell>
       <TableCell>

--- a/src/components/Dialogs/AdvancedDelegateDialog/AdvancedDelegateDialog.tsx
+++ b/src/components/Dialogs/AdvancedDelegateDialog/AdvancedDelegateDialog.tsx
@@ -325,7 +325,7 @@ function InfoDialog({
           </div>
           {delegators?.map((delegator, index) => (
             <div
-              className="flex flex-row w-full items-center justify-between"
+              className="flex flex-row w-full items-center justify-between text-primary"
               key={index}
             >
               <p>

--- a/src/components/Dialogs/AdvancedDelegateDialog/SubdelegationRow.tsx
+++ b/src/components/Dialogs/AdvancedDelegateDialog/SubdelegationRow.tsx
@@ -1,11 +1,11 @@
 import { HStack, VStack } from "@/components/Layout/Stack";
 import ENSAvatar from "@/components/shared/ENSAvatar";
-import HumanAddress from "@/components/shared/HumanAddress";
 import { Input } from "@/components/ui/input";
 import { useEnsName } from "wagmi";
 import { formatUnits } from "viem";
-import { useState, SetStateAction, useEffect, type Dispatch } from "react";
+import { type Dispatch, SetStateAction, useEffect, useState } from "react";
 import Tenant from "@/lib/tenant/tenant";
+import ENSName from "@/components/shared/ENSName";
 
 function SubdelegationToRow({
   to,
@@ -131,8 +131,8 @@ function SubdelegationToRow({
           <ENSAvatar ensName={data} className="h-10 w-10" />
           <VStack>
             <p className="text-xs font-medium text-secondary">Delegated to</p>
-            <div className="w-full font-medium text-ellipsis overflow-hidden max-w-[6rem] sm:max-w-[8rem]">
-              <HumanAddress address={to} />
+            <div className="text-primary w-full font-medium text-ellipsis overflow-hidden max-w-[6rem] sm:max-w-[8rem]">
+              <ENSName address={to} />
             </div>
           </VStack>
         </HStack>

--- a/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
+++ b/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
@@ -243,7 +243,7 @@ export function DelegateDialog({
           </div>
         ) : (
           <div className="flex flex-col gap-4">
-            <p className="text-xl font-bold text-left">
+            <p className="text-xl font-bold text-left text-primary">
               Set <ENSName address={delegate.address} /> as your delegate
             </p>
             <div className="text-secondary">

--- a/src/components/Dialogs/PartialDelegateDialog/PartialDelegationEntry.tsx
+++ b/src/components/Dialogs/PartialDelegateDialog/PartialDelegationEntry.tsx
@@ -1,12 +1,12 @@
 import { Delegation } from "@/app/api/common/delegations/delegation";
 import ENSAvatar from "@/components/shared/ENSAvatar";
-import HumanAddress from "@/components/shared/HumanAddress";
 import { useEnsName } from "wagmi";
 import { Input } from "@/components/ui/input";
 import Tenant from "@/lib/tenant/tenant";
 import { formatUnits } from "viem";
 import { useEffect, useState } from "react";
 import { formatPercentageWithPrecision } from "@/lib/utils";
+import ENSName from "@/components/shared/ENSName";
 
 interface Props {
   delegation: Delegation;
@@ -56,8 +56,8 @@ export const PartialDelegationEntry = ({
         <ENSAvatar ensName={ensName} className="h-10 w-10" />
         <div className="flex flex-col">
           <div className="text-xs font-medium text-secondary">Delegated to</div>
-          <div className="w-full font-medium text-ellipsis overflow-hidden max-w-[6rem] sm:max-w-[8rem]">
-            <HumanAddress address={delegation.to} />
+          <div className="text-primary w-full font-medium text-ellipsis overflow-hidden max-w-[6rem] sm:max-w-[8rem]">
+            <ENSName address={delegation.to} />
           </div>
         </div>
       </div>

--- a/src/components/Header/DesktopProfileDropDown.tsx
+++ b/src/components/Header/DesktopProfileDropDown.tsx
@@ -6,7 +6,6 @@ import ENSAvatar from "../shared/ENSAvatar";
 import { pluralizeAddresses, shortAddress } from "@/lib/utils";
 import Link from "next/link";
 import TokenAmountDisplay from "../shared/TokenAmountDisplay";
-import HumanAddress from "../shared/HumanAddress";
 import { PanelRow } from "../Delegates/DelegateCard/DelegateCard";
 import useConnectedDelegate from "@/hooks/useConnectedDelegate";
 import Tenant from "@/lib/tenant/tenant";
@@ -23,6 +22,7 @@ import {
 import { rgbStringToHex } from "@/app/lib/utils/color";
 import { PowerIcon } from "@/icons/PowerIcon";
 import { balanceOf } from "@/app/delegates/actions";
+import ENSName from "@/components/shared/ENSName";
 
 type Props = {
   ensName: string | undefined;
@@ -81,12 +81,11 @@ export const DesktopProfileDropDown = ({ ensName }: Props) => {
       {({ open }) => (
         <>
           <Popover.Button className="flex outline-none">
-            <div className="flex items-center gap-3">
+            <div className="text-primary flex items-center gap-3">
               <div className="w-6 h-6 shadow-newDefault rounded-full">
                 <ENSAvatar ensName={ensName} />
               </div>
-
-              <HumanAddress address={address} />
+              {address && <ENSName address={address} />}
             </div>
           </Popover.Button>
 

--- a/src/components/Proposals/Proposal/Proposal.tsx
+++ b/src/components/Proposals/Proposal/Proposal.tsx
@@ -8,10 +8,10 @@ import OPOptimisticProposalStatus from "./OPOptimisticProposalStatus";
 import SnapshotProposalStatus from "./SnapshotProposalStatus";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 import Tenant from "@/lib/tenant/tenant";
-import HumanAddress from "@/components/shared/HumanAddress";
 import { TENANT_NAMESPACES } from "@/lib/constants";
 import { type Proposal } from "@/app/api/common/proposals/proposal";
 import { ParsedProposalData } from "@/lib/proposalUtils";
+import ENSName from "@/components/shared/ENSName";
 
 export default function Proposal({
   proposal,
@@ -55,7 +55,7 @@ export default function Proposal({
                     `by The ${ui.organization?.title}`
                   ) : (
                     <>
-                      by <HumanAddress address={proposal.proposer} />{" "}
+                      by <ENSName address={proposal.proposer} />{" "}
                     </>
                   )}
                 </span>

--- a/src/components/Proposals/ProposalPage/CastVoteDialog/CastVoteDialog.tsx
+++ b/src/components/Proposals/ProposalPage/CastVoteDialog/CastVoteDialog.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
-import HumanAddress from "@/components/shared/HumanAddress";
 import Image from "next/image";
 import Link from "next/link";
 import useAdvancedVoting from "../../../../hooks/useAdvancedVoting";
@@ -15,6 +13,7 @@ import useStandardVoting from "@/hooks/useStandardVoting";
 import Tenant from "@/lib/tenant/tenant";
 import { useScwVoting } from "@/hooks/useScwVoting";
 import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
+import ENSName from "@/components/shared/ENSName";
 
 export type SupportTextProps = {
   supportType: "FOR" | "AGAINST" | "ABSTAIN";
@@ -72,7 +71,7 @@ const SCWVoteDialog = ({
             <div className="flex flex-col">
               {delegate.address ? (
                 <div className="text-xs text-tertiary font-medium">
-                  <HumanAddress address={delegate.address} />
+                  <ENSName address={delegate.address} />
                 </div>
               ) : (
                 <div className="text-xs text-tertiary font-medium">
@@ -171,7 +170,7 @@ const BasicVoteDialog = ({
             <div className="flex flex-col">
               {delegate.address ? (
                 <div className="text-xs text-tertiary font-medium">
-                  <HumanAddress address={delegate.address} />
+                  <ENSName address={delegate.address} />
                 </div>
               ) : (
                 <div className="text-xs text-tertiary font-medium">
@@ -281,7 +280,7 @@ function AdvancedVoteDialog({
             <div className="flex flex-col">
               {delegate.address ? (
                 <div className="text-xs text-tertiary font-medium">
-                  <HumanAddress address={delegate.address} />
+                  <ENSName address={delegate.address} />
                 </div>
               ) : (
                 <div className="text-xs text-tertiary font-medium">

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/ApprovalVotesPanel.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/ApprovalVotesPanel.tsx
@@ -17,8 +17,6 @@ import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalN
 
 type Props = {
   proposal: Proposal;
-  initialProposalVotes: PaginatedResult<Vote[]>;
-  nonVoters: any;
   fetchVotesForProposal: (
     proposalId: string,
     pagination?: PaginationParams
@@ -41,8 +39,6 @@ type Props = {
 
 export default function ApprovalVotesPanel({
   proposal,
-  initialProposalVotes,
-  nonVoters,
   fetchVotesForProposal,
   fetchAllForVoting,
   fetchUserVotesForProposal,
@@ -95,7 +91,6 @@ export default function ApprovalVotesPanel({
             </div>
             {showVoters ? (
               <ApprovalProposalVotesList
-                initialProposalVotes={initialProposalVotes}
                 fetchVotesForProposal={fetchVotesForProposal}
                 fetchUserVotes={fetchUserVotesForProposal}
                 proposalId={proposal.id}

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/ApprovalVotesPanel.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/ApprovalVotesPanel.tsx
@@ -101,10 +101,7 @@ export default function ApprovalVotesPanel({
                 proposalId={proposal.id}
               />
             ) : (
-              <ProposalNonVoterList
-                proposal={proposal}
-                initialNonVoters={nonVoters}
-              />
+              <ProposalNonVoterList proposal={proposal} />
             )}
           </>
         )}

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
@@ -63,10 +63,7 @@ export default async function OPProposalApprovalPage({
       <ProposalStateAdmin proposal={proposal} />
 
       <div className="flex gap-16 justify-between items-start max-w-[76rem] flex-col sm:flex-row sm:items-start sm:justify-between">
-        <ProposalDescription
-          proposalVotes={proposalVotes}
-          proposal={proposal}
-        />
+        <ProposalDescription proposal={proposal} />
         <div>
           <div className="flex flex-col gap-4 sticky top-20 flex-shrink max-w-[24rem] bg-neutral border-line border rounded-xl shadow-newDefault mb-8 items-stretch sm:items-start justify-end sm:justify-between w-full max-h-none h-auto">
             <div className="flex flex-col gap-4 w-full">

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
@@ -7,7 +7,6 @@ import {
   fetchVotesForProposal,
 } from "@/app/api/common/votes/getVotes";
 import { PaginationParams } from "@/app/lib/pagination";
-import { fetchVotersWhoHaveNotVotedForProposal } from "@/app/proposals/actions";
 import { ProposalStateAdmin } from "@/app/proposals/components/ProposalStateAdmin";
 
 async function fetchProposalVotes(
@@ -49,14 +48,6 @@ export default async function OPProposalApprovalPage({
 }: {
   proposal: Proposal;
 }) {
-  const [proposalVotes, nonVoters] = await Promise.all([
-    fetchProposalVotes(proposal.id, {
-      limit: 250,
-      offset: 0,
-    }),
-    fetchVotersWhoHaveNotVotedForProposal(proposal.id),
-  ]);
-
   return (
     // 2 Colum Layout: Description on left w/ transactions and Votes / voting on the right
     <div className="flex flex-col">
@@ -70,8 +61,6 @@ export default async function OPProposalApprovalPage({
               {/* Show the results of the approval vote w/ a tab for votes */}
               <ApprovalVotesPanel
                 proposal={proposal}
-                initialProposalVotes={proposalVotes}
-                nonVoters={nonVoters}
                 fetchVotesForProposal={fetchProposalVotes}
                 fetchAllForVoting={fetchAllForVoting}
                 fetchUserVotesForProposal={fetchUserVotesForProposal}

--- a/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
@@ -85,10 +85,7 @@ export default async function OPProposalPage({ proposal }) {
     <div className="flex flex-col">
       <ProposalStateAdmin proposal={proposal} />
       <div className="flex gap-16 justify-between items-start max-w-[76rem] flex-col sm:flex-row sm:items-start sm:justify-between">
-        <ProposalDescription
-          proposalVotes={proposalVotes}
-          proposal={proposal}
-        />
+        <ProposalDescription proposal={proposal} />
         <OptimisticProposalVotesCard
           proposal={proposal}
           proposalVotes={proposalVotes}

--- a/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
@@ -6,7 +6,6 @@ import {
   fetchUserVotesForProposal as apiFetchUserVotesForProposal,
   fetchVotesForProposal,
 } from "@/app/api/common/votes/getVotes";
-import { fetchVotersWhoHaveNotVotedForProposal } from "@/app/proposals/actions";
 import { disapprovalThreshold } from "@/lib/constants";
 import { formatNumber } from "@/lib/utils";
 import { formatUnits } from "ethers";
@@ -54,14 +53,7 @@ async function fetchCurrentDelegators(addressOrENSName) {
 }
 
 export default async function OPProposalPage({ proposal }) {
-  const [votableSupply, proposalVotes, nonVoters] = await Promise.all([
-    fetchVotableSupply(),
-    fetchProposalVotes(proposal.id, {
-      limit: 250,
-      offset: 0,
-    }),
-    fetchVotersWhoHaveNotVotedForProposal(proposal.id),
-  ]);
+  const votableSupply = await fetchVotableSupply();
 
   const formattedVotableSupply = Number(
     BigInt(votableSupply) / BigInt(10 ** 18)

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.tsx
@@ -1,9 +1,10 @@
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import { Vote } from "@/app/api/common/votes/vote";
+import { Bar } from "recharts";
 
 interface Props {
   proposal: Proposal;
-  votes: Vote[];
+  votes: Vote[] | undefined;
 }
 
 type Support = "FOR" | "ABSTAIN" | "AGAINST";
@@ -15,6 +16,10 @@ export default function ProposalVotesBar({ proposal, votes }: Props) {
     ABSTAIN: [],
     AGAINST: [],
   };
+
+  if (!votes) {
+    return <BarSkeleton />;
+  }
 
   votes.forEach((vote) => {
     voteCounts[vote.support as Support].push(vote);
@@ -73,3 +78,11 @@ export default function ProposalVotesBar({ proposal, votes }: Props) {
     </div>
   );
 }
+
+const BarSkeleton = () => {
+  return (
+    <div className="flex animate-pulse">
+      <div className="w-full h-[10px] bg-tertiary/10"></div>
+    </div>
+  );
+};

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.tsx
@@ -59,7 +59,7 @@ export default function ProposalVotesBar({ proposal, votes }: Props) {
                     <div
                       key={`${support}-${idx}`} // use a combination of support and idx as a unique key
                       style={{ flex: `${vote.weight} 1 0%` }}
-                      className={`min-w-[1px] ${support === "FOR" ? "bg-positive" : support === "AGAINST" ? "bg-negative" : "bg-neutral"}`}
+                      className={`min-w-[1px] ${support === "FOR" ? "bg-positive" : support === "AGAINST" ? "bg-negative" : "bg-tertiary"}`}
                     ></div>
                   ))}
                 </div>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesBar/ProposalVotesBar.tsx
@@ -38,7 +38,7 @@ export default function ProposalVotesBar({ proposal, votes }: Props) {
                 >
                   <div
                     style={{ flex: `1 1 0%` }}
-                    className={`min-w-[1px] ${support === "FOR" ? "bg-[#41b579]" : support === "AGAINST" ? "bg-[#db5664]" : "bg-[#666666]"}`}
+                    className={`min-w-[1px] ${support === "FOR" ? "bg-positive" : support === "AGAINST" ? "bg-negative" : "bg-tertiary"}`}
                   ></div>
                 </div>
               ))
@@ -54,7 +54,7 @@ export default function ProposalVotesBar({ proposal, votes }: Props) {
                     <div
                       key={`${support}-${idx}`} // use a combination of support and idx as a unique key
                       style={{ flex: `${vote.weight} 1 0%` }}
-                      className={`min-w-[1px] ${support === "FOR" ? "bg-[#41b579]" : support === "AGAINST" ? "bg-[#db5664]" : "bg-[#666666]"}`}
+                      className={`min-w-[1px] ${support === "FOR" ? "bg-positive" : support === "AGAINST" ? "bg-negative" : "bg-neutral"}`}
                     ></div>
                   ))}
                 </div>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticProposalVotesCard.tsx
@@ -15,8 +15,6 @@ import Tenant from "@/lib/tenant/tenant";
 
 const OptimisticProposalVotesCard = ({
   proposal,
-  proposalVotes,
-  nonVoters,
   disapprovalThreshold,
   againstRelativeAmount,
   againstLengthString,
@@ -28,8 +26,6 @@ const OptimisticProposalVotesCard = ({
   status,
 }: {
   proposal: Proposal;
-  proposalVotes: any;
-  nonVoters: any;
   disapprovalThreshold: number;
   againstRelativeAmount: string;
   againstLengthString: string;
@@ -110,15 +106,9 @@ const OptimisticProposalVotesCard = ({
         </div>
         {/* Show the scrolling list of votes for the proposal */}
         {showVoters ? (
-          <ProposalVotesList
-            initialProposalVotes={proposalVotes}
-            proposalId={proposal.id}
-          />
+          <ProposalVotesList proposalId={proposal.id} />
         ) : (
-          <ProposalNonVoterList
-            proposal={proposal}
-            initialNonVoters={nonVoters}
-          />
+          <ProposalNonVoterList proposal={proposal} />
         )}
         {/* Show the input for the user to vote on a proposal if allowed */}
         <CastVoteInput proposal={proposal} isOptimistic />

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesCard.tsx
@@ -60,10 +60,7 @@ const ProposalVotesCard = ({
         </div>
 
         {showVoters ? (
-          <ProposalVotesList
-            initialProposalVotes={proposalVotes}
-            proposalId={proposal.id}
-          />
+          <ProposalVotesList proposalId={proposal.id} />
         ) : (
           <ProposalNonVoterList
             proposal={proposal}

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesCard.tsx
@@ -7,17 +7,14 @@ import CastVoteInput from "@/components/Votes/CastVoteInput/CastVoteInput";
 import { icons } from "@/assets/icons/icons";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import { PaginatedResult } from "@/app/lib/pagination";
-import { Vote } from "@/app/api/common/votes/vote";
 import ProposalVotesFilter from "./ProposalVotesFilter";
 import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalNonVoterList";
 
 const ProposalVotesCard = ({
   proposal,
-  proposalVotes,
   nonVoters,
 }: {
   proposal: Proposal;
-  proposalVotes: PaginatedResult<Vote[]>;
   nonVoters: PaginatedResult<any[]>; // TODO: add better types
 }) => {
   const [isClicked, setIsClicked] = useState(false);
@@ -45,10 +42,7 @@ const ProposalVotesCard = ({
         </button>
         <div className="flex flex-col gap-4">
           <div className="font-semibold px-4 text-primary">Proposal votes</div>
-          <ProposalVotesSummary
-            votes={proposalVotes.data}
-            proposal={proposal}
-          />
+          <ProposalVotesSummary proposal={proposal} />
           <div className="px-4">
             <ProposalVotesFilter
               initialSelection={showVoters ? "Voters" : "Hasn't voted"}

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesCard.tsx
@@ -6,17 +6,10 @@ import ProposalVotesList from "@/components/Votes/ProposalVotesList/ProposalVote
 import CastVoteInput from "@/components/Votes/CastVoteInput/CastVoteInput";
 import { icons } from "@/assets/icons/icons";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { PaginatedResult } from "@/app/lib/pagination";
 import ProposalVotesFilter from "./ProposalVotesFilter";
 import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalNonVoterList";
 
-const ProposalVotesCard = ({
-  proposal,
-  nonVoters,
-}: {
-  proposal: Proposal;
-  nonVoters: PaginatedResult<any[]>; // TODO: add better types
-}) => {
+const ProposalVotesCard = ({ proposal }: { proposal: Proposal }) => {
   const [isClicked, setIsClicked] = useState(false);
   const [showVoters, setShowVoters] = useState(true);
 
@@ -56,10 +49,7 @@ const ProposalVotesCard = ({
         {showVoters ? (
           <ProposalVotesList proposalId={proposal.id} />
         ) : (
-          <ProposalNonVoterList
-            proposal={proposal}
-            initialNonVoters={nonVoters}
-          />
+          <ProposalNonVoterList proposal={proposal} />
         )}
         {/* Show the input for the user to vote on a proposal if allowed */}
         <CastVoteInput proposal={proposal} />

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -88,21 +88,13 @@ export default function ProposalVotesSummary({ proposal }: Props) {
             side="top"
             align={"start"}
           >
-            {hasVotes ? (
-              <ProposalVotesSummaryDetails
-                proposal={proposal}
-                votes={fetchedVotes?.data}
-              />
-            ) : (
-              <LoadingState />
-            )}
+            <ProposalVotesSummaryDetails
+              proposal={proposal}
+              votes={fetchedVotes?.data}
+            />
           </HoverCardContent>
         </HoverCardTrigger>
       </div>
     </HoverCard>
   );
 }
-
-const LoadingState = () => {
-  return <div className="text-secondary text-xs">Loading</div>;
-};

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -11,18 +11,26 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import ProposalVotesSummaryDetails from "../ProposalVotesSummaryDetails/ProposalVotesSummaryDetails";
-import { Vote } from "@/app/api/common/votes/vote";
+import { useProposalVotes } from "@/hooks/useProposalVotes";
 
 interface Props {
   proposal: Proposal;
-  votes: Vote[];
 }
 
-export default function ProposalVotesSummary({ proposal, votes }: Props) {
+export default function ProposalVotesSummary({ proposal }: Props) {
   const [showDetails, setShowDetails] = useState(false);
 
   const results =
     proposal.proposalResults as ParsedProposalResults["STANDARD"]["kind"];
+
+  const { data: fetchedVotes, isFetched } = useProposalVotes({
+    proposalId: proposal.id,
+    limit: 250,
+    offset: 0,
+    enabled: true,
+  });
+
+  const hasVotes = fetchedVotes && isFetched;
 
   return (
     <HoverCard
@@ -42,7 +50,10 @@ export default function ProposalVotesSummary({ proposal, votes }: Props) {
                 AGAINST <TokenAmountDisplay amount={results.against} />
               </div>
             </div>
-            <ProposalVotesBar proposal={proposal} votes={votes} />
+            {hasVotes && (
+              <ProposalVotesBar proposal={proposal} votes={fetchedVotes.data} />
+            )}
+
             <div className="flex flex-col font-medium">
               <div className="flex flex-row text-secondary pb-2 justify-between">
                 <>
@@ -77,10 +88,21 @@ export default function ProposalVotesSummary({ proposal, votes }: Props) {
             side="top"
             align={"start"}
           >
-            <ProposalVotesSummaryDetails proposal={proposal} votes={votes} />
+            {hasVotes ? (
+              <ProposalVotesSummaryDetails
+                proposal={proposal}
+                votes={fetchedVotes?.data}
+              />
+            ) : (
+              <LoadingState />
+            )}
           </HoverCardContent>
         </HoverCardTrigger>
       </div>
     </HoverCard>
   );
 }
+
+const LoadingState = () => {
+  return <div className="text-secondary text-xs">Loading</div>;
+};

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -30,8 +30,6 @@ export default function ProposalVotesSummary({ proposal }: Props) {
     proposalId: proposal.id,
   });
 
-  const hasVotes = fetchedVotes && isFetched;
-
   return (
     <HoverCard
       open={showDetails}
@@ -50,9 +48,8 @@ export default function ProposalVotesSummary({ proposal }: Props) {
                 AGAINST <TokenAmountDisplay amount={results.against} />
               </div>
             </div>
-            {hasVotes && (
-              <ProposalVotesBar proposal={proposal} votes={fetchedVotes.data} />
-            )}
+
+            <ProposalVotesBar proposal={proposal} votes={fetchedVotes?.data} />
 
             <div className="flex flex-col font-medium">
               <div className="flex flex-row text-secondary pb-2 justify-between">

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -24,10 +24,10 @@ export default function ProposalVotesSummary({ proposal }: Props) {
     proposal.proposalResults as ParsedProposalResults["STANDARD"]["kind"];
 
   const { data: fetchedVotes, isFetched } = useProposalVotes({
-    proposalId: proposal.id,
+    enabled: true,
     limit: 250,
     offset: 0,
-    enabled: true,
+    proposalId: proposal.id,
   });
 
   const hasVotes = fetchedVotes && isFetched;

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummaryDetails/ProposalVotesSummaryDetails.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummaryDetails/ProposalVotesSummaryDetails.tsx
@@ -33,7 +33,7 @@ export default function ProposalVotesSummaryDetails({
   votes,
 }: {
   proposal: Proposal;
-  votes: Vote[];
+  votes?: Vote[];
 }) {
   const { token, namespace } = Tenant.current();
   const results =
@@ -81,7 +81,8 @@ export default function ProposalVotesSummaryDetails({
 
   return (
     <div className="flex flex-col font-inter font-semibold text-xs w-full max-w-[317px] sm:min-w-[317px] bg-wash">
-      <ProposalVotesBar proposal={proposal} votes={votes} />
+      {votes && <ProposalVotesBar proposal={proposal} votes={votes} />}
+
       <div className="flex flex-col gap-2 w-full mt-4">
         <div className="flex justify-between text-positive">
           FOR <AmountAndPercent amount={results.for} total={totalVotes} />

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummaryDetails/ProposalVotesSummaryDetails.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummaryDetails/ProposalVotesSummaryDetails.tsx
@@ -81,7 +81,7 @@ export default function ProposalVotesSummaryDetails({
 
   return (
     <div className="flex flex-col font-inter font-semibold text-xs w-full max-w-[317px] sm:min-w-[317px] bg-wash">
-      {votes && <ProposalVotesBar proposal={proposal} votes={votes} />}
+      <ProposalVotesBar proposal={proposal} votes={votes} />
 
       <div className="flex flex-col gap-2 w-full mt-4">
         <div className="flex justify-between text-positive">

--- a/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
@@ -24,10 +24,7 @@ export default async function StandardProposalPage({
     <div className="flex flex-col">
       <ProposalStateAdmin proposal={proposal} />
       <div className="flex gap-16 justify-between items-start max-w-[76rem] flex-col sm:flex-row sm:items-start sm:justify-between">
-        <ProposalDescription
-          proposalVotes={proposalVotes}
-          proposal={proposal}
-        />
+        <ProposalDescription proposal={proposal} />
         <div>
           <ProposalVotesCard
             proposal={proposal}

--- a/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
@@ -12,13 +12,7 @@ export default async function StandardProposalPage({
 }: {
   proposal: Proposal;
 }) {
-  const [proposalVotes, nonVoters] = await Promise.all([
-    fetchProposalVotes(proposal.id, {
-      limit: 250,
-      offset: 0,
-    }),
-    fetchVotersWhoHaveNotVotedForProposal(proposal.id),
-  ]);
+  const nonVoters = await fetchVotersWhoHaveNotVotedForProposal(proposal.id);
 
   return (
     <div className="flex flex-col">
@@ -26,11 +20,7 @@ export default async function StandardProposalPage({
       <div className="flex gap-16 justify-between items-start max-w-[76rem] flex-col sm:flex-row sm:items-start sm:justify-between">
         <ProposalDescription proposal={proposal} />
         <div>
-          <ProposalVotesCard
-            proposal={proposal}
-            proposalVotes={proposalVotes}
-            nonVoters={nonVoters}
-          />
+          <ProposalVotesCard proposal={proposal} nonVoters={nonVoters} />
         </div>
       </div>
     </div>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/StandardProposalPage.tsx
@@ -1,9 +1,5 @@
 import ProposalDescription from "../ProposalDescription/ProposalDescription";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import {
-  fetchProposalVotes,
-  fetchVotersWhoHaveNotVotedForProposal,
-} from "@/app/proposals/actions";
 import ProposalVotesCard from "./ProposalVotesCard/ProposalVotesCard";
 import { ProposalStateAdmin } from "@/app/proposals/components/ProposalStateAdmin";
 
@@ -12,15 +8,13 @@ export default async function StandardProposalPage({
 }: {
   proposal: Proposal;
 }) {
-  const nonVoters = await fetchVotersWhoHaveNotVotedForProposal(proposal.id);
-
   return (
     <div className="flex flex-col">
       <ProposalStateAdmin proposal={proposal} />
       <div className="flex gap-16 justify-between items-start max-w-[76rem] flex-col sm:flex-row sm:items-start sm:justify-between">
         <ProposalDescription proposal={proposal} />
         <div>
-          <ProposalVotesCard proposal={proposal} nonVoters={nonVoters} />
+          <ProposalVotesCard proposal={proposal} />
         </div>
       </div>
     </div>

--- a/src/components/Proposals/ProposalPage/ProposalChart/ProposalChart.tsx
+++ b/src/components/Proposals/ProposalPage/ProposalChart/ProposalChart.tsx
@@ -74,12 +74,20 @@ export default function ProposalChart({ proposal }: { proposal: Proposal }) {
               )}
             </div>
           ) : (
-            <div className="text-secondary text-xs">
-              {"Loading chart data..."}
-            </div>
+            <ChartSkeleton />
           )}
         </>
       )}
     </div>
   );
 }
+
+const ChartSkeleton = () => {
+  return (
+    <div className="flex anumate-pulse">
+      <div className="flex h-[230px] w-full bg-tertiary/10 rounded-md items-center justify-center text-xs text-secondary">
+        {"Loading chart data..."}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Proposals/ProposalPage/ProposalChart/ProposalChart.tsx
+++ b/src/components/Proposals/ProposalPage/ProposalChart/ProposalChart.tsx
@@ -13,10 +13,10 @@ export default function ProposalChart({ proposal }: { proposal: Proposal }) {
   const [showChart, setShowChart] = useState(proposal.status === "ACTIVE");
 
   const { data: fetchedVotes, isFetched } = useProposalVotes({
-    proposalId: proposal.id,
+    enabled: showChart,
     limit: 250,
     offset: 0,
-    enabled: showChart,
+    proposalId: proposal.id,
   });
 
   const handleTabsChange = (index: number) => {

--- a/src/components/Proposals/ProposalPage/ProposalChart/ProposalChart.tsx
+++ b/src/components/Proposals/ProposalPage/ProposalChart/ProposalChart.tsx
@@ -14,7 +14,7 @@ export default function ProposalChart({ proposal }: { proposal: Proposal }) {
 
   const { data: fetchedVotes, isFetched } = useProposalVotes({
     proposalId: proposal.id,
-    limit: 500,
+    limit: 250,
     offset: 0,
     enabled: showChart,
   });

--- a/src/components/Proposals/ProposalPage/ProposalDescription/ProposalDescription.tsx
+++ b/src/components/Proposals/ProposalPage/ProposalDescription/ProposalDescription.tsx
@@ -6,16 +6,12 @@ import ApprovedTransactions from "../ApprovedTransactions/ApprovedTransactions";
 import ProposalTransactionDisplay from "../ApprovedTransactions/ProposalTransactionDisplay";
 import ProposalChart from "../ProposalChart/ProposalChart";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { Vote } from "@/app/api/common/votes/vote";
-import { PaginatedResult } from "@/app/lib/pagination";
 import Markdown from "@/components/shared/Markdown/Markdown";
 
 export default function ProposalDescription({
   proposal,
-  proposalVotes,
 }: {
   proposal: Proposal;
-  proposalVotes: PaginatedResult<Vote[]>;
 }) {
   const proposalsWithBadDescription = [
     "94365805422398770067924881378455503928423439630602149628781926844759467250082",

--- a/src/components/Proposals/ProposalPage/ProposalDescription/ProposalDescription.tsx
+++ b/src/components/Proposals/ProposalPage/ProposalDescription/ProposalDescription.tsx
@@ -59,7 +59,7 @@ export default function ProposalDescription({
   return (
     <div className={`flex flex-col gap-4 ${styles.proposal_description}`}>
       <ProposalTitle title={shortTitle} proposal={proposal} />
-      <ProposalChart proposal={proposal} proposalVotes={proposalVotes} />
+      <ProposalChart proposal={proposal} />
 
       <div className="flex flex-col gap-2">
         {/* Right now I'm only sure this better decoded component works for standard proposals */}

--- a/src/components/Proposals/ProposalPage/ProposalTitle/ProposalTitle.tsx
+++ b/src/components/Proposals/ProposalPage/ProposalTitle/ProposalTitle.tsx
@@ -1,9 +1,9 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 import { getBlockScanUrl, getProposalTypeText } from "@/lib/utils";
 import Tenant from "@/lib/tenant/tenant";
-import HumanAddress from "@/components/shared/HumanAddress";
 import { TENANT_NAMESPACES } from "@/lib/constants";
 import { Proposal } from "@/app/api/common/proposals/proposal";
+import ENSName from "@/components/shared/ENSName";
 
 export default function ProposalTitle({
   title,
@@ -24,7 +24,7 @@ export default function ProposalTitle({
         ) : (
           <>
             &nbsp;
-            <HumanAddress address={proposal.proposer} />{" "}
+            <ENSName address={proposal.proposer} />{" "}
           </>
         )}
         <a

--- a/src/components/Proposals/ProposalPage/TreeMapChart/TreeMapChart.tsx
+++ b/src/components/Proposals/ProposalPage/TreeMapChart/TreeMapChart.tsx
@@ -5,6 +5,9 @@ import { Proposal } from "@/app/api/common/proposals/proposal";
 import { Vote } from "@/app/api/common/votes/vote";
 import ENSName from "@/components/shared/ENSName";
 import { PaginatedResult } from "@/app/lib/pagination";
+import Tenant from "@/lib/tenant/tenant";
+import { rgbStringToHex } from "@/app/lib/utils/color";
+
 /**
  * Transforms an array of votes into chart data suitable for a treemap.
  */
@@ -42,10 +45,8 @@ const Chart = ({ proposal, votes }: { proposal: Proposal; votes: Vote[] }) => {
         data={chartData.children}
         dataKey="value"
         nameKey="name"
-        stroke="#fff"
-        fill="#8884d8"
         content={<CustomContent />}
-        isAnimationActive={false} // Disable animation on load
+        isAnimationActive={false}
       >
         <Tooltip content={<CustomTooltip />} isAnimationActive={false} />
       </Treemap>
@@ -56,34 +57,28 @@ const Chart = ({ proposal, votes }: { proposal: Proposal; votes: Vote[] }) => {
 const CustomTooltip = ({ payload }: any) => {
   if (payload && payload.length) {
     return (
-      <div className="bg-stone-700 text-neutral p-1 text-xs rounded">
+      <div className="bg-neutral text-primary text-xs rounded border border-line px-3 py-2">
         <ENSName address={payload[0].payload.address} />
       </div>
     );
   }
   return (
-    <div
-      style={{
-        backgroundColor: "black",
-        color: "white",
-        padding: "5px",
-        borderRadius: "3px",
-      }}
-    >
+    <div className="bg-wash text-primary p-1 text-xs rounded border border-line">
       No address
     </div>
   );
 };
 
 const CustomContent = (props: any) => {
-  const { x, y, width, height, support, address, value } = props;
+  const { x, y, width, height, support, address } = props;
+  const { ui } = Tenant.current();
+
   const fillColor =
     support === "AGAINST"
-      ? "#FA2D28"
+      ? rgbStringToHex(ui.customization?.negative)
       : support === "FOR"
-        ? "#23BF6B"
-        : "#959595"; // Red for AGAINST, Green for FOR, Grey for ABSTAIN
-
+        ? rgbStringToHex(ui.customization?.positive)
+        : rgbStringToHex(ui.customization?.tertiary);
   return (
     <g>
       <rect
@@ -91,22 +86,22 @@ const CustomContent = (props: any) => {
         y={y}
         width={width}
         height={height}
-        style={{ fill: fillColor, stroke: "#fff" }}
+        style={{
+          fill: fillColor,
+          stroke: rgbStringToHex(ui.customization?.neutral),
+        }}
       ></rect>
       {width * height > 1600 && (
         <foreignObject x={x} y={y} width={width} height={height}>
           <div
+            className={"text-neutral text-xs items-center justify-center"}
             style={{
               width: "100%",
               height: "100%",
               display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
               overflow: "hidden",
               textOverflow: "ellipsis",
               whiteSpace: "nowrap",
-              color: "white",
-              fontSize: "x-small",
             }}
           >
             {address && <ENSName address={address} />}

--- a/src/components/Proposals/ProposalPage/VotingTimelineChart/VotingTimelineChart.tsx
+++ b/src/components/Proposals/ProposalPage/VotingTimelineChart/VotingTimelineChart.tsx
@@ -22,8 +22,9 @@ import {
 import { PaginatedResult } from "@/app/lib/pagination";
 import { DaoSlug } from "@prisma/client";
 import { TENANT_NAMESPACES } from "@/lib/constants";
+import { rgbStringToHex } from "@/app/lib/utils/color";
 
-const { token, slug } = Tenant.current();
+const { token, slug, ui } = Tenant.current();
 
 /**
  * Transforms an array of votes into chart data.
@@ -233,7 +234,11 @@ const Chart = ({ proposal, votes }: { proposal: Proposal; votes: Vote[] }) => {
     <div className="relative">
       <ResponsiveContainer width="100%" height={230}>
         <AreaChart data={modifiedChartData}>
-          <CartesianGrid vertical={false} strokeDasharray={"3 3"} />
+          <CartesianGrid
+            vertical={false}
+            strokeDasharray={"3 3"}
+            stroke={rgbStringToHex(ui.customization?.tertiary)}
+          />
           <XAxis
             dataKey="timestamp"
             axisLine={false}
@@ -246,13 +251,13 @@ const Chart = ({ proposal, votes }: { proposal: Proposal; votes: Vote[] }) => {
             tickFormatter={tickFormatter}
             tick={customizedXTick}
             className="text-xs font-inter font-semibold text-primary/30"
-            fill={"#AFAFAF"}
+            fill={rgbStringToHex(ui.customization?.tertiary)}
           />
 
           <YAxis
             className="text-xs font-inter font-semibold fill:text-primary/30 fill"
             tick={{
-              fill: "#AFAFAF",
+              fill: rgbStringToHex(ui.customization?.tertiary),
             }}
             tickFormatter={yTickFormatter}
             tickLine={false}
@@ -281,24 +286,24 @@ const Chart = ({ proposal, votes }: { proposal: Proposal; votes: Vote[] }) => {
             type="step"
             dataKey="against"
             stackId={stackIds.against}
-            stroke="#dc2626"
-            fill="#fecaca"
+            stroke={rgbStringToHex(ui.customization?.negative)}
+            fill={rgbStringToHex(ui.customization?.negative)}
             name="Against"
           />
           <Area
             type="step"
             dataKey="abstain"
             stackId={stackIds.abstain}
-            stroke="#57534e"
-            fill="#e7e5e4"
+            stroke={rgbStringToHex(ui.customization?.tertiary)}
+            fill={rgbStringToHex(ui.customization?.tertiary)}
             name="Abstain"
           />
           <Area
             type="step"
             dataKey="for"
             stackId={stackIds.for}
-            stroke="#16a34a"
-            fill="#bbf7d0"
+            stroke={rgbStringToHex(ui.customization?.positive)}
+            fill={rgbStringToHex(ui.customization?.positive)}
             name="For"
           />
         </AreaChart>

--- a/src/components/RetroPGF/RetroPGFApplicationBanner.tsx
+++ b/src/components/RetroPGF/RetroPGFApplicationBanner.tsx
@@ -1,11 +1,10 @@
 import { HStack, VStack } from "@/components/Layout/Stack";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 import { type RetroPGFProject } from "@/lib/types";
-import { cn } from "@/lib/utils";
+import { capitalizeFirstLetter, cn } from "@/lib/utils";
 import Image from "next/image";
 import projectPlaceholder from "@/icons/projectPlaceholder.svg";
-import HumanAddress from "@/components/shared/HumanAddress";
-import { capitalizeFirstLetter } from "@/lib/utils";
+import ENSName from "@/components/shared/ENSName";
 
 function extractWebsiteName(urlString: string): string {
   try {
@@ -78,7 +77,7 @@ export default function RetroPGFApplicationBanner({
                     {capitalizeFirstLetter(applicantType)}
                   </p>
                   <div className="bg-wash py-0 px-3 rounded-[24px]">
-                    <HumanAddress address={applicant.address.address} />
+                    <ENSName address={applicant.address.address} />
                   </div>
                   <div className="bg-wash py-0 px-3 rounded-[24px]">
                     <a href={websiteUrl} rel="noreferrer" target="_blank">

--- a/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalSingleVote.tsx
+++ b/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalSingleVote.tsx
@@ -4,7 +4,6 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { HStack, VStack } from "@/components/Layout/Stack";
-import HumanAddress from "@/components/shared/HumanAddress";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import { useAccount } from "wagmi";
 import { type Vote } from "@/app/api/common/votes/vote";
@@ -15,6 +14,7 @@ import useIsAdvancedUser from "@/app/lib/hooks/useIsAdvancedUser";
 import useConnectedDelegate from "@/hooks/useConnectedDelegate";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 import ENSAvatar from "@/components/shared/ENSAvatar";
+import ENSName from "@/components/shared/ENSName";
 
 export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
   const { isAdvancedUser } = useIsAdvancedUser();
@@ -55,7 +55,7 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
           >
             <div className="text-primary font-semibold flex items-center">
               <ENSAvatar ensName={voterAddress} className="w-5 h-5 mr-1" />
-              <HumanAddress address={voterAddress} />
+              <ENSName address={voterAddress} />
               {address?.toLowerCase() === voterAddress && (
                 <span>&nbsp;(you)</span>
               )}

--- a/src/components/Votes/ProposalVotesList/ProposalNonVoterList.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalNonVoterList.tsx
@@ -1,28 +1,41 @@
 "use client";
 
-import { useRef, useState, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { PaginatedResult } from "@/app/lib/pagination";
 import { fetchVotersWhoHaveNotVotedForProposal } from "@/app/proposals/actions";
 import InfiniteScroll from "react-infinite-scroller";
 import { ProposalSingleNonVoter } from "./ProposalSingleNonVoter";
 import { Proposal } from "@/app/api/common/proposals/proposal";
+import { useProposalNonVotes } from "@/hooks/useProposalNonVotes";
+import { Vote } from "@/app/api/common/votes/vote";
 
-const ProposalNonVoterList = ({
-  proposal,
-  initialNonVoters,
-}: {
-  proposal: Proposal;
-  initialNonVoters: PaginatedResult<any[]>; // TODO: add better types
-}) => {
+const LIMIT = 20;
+
+const ProposalNonVoterList = ({ proposal }: { proposal: Proposal }) => {
+  const { data: fetchedNonVotes, isFetched } = useProposalNonVotes({
+    enabled: true,
+    limit: LIMIT,
+    offset: 0,
+    proposalId: proposal.id,
+  });
+
   const fetching = useRef(false);
-  const [pages, setPages] = useState([initialNonVoters]);
-  const [meta, setMeta] = useState(initialNonVoters.meta);
+  const [pages, setPages] = useState<PaginatedResult<any[]>[]>([]);
+  const [meta, setMeta] = useState<PaginatedResult<Vote[]>["meta"]>();
+
+  // Set the initial votes list
+  useEffect(() => {
+    if (isFetched && fetchedNonVotes) {
+      setPages([fetchedNonVotes]);
+      setMeta(fetchedNonVotes.meta);
+    }
+  }, [fetchedNonVotes, isFetched]);
 
   const loadMore = useCallback(async () => {
-    if (!fetching.current && meta.has_next) {
+    if (!fetching.current && meta?.has_next) {
       fetching.current = true;
       const data = await fetchVotersWhoHaveNotVotedForProposal(proposal.id, {
-        limit: 20,
+        limit: LIMIT,
         offset: meta.next_offset,
       });
       setPages((prev) => [...prev, { ...data, votes: data.data }]);
@@ -35,26 +48,30 @@ const ProposalNonVoterList = ({
 
   return (
     <div className="px-4 pb-4 overflow-y-scroll max-h-[calc(100vh-437px)]">
-      <InfiniteScroll
-        hasMore={meta.has_next}
-        pageStart={0}
-        loadMore={loadMore}
-        useWindow={false}
-        loader={
-          <div className="flex text-xs font-medium text-secondary" key={0}>
-            Loading more voters...
-          </div>
-        }
-        element="main"
-      >
-        <ul className="flex flex-col gap-2">
-          {voters.map((voter) => (
-            <li key={voter.delegate} className="">
-              <ProposalSingleNonVoter voter={voter} proposal={proposal} />
-            </li>
-          ))}
-        </ul>
-      </InfiniteScroll>
+      {isFetched && fetchedNonVotes ? (
+        <InfiniteScroll
+          hasMore={meta?.has_next}
+          pageStart={0}
+          loadMore={loadMore}
+          useWindow={false}
+          loader={
+            <div className="flex text-xs font-medium text-secondary" key={0}>
+              Loading more voters...
+            </div>
+          }
+          element="main"
+        >
+          <ul className="flex flex-col gap-2">
+            {voters.map((voter) => (
+              <li key={voter.delegate} className="">
+                <ProposalSingleNonVoter voter={voter} proposal={proposal} />
+              </li>
+            ))}
+          </ul>
+        </InfiniteScroll>
+      ) : (
+        <div className="text-secondary text-xs">Loading...</div>
+      )}
     </div>
   );
 };

--- a/src/components/Votes/ProposalVotesList/ProposalSingleNonVoter.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalSingleNonVoter.tsx
@@ -1,8 +1,7 @@
-import { VStack, HStack } from "@/components/Layout/Stack";
-import HumanAddress from "@/components/shared/HumanAddress";
+import { HStack, VStack } from "@/components/Layout/Stack";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import ENSAvatar from "@/components/shared/ENSAvatar";
-import { useEnsName, useAccount } from "wagmi";
+import { useAccount, useEnsName } from "wagmi";
 import discordIcon from "@/icons/discord.svg";
 import xIcon from "@/icons/x.svg";
 import warpcastIcon from "@/icons/warpcast.svg";
@@ -12,6 +11,7 @@ import { useGetVotes } from "@/hooks/useGetVotes";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import Tenant from "@/lib/tenant/tenant";
 import { TENANT_NAMESPACES } from "@/lib/constants";
+import ENSName from "@/components/shared/ENSName";
 
 export function ProposalSingleNonVoter({
   voter,
@@ -52,7 +52,7 @@ export function ProposalSingleNonVoter({
       >
         <HStack gap={1} alignItems="items-center">
           <ENSAvatar ensName={data} className="w-5 h-5" />
-          <HumanAddress address={voter.delegate} />
+          <ENSName address={voter.delegate} />
           {voter.delegate === connectedAddress?.toLowerCase() && <p>(you)</p>}
           {voter.twitter && (
             <button

--- a/src/components/Votes/ProposalVotesList/ProposalSingleVote.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalSingleVote.tsx
@@ -1,12 +1,11 @@
 import { Vote } from "@/app/api/common/votes/vote";
-import { useAccount } from "wagmi";
+import { useAccount, useEnsName } from "wagmi";
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import { VStack, HStack } from "@/components/Layout/Stack";
-import HumanAddress from "@/components/shared/HumanAddress";
+import { HStack, VStack } from "@/components/Layout/Stack";
 import TokenAmountDisplay from "@/components/shared/TokenAmountDisplay";
 import VoteText from "../VoteText/VoteText";
 import VoterHoverCard from "../VoterHoverCard";
@@ -14,7 +13,7 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 import { getBlockScanUrl, timeout } from "@/lib/utils";
 import { useState } from "react";
 import ENSAvatar from "@/components/shared/ENSAvatar";
-import { useEnsName } from "wagmi";
+import ENSName from "@/components/shared/ENSName";
 
 export function ProposalSingleVote({
   vote,
@@ -62,7 +61,7 @@ export function ProposalSingleVote({
             >
               <HStack gap={1} alignItems="items-center">
                 <ENSAvatar ensName={data} className="w-5 h-5" />
-                <HumanAddress address={vote.address} />
+                <ENSName address={vote.address} />
                 {vote.address === connectedAddress?.toLowerCase() && (
                   <p>(you)</p>
                 )}

--- a/src/components/Votes/ProposalVotesList/ProposalVotesList.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalVotesList.tsx
@@ -12,19 +12,29 @@ import {
 } from "@/app/proposals/actions";
 import useConnectedDelegate from "@/hooks/useConnectedDelegate";
 import { PaginatedResult } from "@/app/lib/pagination";
+import { useProposalVotes } from "@/hooks/useProposalVotes";
 
-export default function ProposalVotesList({
-  initialProposalVotes,
-  proposalId,
-}: {
-  initialProposalVotes: PaginatedResult<Vote[]>;
+interface Props {
   proposalId: string;
-}) {
+}
+
+const LIMIT = 100;
+
+export default function ProposalVotesList({ proposalId }: Props) {
+  const { data: fetchedVotes, isFetched } = useProposalVotes({
+    proposalId: proposalId,
+    limit: LIMIT,
+    offset: 0,
+    enabled: true,
+  });
+
   const { address: connectedAddress } = useAccount();
   const { advancedDelegators } = useConnectedDelegate();
   const fetching = useRef(false);
-  const [pages, setPages] = useState([initialProposalVotes]);
-  const [meta, setMeta] = useState(initialProposalVotes.meta);
+
+  const [pages, setPages] = useState<PaginatedResult<Vote[]>[]>([]);
+  const [meta, setMeta] = useState<PaginatedResult<Vote[]>["meta"]>();
+
   const [userVotes, setUserVotes] = useState<Vote[]>([]);
 
   const fetchUserVoteAndSet = useCallback(
@@ -40,6 +50,14 @@ export default function ProposalVotesList({
     []
   );
 
+  // Set the initial votes list
+  useEffect(() => {
+    if (isFetched && fetchedVotes) {
+      setPages([fetchedVotes]);
+      setMeta(fetchedVotes.meta);
+    }
+  }, [fetchedVotes, isFetched]);
+
   useEffect(() => {
     if (connectedAddress) {
       fetchUserVoteAndSet(proposalId, connectedAddress);
@@ -48,16 +66,13 @@ export default function ProposalVotesList({
     }
   }, [connectedAddress, fetchUserVoteAndSet, proposalId]);
 
-  const proposalVotes = pages.reduce(
-    (all, page) => all.concat(page.data),
-    [] as Vote[]
-  );
+  const proposalVotes = pages.flatMap((page) => page.data);
 
   const loadMore = useCallback(async () => {
-    if (!fetching.current && meta.has_next) {
+    if (!fetching.current && meta?.has_next) {
       fetching.current = true;
       const data = await fetchProposalVotes(proposalId, {
-        limit: 20,
+        limit: LIMIT,
         offset: meta.next_offset,
       });
       setPages((prev) => [...prev, { ...data, votes: data.data }]);
@@ -71,7 +86,7 @@ export default function ProposalVotesList({
   return (
     <div className="px-4 pb-4 overflow-y-scroll max-h-[calc(100vh-437px)]">
       <InfiniteScroll
-        hasMore={meta.has_next}
+        hasMore={meta?.has_next}
         pageStart={0}
         loadMore={loadMore}
         useWindow={false}

--- a/src/components/Votes/ProposalVotesList/ProposalVotesList.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalVotesList.tsx
@@ -18,14 +18,14 @@ interface Props {
   proposalId: string;
 }
 
-const LIMIT = 100;
+const LIMIT = 20;
 
 export default function ProposalVotesList({ proposalId }: Props) {
   const { data: fetchedVotes, isFetched } = useProposalVotes({
-    proposalId: proposalId,
+    enabled: true,
     limit: LIMIT,
     offset: 0,
-    enabled: true,
+    proposalId: proposalId,
   });
 
   const { address: connectedAddress } = useAccount();
@@ -85,44 +85,48 @@ export default function ProposalVotesList({ proposalId }: Props) {
 
   return (
     <div className="px-4 pb-4 overflow-y-scroll max-h-[calc(100vh-437px)]">
-      <InfiniteScroll
-        hasMore={meta?.has_next}
-        pageStart={0}
-        loadMore={loadMore}
-        useWindow={false}
-        loader={
-          <div className="flex text-xs font-medium text-secondary" key={0}>
-            Loading more votes...
-          </div>
-        }
-        element="main"
-      >
-        <ul className="flex flex-col">
-          {userVotes.map((vote) => (
-            <li key={vote.transactionHash}>
-              <ProposalSingleVote
-                vote={vote}
-                isAdvancedUser={isAdvancedUser}
-                delegators={advancedDelegators}
-              />
-            </li>
-          ))}
-          {proposalVotes.map((vote) => (
-            <li
-              key={vote.transactionHash}
-              className={`${
-                connectedAddress?.toLowerCase() === vote.address && "hidden"
-              }`}
-            >
-              <ProposalSingleVote
-                vote={vote}
-                isAdvancedUser={isAdvancedUser}
-                delegators={advancedDelegators}
-              />
-            </li>
-          ))}
-        </ul>
-      </InfiniteScroll>
+      {isFetched && fetchedVotes ? (
+        <InfiniteScroll
+          hasMore={meta?.has_next}
+          pageStart={0}
+          loadMore={loadMore}
+          useWindow={false}
+          loader={
+            <div className="flex text-xs font-medium text-secondary" key={0}>
+              Loading more votes...
+            </div>
+          }
+          element="main"
+        >
+          <ul className="flex flex-col">
+            {userVotes.map((vote) => (
+              <li key={vote.transactionHash}>
+                <ProposalSingleVote
+                  vote={vote}
+                  isAdvancedUser={isAdvancedUser}
+                  delegators={advancedDelegators}
+                />
+              </li>
+            ))}
+            {proposalVotes.map((vote) => (
+              <li
+                key={vote.transactionHash}
+                className={`${
+                  connectedAddress?.toLowerCase() === vote.address && "hidden"
+                }`}
+              >
+                <ProposalSingleVote
+                  vote={vote}
+                  isAdvancedUser={isAdvancedUser}
+                  delegators={advancedDelegators}
+                />
+              </li>
+            ))}
+          </ul>
+        </InfiniteScroll>
+      ) : (
+        <div className="text-secondary text-xs">Loading...</div>
+      )}
     </div>
   );
 }

--- a/src/components/shared/ENSName.tsx
+++ b/src/components/shared/ENSName.tsx
@@ -21,7 +21,7 @@ const ENSName = ({ address }: { address: string | `0x${string}` }) => {
     }
   }, [data, address]);
 
-  return <span className="text-primary">{ensName}</span>;
+  return <span>{ensName}</span>;
 };
 
 export default ENSName;

--- a/src/components/shared/HumanAddress.jsx
+++ b/src/components/shared/HumanAddress.jsx
@@ -1,8 +1,0 @@
-import ENSName from "./ENSName"; // adjust the import path as per your project structure
-
-// This component will display the ENS name for a given address
-function HumanAddress({ address }) {
-  return <ENSName address={address} />;
-}
-
-export default HumanAddress;

--- a/src/hooks/useProposalNonVotes.ts
+++ b/src/hooks/useProposalNonVotes.ts
@@ -19,14 +19,14 @@ export const useProposalNonVotes = ({
 }: Props) => {
   const { data, isFetching, isFetched } = useQuery({
     enabled: enabled,
-    queryKey: [QK, proposalId],
+    queryKey: [QK, proposalId, offset],
     queryFn: async () => {
       return (await fetchVotersWhoHaveNotVotedForProposal(proposalId, {
         offset: offset || 0,
         limit: limit || 20,
       })) as PaginatedResult<any[]>;
     },
-    staleTime: 180000, // 3 minute cache
+    staleTime: 30000, // 30 second cache
   });
 
   return { data, isFetching, isFetched, queryKey: QK };

--- a/src/hooks/useProposalNonVotes.ts
+++ b/src/hooks/useProposalNonVotes.ts
@@ -1,8 +1,6 @@
-import { fetchProposalVotes } from "@/app/proposals/actions";
-
 import { useQuery } from "@tanstack/react-query";
 import { PaginatedResult } from "@/app/lib/pagination";
-import { Vote } from "@/app/api/common/votes/vote";
+import { fetchVotersWhoHaveNotVotedForProposal } from "@/app/proposals/actions";
 
 interface Props {
   enabled: boolean;
@@ -11,9 +9,9 @@ interface Props {
   proposalId: string;
 }
 
-const QK = "votes";
+const QK = "nonvotes";
 
-export const useProposalVotes = ({
+export const useProposalNonVotes = ({
   enabled,
   limit,
   offset,
@@ -21,14 +19,14 @@ export const useProposalVotes = ({
 }: Props) => {
   const { data, isFetching, isFetched } = useQuery({
     enabled: enabled,
-    queryKey: [QK, proposalId, offset],
+    queryKey: [QK, proposalId],
     queryFn: async () => {
-      return (await fetchProposalVotes(proposalId, {
-        limit: limit || 20,
+      return (await fetchVotersWhoHaveNotVotedForProposal(proposalId, {
         offset: offset || 0,
-      })) as PaginatedResult<Vote[]>;
+        limit: limit || 20,
+      })) as PaginatedResult<any[]>;
     },
-    staleTime: 60000, // 1 minute cache
+    staleTime: 180000, // 3 minute cache
   });
 
   return { data, isFetching, isFetched, queryKey: QK };

--- a/src/hooks/useProposalVotes.ts
+++ b/src/hooks/useProposalVotes.ts
@@ -1,0 +1,35 @@
+import { fetchProposalVotes } from "@/app/proposals/actions";
+
+import { useQuery } from "@tanstack/react-query";
+import { PaginatedResult } from "@/app/lib/pagination";
+import { Vote } from "@/app/api/common/votes/vote";
+
+interface Props {
+  proposalId: string;
+  limit?: number;
+  offset?: number;
+  enabled: boolean;
+}
+
+const QK = "votes";
+
+export const useProposalVotes = ({
+  proposalId,
+  limit,
+  offset,
+  enabled,
+}: Props) => {
+  const { data, isFetching, isFetched } = useQuery({
+    enabled: enabled,
+    queryKey: [QK, proposalId, offset],
+    queryFn: async () => {
+      return (await fetchProposalVotes(proposalId, {
+        limit: limit || 250,
+        offset: offset || 0,
+      })) as PaginatedResult<Vote[]>;
+    },
+    staleTime: 60000, // 1 minute cache
+  });
+
+  return { data, isFetching, isFetched, queryKey: QK };
+};


### PR DESCRIPTION
All vote and non-vote data requests have been moved to the client. The UI progressively enhances as data is received. All queries are cached to prevent duplicate requests. The votes `cache` is shared across charts, the votes list is cached under a different key. 

I also updated the following 
- treemap chart uses tenant styles 
- linechart uses treemap tenant 
- removed style from the ENSName component to a part component

<img width="1274" alt="Screenshot 2025-01-15 at 4 04 49 PM" src="https://github.com/user-attachments/assets/a2f9b523-5d84-4408-a9bb-dedda9a6ef66" />
