### PR TITLE
Fix: Round of Delegate info card participation percentage

### DIFF
--- a/src/components/Delegates/DelegateCard/DelegateCardHeader.tsx
+++ b/src/components/Delegates/DelegateCard/DelegateCardHeader.tsx
@@ -13,9 +13,12 @@ export const DelegateCardHeader = ({ delegate }: Props) => {
     return null;
   }
 
-  const percentParticipation =
-    (voterStats.last_10_props / Math.min(10, voterStats.total_proposals)) *
-      100 || 0;
+  const percentParticipation = Number(
+    Math.round(
+      ((voterStats.last_10_props / Math.min(10, voterStats.total_proposals)) *
+        100 || 0) * 100
+    ) / 100
+  );
 
   return percentParticipation > 50 ? (
     <ActiveHeader


### PR DESCRIPTION
 * Round of to 2 decimal points, this would reflect in inactive and active delegate cards
 
 Testing notes: Tested locally. Once xai is merged we can use preview to test this on preview