### PR TITLE
Update XAI OG svg to match agora icon size

### DIFF
--- a/src/app/api/images/og/assets/shared.tsx
+++ b/src/app/api/images/og/assets/shared.tsx
@@ -419,8 +419,8 @@ const ogLogoForNamespace = (namespace: TenantNamespace) => {
     case TENANT_NAMESPACES.XAI:
       return (
         <svg
-          width="90"
-          height="90"
+          width="32"
+          height="32"
           viewBox="0 0 90 90"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Tested on vercel [OG preview](https://vercel.com/voteagora/agora-next-xai/fHWYWfCGmZX8gs9dGb5p85WPq6Ur/og?path=delegates) 

![og](https://github.com/user-attachments/assets/1e6dd229-898d-4073-955f-5eb49ac1c1ce)
