### PR TITLE
Fix calendar description not working correctly

### DIFF
--- a/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
+++ b/src/components/Proposals/CurrentGovernanceStage/CurrentGovernanceStage.tsx
@@ -4,11 +4,16 @@ export default function CurrentGovernanceStage({
   title,
   endDate,
   reviewPeriod,
+  votingPeriod,
 }: {
   title: string;
   endDate: string;
   reviewPeriod: boolean;
+  votingPeriod: boolean;
 }) {
+  const showVotingCommand = votingPeriod || reviewPeriod;
+  const startString = showVotingCommand ? "starts" : "Starts";
+  const endString = showVotingCommand ? "ends" : "Ends";
   return (
     <div className="flex items-center justify-between bg-wash text-secondary text-xs px-6 pt-2 pb-6 -mb-5 border border-line border-b-0 rounded-tl-2xl rounded-tr-2xl">
       <div className="flex flex-col sm:flex-row">
@@ -18,7 +23,8 @@ export default function CurrentGovernanceStage({
         </div>
         <span className="hidden sm:block">&nbsp;·&nbsp;</span>
         <span>
-          Voting {reviewPeriod ? "starts" : "ends"} on {endDate}
+          {showVotingCommand ? "Voting " : ""}
+          {reviewPeriod ? startString : endString} on {endDate}
         </span>
       </div>
       <a

--- a/src/components/Proposals/ProposalsList/ProposalsList.tsx
+++ b/src/components/Proposals/ProposalsList/ProposalsList.tsx
@@ -33,6 +33,7 @@ export default function ProposalsList({
     title: string;
     endDate: string;
     reviewPeriod: boolean;
+    votingPeriod: boolean;
   } | null;
 }) {
   const { address } = useAccount();
@@ -92,6 +93,7 @@ export default function ProposalsList({
           title={governanceCalendar.title}
           endDate={governanceCalendar.endDate}
           reviewPeriod={governanceCalendar.reviewPeriod}
+          votingPeriod={governanceCalendar.votingPeriod}
         />
       )}
       <div className="flex flex-col bg-neutral border border-line rounded-lg shadow-newDefault overflow-hidden">


### PR DESCRIPTION
Issue was happening due to ICS file lines not being correctly parsed. The summary wasn't being correctly set.

Check for reference the source calendar: https://calendar.google.com/calendar/u/0/embed?src=c_fnmtguh6noo6qgbni2gperid4k@group.calendar.google.com

### 2024-10-10

Before:
![CleanShot 2025-01-30 at 10  02 00@2x](https://github.com/user-attachments/assets/9fcf3024-1977-4e3e-8b6d-d9b1b76732a7)

After:
![CleanShot 2025-01-30 at 10  00 52@2x](https://github.com/user-attachments/assets/716e3bc5-d357-4b04-b096-8779cef93f2c)

### 2024-10-24

Before:
![CleanShot 2025-01-30 at 10  02 25@2x](https://github.com/user-attachments/assets/7ac06b35-9082-431c-9df5-bec56b0bfd2f)

After:
![CleanShot 2025-01-30 at 10  00 32@2x](https://github.com/user-attachments/assets/64156891-50fc-4937-94e3-84642f67ce5e)

### 2024-10-31

Before:
![CleanShot 2025-01-30 at 10  02 52@2x](https://github.com/user-attachments/assets/dae28fba-bb95-4e7f-ae75-e51d2bc433c9)

After:
![CleanShot 2025-01-30 at 10  00 11@2x](https://github.com/user-attachments/assets/dfd65bea-e553-4d5d-b9a4-b8f086448e99)



### A few other after screenshots

#### 2024-11-14
![CleanShot 2025-01-30 at 10  00 11@2x](https://github.com/user-attachments/assets/d8402278-0377-487b-afde-266925be275f)

#### 2024-11-21
No voting cycle
![CleanShot 2025-01-30 at 9  58 55@2x](https://github.com/user-attachments/assets/04414437-75d2-43c8-884e-6c7a61b7a360)

#### 2024-11-28
Voting cycle which isn't review period or voting period. So there is no voting to begin or end yet. Removed "Voting" string and left just "Ends" string.
![CleanShot 2025-01-30 at 10  16 38@2x](https://github.com/user-attachments/assets/ea44d6ed-bb1c-4131-9c6c-5b3b65047b9b)

#### 2024-12-05
Same as above
![CleanShot 2025-01-30 at 9  57 53@2x](https://github.com/user-attachments/assets/28d2222f-fa40-43f8-a546-1eb29efd70f8)

#### 2024-12-12
![CleanShot 2025-01-30 at 9  57 35@2x](https://github.com/user-attachments/assets/11354661-a00e-4f3c-b540-e798f409831f)

#### 2024-12-19
![CleanShot 2025-01-30 at 9  56 21@2x](https://github.com/user-attachments/assets/0a7ae466-0765-4f0e-b63e-1ba16edba3e3)

#### 2025-01-02
![CleanShot 2025-01-30 at 9  55 42@2x](https://github.com/user-attachments/assets/212c40cb-56dd-4012-8705-dd344b64c39a)

#### 2025-01-09
![CleanShot 2025-01-30 at 9  55 19@2x](https://github.com/user-attachments/assets/3eaaa40d-597b-4117-a960-add31615cc44)


#### 2025-01-16
![CleanShot 2025-01-30 at 9  54 42@2x](https://github.com/user-attachments/assets/680edef7-e1a1-4a05-8f61-b5b7c1e817f5)

#### 2025-01-30
![CleanShot 2025-01-30 at 9  54 21@2x](https://github.com/user-attachments/assets/04343f08-da90-4020-88a5-f2c93ad6b6a3)




