### PR TITLE
Fix cancelled button not clickable

### DIFF
--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesSummary/ProposalVotesSummary.tsx
@@ -30,8 +30,8 @@ export default function ProposalVotesSummary({ proposal }: Props) {
       closeDelay={0}
     >
       <div style={{ position: "relative" }}>
-        <HoverCardTrigger className="w-full cursor-pointer block">
-          <div className="flex flex-col gap-2 pt-2 px-4 rounded-md font-bold shrink-0 text-xs border border-line mx-4 shadow-newDefault">
+        <div className="flex flex-col rounded-md font-bold shrink-0 text-xs border border-line mx-4 shadow-newDefault">
+          <HoverCardTrigger className="w-full cursor-pointer flex flex-col gap-2 px-4 pt-2">
             <div className="flex flex-row justify-between mt-2">
               <div className="text-positive">
                 FOR <TokenAmountDisplay amount={results.for} />
@@ -62,24 +62,27 @@ export default function ProposalVotesSummary({ proposal }: Props) {
                   )}
                 </>
               </div>
-              <ProposalStatusDetail
-                proposalStartTime={proposal.startTime}
-                proposalEndTime={proposal.endTime}
-                proposalStatus={proposal.status}
-                proposalCancelledTime={proposal.cancelledTime}
-                cancelledTransactionHash={proposal.cancelledTransactionHash}
-              />
             </div>
-          </div>
+          </HoverCardTrigger>
 
-          <HoverCardContent
-            className="pb-0 absolute w-auto ml-4 mt-1"
-            side="top"
-            align={"start"}
-          >
-            <ProposalVotesSummaryDetails proposal={proposal} />
-          </HoverCardContent>
-        </HoverCardTrigger>
+          <div className="px-4 font-medium">
+            <ProposalStatusDetail
+              proposalStartTime={proposal.startTime}
+              proposalEndTime={proposal.endTime}
+              proposalStatus={proposal.status}
+              proposalCancelledTime={proposal.cancelledTime}
+              cancelledTransactionHash={proposal.cancelledTransactionHash}
+            />
+          </div>
+        </div>
+
+        <HoverCardContent
+          className="pb-0 absolute w-auto mt-1"
+          side="top"
+          align={"start"}
+        >
+          <ProposalVotesSummaryDetails proposal={proposal} />
+        </HoverCardContent>
       </div>
     </HoverCard>
   );


### PR DESCRIPTION
Tested on https://agora-next-optimism-ylst9502a-voteagora.vercel.app/proposals/88081957117197857131618413056069851464239155680037310590555441907734514873482

The fix implemented here was to basically just remove the bottom section of the card from the hoverTrigger allowing the cancelled button to be clickable. Another option would be to display the modal in the bottom instead of on top of the card.

Chose first option due to lower risk/impact but can switch to option 2 if we decide that it's better.