### PR TITLE
Fix switch between delegates and citizen tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "@typechain/ethers-v6": "^0.5.1",
     "@types/d3": "^7.4.3",
     "@types/dompurify": "^3.2.0",
-    "@types/jest": "^29.5.12",
     "@types/node": "^22.7.5",
     "@types/react": "^18.2.8",
     "@types/react-dom": "^18.2.25",

--- a/src/components/Delegates/DelegateCardList/CitzenCardList.tsx
+++ b/src/components/Delegates/DelegateCardList/CitzenCardList.tsx
@@ -15,7 +15,6 @@ import { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
 import { DelegateChunk } from "@/app/api/common/delegates/delegate";
 
 interface Props {
-  isDelegatesCitizensFetching: boolean;
   initialDelegates: PaginatedResult<DelegateChunk[]>;
   fetchDelegates: (
     pagination: PaginationParams,
@@ -27,7 +26,6 @@ interface Props {
 export default function CitizenCardList({
   initialDelegates,
   fetchDelegates,
-  isDelegatesCitizensFetching,
 }: Props) {
   const fetching = useRef(false);
   const [meta, setMeta] = useState(initialDelegates.meta);
@@ -88,9 +86,7 @@ export default function CitizenCardList({
               key={delegate.address}
               className={cn(
                 "flex flex-col",
-                isDelegatesCitizensFetching || isDelegatesFiltering
-                  ? "animate-pulse"
-                  : ""
+                isDelegatesFiltering ? "animate-pulse" : ""
               )}
             >
               <Link href={`/delegates/${delegate.address}`}>

--- a/src/components/Delegates/DelegateCardList/DelegateCard.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCard.tsx
@@ -11,13 +11,11 @@ import { sanitizeContent } from "@/lib/sanitizationUtils";
 
 const DelegateCard = ({
   delegate,
-  isDelegatesCitizensFetching,
   isDelegatesFiltering,
   isAdvancedUser,
   truncatedStatement,
 }: {
   delegate: DelegateChunk;
-  isDelegatesCitizensFetching: boolean;
   isDelegatesFiltering: boolean;
   isAdvancedUser: boolean;
   truncatedStatement: string;
@@ -40,9 +38,7 @@ const DelegateCard = ({
       key={delegate.address}
       className={cn(
         "flex flex-col",
-        isDelegatesCitizensFetching || isDelegatesFiltering
-          ? "animate-pulse"
-          : ""
+        isDelegatesFiltering ? "animate-pulse" : ""
       )}
     >
       <Link href={`/delegates/${delegate.address}`}>

--- a/src/components/Delegates/DelegateCardList/DelegateCardList.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCardList.tsx
@@ -11,7 +11,6 @@ import { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
 import DelegateCard from "./DelegateCard";
 
 interface Props {
-  isDelegatesCitizensFetching: boolean;
   initialDelegates: PaginatedResult<DelegateChunk[]>;
   fetchDelegates: (
     pagination: PaginationParams,
@@ -23,7 +22,6 @@ interface Props {
 export default function DelegateCardList({
   initialDelegates,
   fetchDelegates,
-  isDelegatesCitizensFetching,
 }: Props) {
   const fetching = useRef(false);
   const [meta, setMeta] = useState(initialDelegates.meta);
@@ -84,7 +82,6 @@ export default function DelegateCardList({
               key={idx}
               delegate={delegate}
               truncatedStatement={truncatedStatement}
-              isDelegatesCitizensFetching={isDelegatesCitizensFetching}
               isDelegatesFiltering={isDelegatesFiltering}
               isAdvancedUser={isAdvancedUser}
             />

--- a/src/components/Delegates/DelegateCardList/DelegateCardWrapper.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateCardWrapper.tsx
@@ -81,7 +81,6 @@ const DelegateCardWrapper = async ({ searchParams }: { searchParams: any }) => {
     <DelegateTabs>
       <TabsContent value="delegates">
         <DelegateContent
-          isDelegatesCitizensFetching={tab === "citizens"}
           initialDelegates={delegates}
           fetchDelegates={async (pagination, seed) => {
             "use server";
@@ -93,7 +92,6 @@ const DelegateCardWrapper = async ({ searchParams }: { searchParams: any }) => {
       </TabsContent>
       <TabsContent value="citizens">
         <CitizenCardList
-          isDelegatesCitizensFetching={tab !== "citizens"}
           initialDelegates={delegates}
           fetchDelegates={async (pagination, seed) => {
             "use server";

--- a/src/components/Delegates/DelegateCardList/DelegateContent.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateContent.tsx
@@ -8,7 +8,6 @@ import { Delegation } from "@/app/api/common/delegations/delegation";
 import { useQueryState } from "nuqs";
 
 interface Props {
-  isDelegatesCitizensFetching: boolean;
   initialDelegates: PaginatedResult<DelegateChunk[]>;
   fetchDelegates: (
     pagination: PaginationParams,
@@ -20,7 +19,6 @@ interface Props {
 export default function DelegateContent({
   initialDelegates,
   fetchDelegates,
-  isDelegatesCitizensFetching,
   fetchDelegators,
 }: Props) {
   const [layout] = useQueryState("layout", {
@@ -28,7 +26,6 @@ export default function DelegateContent({
   });
   return layout === "grid" ? (
     <DelegateCardList
-      isDelegatesCitizensFetching={isDelegatesCitizensFetching}
       initialDelegates={initialDelegates}
       fetchDelegates={fetchDelegates}
       fetchDelegators={fetchDelegators}

--- a/src/components/Delegates/DelegatesTabs/DelegatesTabs.tsx
+++ b/src/components/Delegates/DelegatesTabs/DelegatesTabs.tsx
@@ -4,7 +4,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import DelegatesFilter from "@/components/Delegates/DelegatesFilter/DelegatesFilter";
 import CitizensFilter from "@/components/Delegates/DelegatesFilter/CitizensFilter";
 import DelegatesSearch from "@/components/Delegates/DelegatesSearch/DelegatesSearch";
-import { type ReactNode } from "react";
+import { useTransition, type ReactNode } from "react";
 import Tenant from "@/lib/tenant/tenant";
 import StakeholdersFilter from "@/app/delegates/components/StakeholdersFilter";
 import IssuesFilter from "@/app/delegates/components/IssuesFilter";
@@ -12,13 +12,18 @@ import EndorsedFilter from "@/app/delegates/components/EndorsedFilter";
 import DelegateeFilter from "@/app/delegates/components/DelegatorFilter";
 import { LayoutGrid, AlignJustify } from "lucide-react";
 import { useQueryState } from "nuqs";
+import { cn } from "@/lib/utils";
 
 export default function DelegateTabs({ children }: { children: ReactNode }) {
+  const [isPending, startTransition] = useTransition();
   const [tab, setTab] = useQueryState("tab", {
     defaultValue: "delegates",
+    shallow: false,
+    startTransition,
   });
   const [layout, setLayout] = useQueryState("layout", {
     defaultValue: "grid",
+    shallow: true,
   });
 
   const { ui } = Tenant.current();
@@ -73,7 +78,7 @@ export default function DelegateTabs({ children }: { children: ReactNode }) {
             <div className="flex items-center gap-2 bg-wash rounded-full px-4 py-2 shrink-0">
               <button
                 onClick={() => {
-                  setLayout("grid", { shallow: true });
+                  setLayout("grid");
                 }}
                 disabled={layout === "grid"}
               >
@@ -83,7 +88,7 @@ export default function DelegateTabs({ children }: { children: ReactNode }) {
               </button>
               <button
                 onClick={() => {
-                  setLayout("list", { shallow: true });
+                  setLayout("list");
                 }}
                 disabled={layout === "list"}
               >
@@ -95,7 +100,7 @@ export default function DelegateTabs({ children }: { children: ReactNode }) {
           )}
         </div>
       </div>
-      {children}
+      <div className={cn(isPending && "animate-pulse")}>{children}</div>
     </Tabs>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11684,11 +11684,6 @@ html-encoding-sniffer@^4.0.0:
   dependencies:
     whatwg-encoding "^3.1.1"
 
-html-escaper@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
-  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
-
 html-url-attributes@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz#83b052cd5e437071b756cd74ae70f708870c2d87"
@@ -16263,6 +16258,34 @@ rollup-plugin-visualizer@^5.9.2:
     source-map "^0.7.4"
     yargs "^17.5.1"
 
+rollup@^4.30.1:
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.34.6.tgz#a07e4d2621759e29034d909655e7a32eee9195c9"
+  integrity sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==
+  dependencies:
+    "@types/estree" "1.0.6"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.34.6"
+    "@rollup/rollup-android-arm64" "4.34.6"
+    "@rollup/rollup-darwin-arm64" "4.34.6"
+    "@rollup/rollup-darwin-x64" "4.34.6"
+    "@rollup/rollup-freebsd-arm64" "4.34.6"
+    "@rollup/rollup-freebsd-x64" "4.34.6"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.34.6"
+    "@rollup/rollup-linux-arm-musleabihf" "4.34.6"
+    "@rollup/rollup-linux-arm64-gnu" "4.34.6"
+    "@rollup/rollup-linux-arm64-musl" "4.34.6"
+    "@rollup/rollup-linux-loongarch64-gnu" "4.34.6"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.34.6"
+    "@rollup/rollup-linux-riscv64-gnu" "4.34.6"
+    "@rollup/rollup-linux-s390x-gnu" "4.34.6"
+    "@rollup/rollup-linux-x64-gnu" "4.34.6"
+    "@rollup/rollup-linux-x64-musl" "4.34.6"
+    "@rollup/rollup-win32-arm64-msvc" "4.34.6"
+    "@rollup/rollup-win32-ia32-msvc" "4.34.6"
+    "@rollup/rollup-win32-x64-msvc" "4.34.6"
+    fsevents "~2.3.2"
+
 rrweb-cssom@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
@@ -16788,14 +16811,6 @@ string-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
   integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
 
-string-length@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
-  integrity sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==
-  dependencies:
-    char-regex "^1.0.2"
-    strip-ansi "^6.0.0"
-
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -17284,6 +17299,31 @@ tiny-invariant@^1.3.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinypool@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
+  integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 tldts-core@^6.1.77:
   version "6.1.77"
@@ -18477,7 +18517,7 @@ xml-name-validator@^5.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
   integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
 
-xml@=1.0.1, xml@^1.0.1:
+xml@=1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==


### PR DESCRIPTION
The loading state was static variable and never changed. The actual refetch needed between switches never happened/started either.

This PR:
- Removes previous loading state variable
- Uses nuqs shallow option to trigger refetch (https://nuqs.47ng.com/docs/options#shallow)
- Uses React's useTransition hook as recommended by nuqs (https://nuqs.47ng.com/docs/options#transitions) to get loading states