### PR TITLE
Updates stale voting states loading states (ENG-1022)

### DIFF
--- a/src/components/Delegates/DelegateCardList/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCard.tsx
@@ -57,11 +57,13 @@ const DelegateCard = ({
               <span className="text-primary font-bold">
                 {formatNumber(delegate.votingPower.total)} {token.symbol}
               </span>
-              {numProposals > 0 && !isVotingStatsPending && (
+              {!isVotingStatsPending && (
                 <span className="text-primary font-bold">
-                  {((votingStats?.last_10_props || 0) /
-                    Math.min(10, numProposals)) *
-                    100 || "0"}
+                  {numProposals === 0
+                    ? "0"
+                    : ((votingStats?.last_10_props || 0) /
+                        Math.min(10, numProposals)) *
+                      100}
                   % Participation
                 </span>
               )}

--- a/src/components/Delegates/DelegateCardList/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCard.tsx
@@ -57,13 +57,11 @@ const DelegateCard = ({
               <span className="text-primary font-bold">
                 {formatNumber(delegate.votingPower.total)} {token.symbol}
               </span>
-              {!isVotingStatsPending && (
+              {numProposals > 0 && !isVotingStatsPending && (
                 <span className="text-primary font-bold">
-                  {numProposals === 0
-                    ? "0"
-                    : ((votingStats?.last_10_props || 0) /
-                        Math.min(10, numProposals)) *
-                      100}
+                  {((votingStats?.last_10_props || 0) /
+                    Math.min(10, numProposals)) *
+                    100}
                   % Participation
                 </span>
               )}


### PR DESCRIPTION
## Description 
Resolves the issue of some voter participation numbers number showing up, even after minutes of waiting. The issue was twofold -- the `voterStats` query was returning no record if the voter had never voted yet, which meant that the voter stats data fetch returned 0 for the field `num_proposals`. `num_proposals` was intended to be the number of proposals submitted to the tenant, so even if the voter had never voted, this should still return the correct number. The reason is that the UI was then looking at this response, and if `num_proposals` was 0 it was skipping over the render and showing nothing. This was to prevent div/by/zero. 

The fix here is two-fold
1. fix the query to return correct num_proposals even if the voter has never voted
2. ~~return 0 instead of nothing if num_proposals truly is zero.~~ Following the JIRA thread, I see Brennan mention that if there are no proposals in the tenant, we should hide voter stats. So I'm removing this "fix"

## Test cases
- [ ] open the preview branch and prod and compare numbers to make sure the query did not alter the response
- [ ] check a few delegate profiles to make sure the responses are fine there as well, and are matching the numbers shown on the voter page.
- [ ] make sure a tenant with no proposals (do we have any of these?) hides voter stats rather than showing 0%.