### PR TITLE
Fix to get advanced delegations from alligator contract

### DIFF
--- a/src/app/api/common/delegations/getDelegations.ts
+++ b/src/app/api/common/delegations/getDelegations.ts
@@ -62,7 +62,7 @@ async function getCurrentDelegateesForAddress({
       findAdvancedDelegatee({
         namespace,
         address,
-        contract: contracts.token.address,
+        contract: contracts.alligator?.address || contracts.token.address,
       }),
       getDirectDelegatee(),
     ]);
@@ -382,7 +382,7 @@ async function getCurrentAdvancedDelegatorsForAddress({
     findAdvancedDelegatee({
       namespace,
       address,
-      contract: contracts.alligator?.address,
+      contract: contracts.alligator?.address || contracts.token.address,
     }),
     contracts.token.provider.getBlock("latest"),
   ]);


### PR DESCRIPTION
Tested against optimism as the ticket calls that out specifically.

Also manually tested against cyber as a FULL delegation tenant and derive as a PARTIAL delegation tenant