### PR TITLE
Fix Proposal Type Info Formatting

### DIFF
--- a/src/app/info/components/GovernorSettingsProposalTypes.tsx
+++ b/src/app/info/components/GovernorSettingsProposalTypes.tsx
@@ -32,7 +32,13 @@ const GovernorSettingsProposalTypes = ({
   // TODO: Refactor this to use the governor types
   const isQuorumSupportedByGovernor =
     namespace !== TENANT_NAMESPACES.CYBER &&
-    namespace !== TENANT_NAMESPACES.PGUILD;
+    namespace !== TENANT_NAMESPACES.BOOST &&
+    namespace !== TENANT_NAMESPACES.PGUILD &&
+    namespace !== TENANT_NAMESPACES.DERIVE &&
+    namespace !== TENANT_NAMESPACES.DEMO &&
+    namespace !== TENANT_NAMESPACES.B3 &&
+    namespace !== TENANT_NAMESPACES.XAI &&
+    namespace !== TENANT_NAMESPACES.SCROLL;
 
   const { data: quorum, isFetched: isQuorumFetched } = useReadContract({
     address: contracts.governor.address as `0x${string}`,
@@ -162,7 +168,13 @@ const GovernorSettingsProposalTypes = ({
               {Number(proposalType.approval_threshold) / 100} %
             </TableCell>
             <TableCell colSpan={3} className="rounded-bl-xl">
-              {threshold && formatNumber(threshold)}
+              {isThresholdFetched && threshold !== undefined && (
+                <TokenAmountDecorated
+                  amount={BigInt(threshold.toString())}
+                  currency={token.symbol}
+                  decimals={token.decimals}
+                />
+              )}
             </TableCell>
             <TableCell colSpan={4} className="rounded-br-xl">
               {Number(proposalType.quorum) / 100} %


### PR DESCRIPTION
This fixes the proposal type table view to include all relevant governors and format tokens accordingly.

![image](https://github.com/user-attachments/assets/7d238f6b-a823-4bb3-91e9-ad179b6bf738)

Note that the 51% will be changed to 67% shortly.