### PR TITLE
Fix errors with etherfi getVoterStats in the getDelegates endpoint

### DIFF
--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -568,7 +568,7 @@ async function getVoterStats(
         SELECT proposal_id
         FROM ${namespace}.proposals_v2
         WHERE contract = $2
-        AND end_block::INTEGER <= $3
+        AND NULLIF(end_block, '')::INTEGER <= $3
         AND cancelled_block IS NULL
         ORDER BY ordinal DESC
         LIMIT 10


### PR DESCRIPTION
I was poking around vercel and noticed high rates for etherfi. The delegates endpoint has been failing with: 

ERROR: invalid input syntax for type integer: ""

https://vercel.com/voteagora/agora-next-etherfi/logs?selectedLogId=8rw5r-1738242692108-05fb0c2ea531

This seems to be due to handling of empty strings from the db, however when looking at the db proposals_v2 is either not there or an empty material view. This is because etherfi is snapshot so we aren't indexing their proposals but the error is a bit strange given that context. Maybe I am not looking at the right table/view.

