### PR TITLE
Resolves delegation analytics fixes

### DIFF
--- a/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
+++ b/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
@@ -121,7 +121,9 @@ export function DelegateDialog({
         event_data: {
           delegate: delegate.address as `0x${string}`,
           delegator: accountAddress as `0x${string}`,
-          transaction_hash: delegateTxHash as `0x${string}`,
+          transaction_hash: (isGasRelayLive
+            ? sponsoredTxnHash
+            : delegateTxHash) as `0x${string}`,
         },
       });
     }

--- a/src/hooks/useSponsoredDelegation.ts
+++ b/src/hooks/useSponsoredDelegation.ts
@@ -85,22 +85,6 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
 
     const hash = await response.json();
 
-    const { status } = await waitForTransactionReceipt(config, {
-      hash: hash,
-      chainId: contracts.governor.chain.id,
-    });
-
-    if (status === "success") {
-      trackEvent({
-        event_name: ANALYTICS_EVENT_NAMES.DELEGATE,
-        event_data: {
-          delegate: delegate.address as `0x${string}`,
-          delegator: address as `0x${string}`,
-          transaction_hash: hash,
-        },
-      });
-    }
-
     setTxHash(hash);
     setIsFetching(false);
     setIsFetched(true);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -27,8 +27,12 @@ class DatabaseAnalytics implements AnalyticsService {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify(event, (_, value) =>
-        typeof value === "bigint" ? value.toString() : value
+      body: JSON.stringify(event, (key, value) =>
+        value === undefined
+          ? null // Convert undefined to null to preserve the key, otherwise JSON.stringify will remove it
+          : typeof value === "bigint"
+            ? value.toString()
+            : value
       ),
     });
   }


### PR DESCRIPTION
## Description
Resolves two issues we were seeing with analytics:

- Some events were being tracked twice
- Some events were missing transaction hash

The issue came from the same place -- the sponsored (gas relay) delegation was counting events, and the regular delegation dialog was counting events, so they got counted twice. However, the dialog was trying to include the non-sponsored txHash, which didn't exist in the context of a sponsored delegation. When we were sending the event to the database, we used a fetch call, and needed to stringify the event so it could be sent across the wire. To do this, we used `JSON.stringify`, which I did not realize will remove all keys with undefined as a value. 

The fix is to....
- remove the double tracking
- add either sponsored OR nonsponsored txHash to the delegation dialog tracking event. Whichever exists at the time.
- Update the `JSON.stringify` method to preserve keys with undefined values by changing undefined to null.

**The good news here is that this only affected our gas sponsored tenants, so UNI and ENS. Right now it seems like it only affected our tests records, and we should be able to purge the db of these records. Its small enough we can clean it up manually in a few minutes.**

## Tests
- [ ] try delegating on gas sponsored tenant (UNI) make sure only a single event is logged with txHash
- [ ] try delegating on non gas sponsored tenant (OP) make sure only a single event is logged with txHash