### PR TITLE
Add Uniswap delegate code of conduct link

### DIFF
--- a/src/lib/tenant/configs/ui/uniswap.ts
+++ b/src/lib/tenant/configs/ui/uniswap.ts
@@ -45,6 +45,11 @@ export const uniswapTenantUIConfig = new TenantUI({
       title: "Change log",
       url: "/changelog",
     },
+    {
+      name: "code-of-conduct",
+      title: "Delegate Code of Conduct",
+      url: "https://gov.uniswap.org/t/rfc-delegate-code-of-conduct/20913",
+    },
   ],
 
   governanceStakeholders: [


### PR DESCRIPTION
Uniswap had the "delegates/code-of-conduct" toggle enabled but no link for "code-of-conduct" causing the label to not be displayed due to the missing link.

![image](https://github.com/user-attachments/assets/5407cba8-4ca4-4cab-b85f-3a0dcc6e726f)

Checked all others and Uniswap is the only one with these conditions.

This PR fixes this.

