### PR TITLE
Fix: Add Quorum reference line to visualisation

### DIFF
--- a/src/components/Proposals/ProposalPage/Charts/TimelineChart.tsx
+++ b/src/components/Proposals/ProposalPage/Charts/TimelineChart.tsx
@@ -4,6 +4,7 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -143,6 +144,20 @@ export const TimelineChart = ({ votes, proposal }: Props) => {
               },
             ]}
           />
+          {!!proposal.quorum && (
+            <ReferenceLine
+              y={+proposal.quorum.toString()}
+              strokeWidth={1}
+              strokeDasharray="3 3"
+              stroke="#4F4F4F"
+              label={{
+                position: "insideBottomLeft",
+                value: "QUORUM",
+                className: "text-xs font-inter font-semibold",
+                fill: "#565656",
+              }}
+            />
+          )}
 
           <Tooltip
             content={<CustomTooltip quorum={proposal.quorum} />}


### PR DESCRIPTION
This is a regression from https://github.com/voteagora/agora-next/commit/742e0e68bbac51599cbada93d58758b449f6b995#diff-586cd8bcb4021257470f2ef0ce06fe7cdea9fd74e19b71d39e3f5f2b13db6cb7L210

Adding back  reference line change

Testing Notes:
preview of OP below with [proposal](https://agora-next-optimism-git-fix-eng-1116-quorum-li-0ffce7-voteagora.vercel.app/proposals/71928632649116715308847337447543955907072794738294227130170691217045092512147) 
Preview on same [proposal](https://agora-next-optimism-git-fix-eng-1069-markdown-tables-voteagora.vercel.app/proposals/71928632649116715308847337447543955907072794738294227130170691217045092512147) an existing pr where the bug can be replicated
