### PR TITLE
Added the Approval Options back to the past votes

### DIFF
--- a/src/lib/voteUtils.ts
+++ b/src/lib/voteUtils.ts
@@ -16,6 +16,7 @@ import { VotingPowerData } from "@/app/api/common/voting-power/votingPower";
 import Tenant from "@/lib/tenant/tenant";
 import { TENANT_NAMESPACES } from "@/lib/constants";
 import { Block } from "ethers";
+import { AbiCoder } from "ethers";
 
 /**
  * Vote primitives
@@ -118,12 +119,20 @@ export function parseParams(
   }
 
   try {
-    const parsedParams = JSON.parse(params);
-    return parsedParams[0].map((param: string) => {
-      const idx = Number(param);
+    const hexParams = params.startsWith("0x") ? params : `0x${params}`;
+
+    const decoded = new AbiCoder().decode(["uint256[]"], hexParams);
+
+    const selectedOptions = decoded[0];
+
+    const result = selectedOptions.map((optionIndex: bigint) => {
+      const idx = Number(optionIndex);
       return proposalData.kind.options[idx].description;
     });
+
+    return result;
   } catch (e) {
+    console.error("Error decoding params:", e);
     return null;
   }
 }


### PR DESCRIPTION
Alright, this is a strange one. This was reported by a Discord user. 

![CleanShot 2025-01-24 at 00 35 00@2x](https://github.com/user-attachments/assets/9900aafc-0d51-4f1e-8414-3a04249b7b4d)

On the approval vote, the options you voted for didn't show up. This used to work, but I can't find it in Git blame (probably there but eyes are hurting). 

So, the prolem was really simple, the `params` data for an approval vote is HEX encoded, and we were trying to parse the JSON directly, so it was going to `null` when passed to the client. 

This PR fixes this. 

![CleanShot 2025-01-24 at 01 18 16@2x](https://github.com/user-attachments/assets/248cb15b-f0d8-4102-9ff4-d57f3b048f4d)
