### PR TITLE
ENG-896 fix snapshot timestamps

### DIFF
--- a/src/lib/voteUtils.ts
+++ b/src/lib/voteUtils.ts
@@ -143,7 +143,7 @@ export function parseSnapshotVote(vote: SnapshotVotePayload): SnapshotVote {
     id: vote.id,
     title: vote.title || "",
     address: vote.voter,
-    createdAt: new Date(Number(vote.created)),
+    createdAt: new Date(Number(vote.created) * 1000), // Convert seconds to milliseconds for Date
     choice: vote.choice,
     votingPower: vote.vp,
     reason: vote.reason || "",


### PR DESCRIPTION
Tested against ENS. I do not believe any other tenants have snapshot votes, except etherfi which is a strange one. You may need to look at the jira ticket to navigate to the correct place in the app for the timestamp