### PR TITLE
Fix: Update relativeVotingPowerToVotableSupply calculation

### DIFF
--- a/spec/oas_v1.yaml
+++ b/spec/oas_v1.yaml
@@ -282,6 +282,7 @@ components:
           summary: Delegate's voting power relative to votable supply
           description: The delegate's voting power relative to the votable supply.
           type: number
+          deprecated: true
         votingPowerRelativeToQuorum:
           summary: Delegate's voting power relative to quorum
           description: The delegate's voting power relative to the quorum.
@@ -317,6 +318,10 @@ components:
         numOfDelegators:
           summary: Number of delegators
           description: The number of delegators.
+          type: string
+        relativeVotingPowerToVotableSupply:
+          summary: Delegate's voting power relative to votable supply
+          description: The delegate's voting power relative to the votable supply.
           type: string
     DelegateStatement:
       summary: A delegate's statement

--- a/src/app/api/common/delegates/delegate.d.ts
+++ b/src/app/api/common/delegates/delegate.d.ts
@@ -21,6 +21,7 @@ export type Delegate = {
   totalProposals: number;
   numOfDelegators: bigint;
   statement: DelegateStatement | null;
+  relativeVotingPowerToVotableSupply: string;
 };
 
 export type DelegateChunk = Pick<

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -521,11 +521,12 @@ async function getDelegate(addressOrENSName: string): Promise<Delegate> {
         )
       : cachedNumOfDelegators;
 
-  const votingPowerRelativeToVotableSupplyExponential = votableSupply && BigInt(votableSupply) > 0n
-    ? Number(Number(totalVotingPower) / Number(votableSupply)).toExponential(3)
-    : 0;
-  
-  const votingPowerRelativeToVotableSupply = Number(votingPowerRelativeToVotableSupplyExponential);
+  const votingPowerRatio =
+    votableSupply && BigInt(votableSupply) > 0n
+      ? (Number(totalVotingPower) / Number(votableSupply)).toExponential(3)
+      : 0;
+
+  const votingPowerRelativeToVotableSupply = Number(votingPowerRatio);
 
   // Build out delegate JSON response
   return {

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -521,6 +521,12 @@ async function getDelegate(addressOrENSName: string): Promise<Delegate> {
         )
       : cachedNumOfDelegators;
 
+  const votingPowerRelativeToVotableSupplyExponential = votableSupply && BigInt(votableSupply) > 0n
+    ? Number(Number(totalVotingPower) / Number(votableSupply)).toExponential(3)
+    : 0;
+  
+  const votingPowerRelativeToVotableSupply = Number(votingPowerRelativeToVotableSupplyExponential);
+
   // Build out delegate JSON response
   return {
     address: address,
@@ -530,10 +536,7 @@ async function getDelegate(addressOrENSName: string): Promise<Delegate> {
       direct: delegate?.voting_power?.toString() || "0",
       advanced: delegate?.advanced_vp?.toFixed(0) || "0",
     },
-    votingPowerRelativeToVotableSupply:
-      votableSupply && BigInt(votableSupply) > 0n
-        ? Number(totalVotingPower / BigInt(votableSupply || 0))
-        : 0,
+    votingPowerRelativeToVotableSupply,
     votingPowerRelativeToQuorum:
       quorum && quorum > 0n
         ? Number((totalVotingPower * 10000n) / quorum) / 10000

--- a/src/app/api/common/utils/bigIntRatio.test.ts
+++ b/src/app/api/common/utils/bigIntRatio.test.ts
@@ -26,11 +26,13 @@ describe("calculateBigIntRatio", () => {
     expect(result).toBe("0.000000000049");
   });
 
-  test("handles 18-digit BigInt numbers", () => {
-    const num1 = 10n;
-    const num2 = 123456789012345678n;
+  test("handles numbers larger than MAX_SAFE_INTEGER", () => {
+    const maxSafeInt = BigInt(Number.MAX_SAFE_INTEGER); // 9007199254740991
+    const num1 = 10000000000000000000n; // 20 digits, above MAX_SAFE_INTEGER
+    const num2 = 40000000000000000000n;
 
     const result1 = calculateBigIntRatio(num1, num2);
-    expect(result1).toBe("0.000000000000000081");
+    expect(result1).toBe("0.25");
+    expect(num1 > maxSafeInt).toBe(true);
   });
 });

--- a/src/app/api/common/utils/bigIntRatio.test.ts
+++ b/src/app/api/common/utils/bigIntRatio.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "@jest/globals";
+
+import { calculateBigIntRatio } from "./bigIntRatio";
+
+describe("calculateBigIntRatio", () => {
+  test("handles zero denominator", () => {
+    expect(calculateBigIntRatio(10n, 0n)).toBe("0");
+  });
+
+  test("calculates simple ratios correctly", () => {
+    expect(calculateBigIntRatio(5n, 10n)).toBe("0.5");
+  });
+
+  test("handles large numbers accurately", () => {
+    const trillion = 1000000000000n;
+    const billion = 1000000000n;
+
+    expect(calculateBigIntRatio(billion, trillion)).toBe("0.001");
+  });
+
+  test("maintains precision with very different magnitudes", () => {
+    const veryLarge = 1000000000000n;
+    const verySmall = 49n;
+
+    const result = calculateBigIntRatio(verySmall, veryLarge);
+    expect(result).toBe("0.000000000049");
+  });
+
+  test("handles 18-digit BigInt numbers", () => {
+    const num1 = 10n;
+    const num2 = 123456789012345678n;
+
+    const result1 = calculateBigIntRatio(num1, num2);
+    expect(result1).toBe("0.000000000000000081");
+  });
+});

--- a/src/app/api/common/utils/bigIntRatio.ts
+++ b/src/app/api/common/utils/bigIntRatio.ts
@@ -1,0 +1,19 @@
+export function calculateBigIntRatio(
+  numerator: bigint,
+  denominator: bigint
+): string {
+  if (!denominator || denominator <= 0n) return "0";
+
+  const magnitude = Math.abs(
+    denominator.toString().length - numerator.toString().length + 3
+  );
+  const scalingFactor = 10n ** BigInt(magnitude);
+
+  const result =
+    Number(numerator * scalingFactor) / Number(denominator * scalingFactor);
+  return result.toLocaleString("fullwide", {
+    useGrouping: false,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: magnitude,
+  });
+}


### PR DESCRIPTION
BigInt / BigInt in Js is truncated to nearest integer causing it to return zero. Adding a new util function calculateBigIntRatio to calculate relativeVotingPowerToVotableSupply
Added a flag in swagger to indicate `votingPowerRelativeToVotableSupply` is deprecated and returning the value in string format from a new key `relativeVotingPowerToVotableSupply`

Testing Notes:
Checked on https://agora-next-optimism-git-fix-eng-1078-votingpow-9253bf-voteagora.vercel.app/ with test wallet and can see relative vote power now
 
![Untitled](https://github.com/user-attachments/assets/4ad93b4b-c87b-4bee-ae0a-7b69415271c2)

