### PR TITLE
Adds dev badge

### DIFF
--- a/src/components/Header/LogoLink.jsx
+++ b/src/components/Header/LogoLink.jsx
@@ -32,7 +32,7 @@ export default function LogoLink() {
           <>
             <div className="h-3 w-[2px] bg-line rounded-full hidden sm:block"></div>
             <span className="hidden sm:block font-semibold text-primary bg-tertiary/10 px-1.5 py-0.5 rounded-lg text-xs border border-line">
-              DEV MODE
+              Test contracts mode
             </span>
           </>
         )}

--- a/src/components/Header/LogoLink.jsx
+++ b/src/components/Header/LogoLink.jsx
@@ -6,7 +6,7 @@ import { AgoraIcon } from "@/icons/AgoraIcon";
 import { rgbStringToHex } from "@/app/lib/utils/color";
 
 export default function LogoLink() {
-  const { namespace, ui } = Tenant.current();
+  const { namespace, ui, isProd } = Tenant.current();
 
   return (
     <Link href="/" className="flex flex-row justify-between w-full">
@@ -27,7 +27,15 @@ export default function LogoLink() {
           height="24"
           className="h-[24px] w-auto"
         />
-        <span className="hidden sm:block font-medium text-primary flex-1">{`${ui.title}`}</span>
+        <span className="hidden sm:block font-medium text-primary">{`${ui.title}`}</span>
+        {!isProd && (
+          <>
+            <div className="h-3 w-[2px] bg-line rounded-full hidden sm:block"></div>
+            <span className="hidden sm:block font-semibold text-primary bg-tertiary/10 px-1.5 py-0.5 rounded-lg text-xs border border-line">
+              DEV MODE
+            </span>
+          </>
+        )}
       </div>
     </Link>
   );


### PR DESCRIPTION
Adds badge to header when in a dev environment. Jeff made the suggestion somewhere in Slack. The idea is that it's not always clear if we are on prod or dev, especially when on a preview branch. This badge helps us know for certain which environment we are on.

<img width="1705" alt="Screenshot 2025-01-28 at 10 27 21 AM" src="https://github.com/user-attachments/assets/30751d78-80ec-4f3b-952e-d83c82e3fbc3" />
