### PR TITLE
Fix: Markdown table overflow

### DIFF
--- a/src/app/proposals/draft/components/DraftPreview.tsx
+++ b/src/app/proposals/draft/components/DraftPreview.tsx
@@ -242,7 +242,7 @@ const DraftPreview = ({
         <div className="mt-2 p-4 bg-wash border border-line rounded-lg text-primary">
           <MarkdownPreview
             source={proposalDraft.abstract}
-            className={`h-full text-primary py-3 px-4 rounded-t-lg max-w-full bg-transparent prose`}
+            className={`h-full text-primary py-3 px-4 rounded-t-lg max-w-full bg-transparent prose prose-table:overflow-x-auto prose-td:min-w-[140px]`}
             style={{
               backgroundColor: "transparent",
             }}

--- a/src/components/shared/Markdown/Markdown.tsx
+++ b/src/components/shared/Markdown/Markdown.tsx
@@ -50,7 +50,7 @@ export default function Markdown({ content }: { content: string }) {
             fontFamily: ui?.customization?.font ?? defaults.font,
           } as React.CSSProperties
         }
-        className={`h-full py-3 max-w-full bg-transparent prose prose-code:bg-wash prose-code:text-tertiary prose-pre:text-tertiary`}
+        className={`h-full py-3 max-w-full bg-transparent prose prose-code:bg-wash prose-code:text-tertiary prose-pre:text-tertiary prose-table:overflow-x-auto prose-td:min-w-[140px]`}
         wrapperElement={{
           "data-color-mode": "light",
         }}


### PR DESCRIPTION
 * Add overflow-x to be auto so tables in markdown does not cause the page content to overflow
 * Add min-width to td so larger $ values dont wrap into multiple lines works till 10B and 1B with commas
 
 Testing notes:
 Tested with draft [proposal](https://agora-next-uniswap-git-fix-eng-1069-markdown-tables-voteagora.vercel.app/proposals/draft/481?stage=1
 ) preview on 