### PR TITLE
Fix: Delete proposal type

### DIFF
--- a/src/components/Admin/ProposalType.tsx
+++ b/src/components/Admin/ProposalType.tsx
@@ -136,7 +136,7 @@ export default function ProposalType({
     isLoadingDeleteProposalTypeTransaction ||
     isLoadingSetProposalType ||
     isLoadingSetProposalTypeTransaction;
-  const isDisabled = isLoading || name == "Optimistic";
+  const isDisabled = isLoading;
 
   function onSubmit(values: z.infer<typeof proposalTypeSchema>) {
     const name = values.name;

--- a/src/components/Admin/ProposalType.tsx
+++ b/src/components/Admin/ProposalType.tsx
@@ -38,6 +38,7 @@ type ProposalType = {
   quorum: number;
   approval_threshold: number;
   name: string;
+  isClientSide: boolean;
 };
 
 const proposalTypeSchema = z.object({

--- a/src/components/Admin/ProposalTypeSettings.tsx
+++ b/src/components/Admin/ProposalTypeSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Separator } from "@/components/ui/separator";
-import { Fragment, useState } from "react";
+import { Fragment, useState, useCallback } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { OptimismProposalTypes } from "@prisma/client";
@@ -86,14 +86,35 @@ export default function ProposalTypeSettings({
   proposalTypes: OptimismProposalTypes[];
 }) {
   const fmtPropTypes = proposalTypes.map(
-    ({ quorum, approval_threshold, name }) => ({
+    ({ quorum, approval_threshold, name, proposal_type_id }) => ({
       name,
       quorum: Number(quorum) / 100,
       approval_threshold: Number(approval_threshold) / 100,
+      proposal_type_id: Number(proposal_type_id), // This will be of the format "0", "1", "2", etc.
+      isClientSide: false,
     })
   );
 
   const [propTypes, setPropTypes] = useState(fmtPropTypes);
+
+  const handleDeleteProposalType = useCallback((id: number) => {
+    setPropTypes((prevPropTypes) =>
+      prevPropTypes.filter(
+        (proposalType) => id !== proposalType.proposal_type_id
+      )
+    );
+  }, []);
+
+  const handleSuccessSetProposalType = useCallback((id: number) => {
+    setPropTypes((prevPropTypes) =>
+      prevPropTypes.map((proposalType) => {
+        if (proposalType.proposal_type_id === id) {
+          return { ...proposalType, isClientSide: false }; // Toggle the isClientSide flag only for the matching id
+        }
+        return proposalType;
+      })
+    );
+  }, []);
 
   return (
     <section className="gl_box bg-neutral">
@@ -104,12 +125,14 @@ export default function ProposalTypeSettings({
         Create and manage different types of proposals
       </p>
       <RestrictedCallout />
-      {propTypes.map((proposalType, key) => (
-        <Fragment key={key}>
+      {propTypes.map((proposalType) => (
+        <Fragment key={proposalType.proposal_type_id}>
           <ProposalType
             votableSupply={votableSupply}
             proposalType={proposalType}
-            index={key}
+            index={proposalType.proposal_type_id}
+            onDelete={handleDeleteProposalType}
+            onSuccessSetProposalType={handleSuccessSetProposalType}
           />
           <Separator className="my-8" />
         </Fragment>
@@ -120,7 +143,13 @@ export default function ProposalTypeSettings({
         onClick={() => {
           setPropTypes((prevPropTypes) => [
             ...prevPropTypes,
-            { quorum: 50, approval_threshold: 50, name: "" },
+            {
+              quorum: 50,
+              approval_threshold: 50,
+              name: "",
+              proposal_type_id: prevPropTypes.length,
+              isClientSide: true,
+            },
           ]);
         }}
       >


### PR DESCRIPTION
  * Send empty strings inplace of name and description to delete a proposal type
  * Add onDelete and onSuccessSetProposalType to handle client vs onchain state.
  * use isClient flag as a way to remove the proposal type from UI
  * On successful delete, use isSuccess flag to remove the proposal type from state so that ui reflects the change
  
 Testing notes:
  Tested on B3 [preview](https://agora-next-b3-git-sudheer-eng-1128-fix-the-del-8b0748-voteagora.vercel.app/admin) with admin wallet.
  
 Scenarios:

1. Click on `Add another proposal type`
2. Click on  delete button without saving.

Expected: Ui should delete the newly added row without any creating a transaction.


1. Click on delete of `proposal type 5`
2. Confirm the transaction.


Expected: On success of transaction, the ui should remove the row from the ui.

1. Add a new proposal type.
2. Repeat steps of deletion

Expected: On success of transaction, the ui should remove the row from the ui. 
