### PR TITLE
* Update proposal creation flow with votable supply update

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,5 +136,6 @@
     "typescript": "^5.4.5",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha512.ff4579ab459bb25aa7c0ff75b62acebe576f6084b36aa842971cf250a5d8c6cd3bc9420b22ce63c7f93a0857bc6ef29291db39c3e7a23aab5adfd5a4dd6c5d71"
 }

--- a/src/app/api/common/votableSupply/route.ts
+++ b/src/app/api/common/votableSupply/route.ts
@@ -1,0 +1,16 @@
+import { findVotableSupply } from "@/lib/prismaUtils";
+import Tenant from "@/lib/tenant/tenant";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { namespace, contracts } = Tenant.current();
+  const address = contracts.token.address;
+  try {
+    const response = await findVotableSupply({ namespace, address });
+    return NextResponse.json(response);
+  } catch (e: any) {
+    return new Response("Internal server error: " + e.toString(), {
+      status: 500,
+    });
+  }
+}

--- a/src/app/proposals/components/UpdateVotableSupplyOracle.tsx
+++ b/src/app/proposals/components/UpdateVotableSupplyOracle.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  useAccount,
+  useReadContract,
+  useWaitForTransactionReceipt,
+  useWriteContract,
+} from "wagmi";
+
+import Tenant from "@/lib/tenant/tenant";
+import {
+  VOTABLE_SUPPLY_QK,
+  useGetVotableSupply,
+} from "@/hooks/useGetVotableSupply";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { formatNumber } from "@/lib/utils";
+import { useQueryClient } from "@tanstack/react-query";
+import { UpdatedButton } from "@/components/Button";
+
+export const UpdateVotableSupplyOracle = () => {
+  const { address } = useAccount();
+  const { data: presentVotableSupply } = useGetVotableSupply();
+  const queryClient = useQueryClient();
+  const [txHash, setTxHash] = useState<`0x${string}` | undefined>(undefined);
+
+  const { contracts } = Tenant.current();
+
+  const { writeContractAsync, isPending } = useWriteContract();
+
+  const { data: votableSupplyOracle, refetch: refetchVotableSupplyOracle } =
+    useReadContract({
+      address: contracts.votableSupplyOracle?.address as `0x${string}`,
+      abi: contracts.votableSupplyOracle?.abi,
+      functionName: "votableSupply",
+    });
+
+  const { data: ownerAddress } = useReadContract({
+    address: contracts.votableSupplyOracle?.address as `0x${string}`,
+    abi: contracts.votableSupplyOracle?.abi,
+    functionName: "owner",
+  });
+
+  const { isSuccess: isTxConfirmed } = useWaitForTransactionReceipt({
+    hash: txHash,
+  });
+
+  // Format the votableSupplyOracle for display
+  const formattedOracleSupply =
+    votableSupplyOracle !== undefined && votableSupplyOracle !== null
+      ? formatNumber(votableSupplyOracle.toString(), 18, 4, false, false)
+      : "0";
+
+  const formattedPresentVotableSupply =
+    presentVotableSupply !== undefined && presentVotableSupply !== null
+      ? formatNumber(presentVotableSupply.toString(), 18, 4, false, false)
+      : "0";
+
+  useEffect(() => {
+    if (isTxConfirmed) {
+      // Invalidate the votable supply query when transaction is confirmed
+      queryClient.invalidateQueries({ queryKey: [VOTABLE_SUPPLY_QK] });
+      refetchVotableSupplyOracle();
+      setTxHash(undefined);
+    }
+  }, [isTxConfirmed, queryClient, refetchVotableSupplyOracle]);
+
+  const handleUpdateSupply = async () => {
+    try {
+      const supplyInWei = BigInt(presentVotableSupply);
+
+      const hash = await writeContractAsync({
+        address: contracts.votableSupplyOracle!.address as `0x${string}`,
+        abi: contracts.votableSupplyOracle!.abi,
+        functionName: "_updateVotableSupply",
+        args: [supplyInWei],
+      });
+
+      // Store the transaction hash to track confirmation
+      setTxHash(hash);
+    } catch (err) {
+      console.error("Error updating votable supply:", err);
+    }
+  };
+
+  if (!address || address !== ownerAddress) return null;
+
+  return (
+    <Card className="mb-6">
+      <CardContent className="pt-6">
+        <div className="flex justify-between items-center">
+          <div className="flex flex-col space-y-1">
+            <div>Current votable supply: {formattedPresentVotableSupply}</div>
+            <div>Current value in oracle: {formattedOracleSupply}</div>
+          </div>
+          <UpdatedButton
+            onClick={handleUpdateSupply}
+            disabled={isPending}
+            className="ml-auto"
+          >
+            {isPending ? "Updating..." : "Update Votable Supply"}
+          </UpdatedButton>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/app/proposals/components/__tests__/UpdateVotableSupplyOracle.test.tsx
+++ b/src/app/proposals/components/__tests__/UpdateVotableSupplyOracle.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, test, expect, beforeEach, vi, afterEach } from "vitest";
+import { UpdateVotableSupplyOracle } from "@/app/proposals/components/UpdateVotableSupplyOracle";
+import * as wagmi from "wagmi";
+import * as tanstackQuery from "@tanstack/react-query";
+import * as useGetVotableSupplyHook from "@/hooks/useGetVotableSupply";
+import {
+  UseWaitForTransactionReceiptReturnType,
+  UseAccountReturnType,
+  UseReadContractReturnType,
+  UseWriteContractReturnType,
+} from "wagmi";
+import { QueryClient } from "@tanstack/react-query";
+
+vi.mock("wagmi");
+vi.mock("@tanstack/react-query");
+vi.mock("@/hooks/useGetVotableSupply");
+
+vi.mock("@/components/Button", () => ({
+  UpdatedButton: vi.fn(({ children, ...props }) => (
+    <button data-testid="update-supply-button" {...props}>
+      {children}
+    </button>
+  )),
+}));
+
+// Mock utilities
+vi.mock("@/lib/utils", () => ({
+  formatNumber: vi.fn((val) => val.toString()),
+  cn: vi.fn(() => "cn"), // this is used in button component
+}));
+
+// Mock Tenant using module factory pattern
+vi.mock("@/lib/tenant/tenant", () => {
+  return {
+    default: {
+      current: vi.fn().mockImplementation(() => ({
+        contracts: {
+          votableSupplyOracle: {
+            address: "0xvotableSupplyOracle" as `0x${string}`,
+            abi: [],
+          },
+        },
+      })),
+    },
+  };
+});
+
+describe("UpdateVotableSupplyOracle", () => {
+  // Setup common mocks
+  const mockUseAccount = vi.spyOn(wagmi, "useAccount");
+  const mockUseReadContract = vi.spyOn(wagmi, "useReadContract");
+  const mockUseWriteContract = vi.spyOn(wagmi, "useWriteContract");
+  const mockUseWaitForTransactionReceipt = vi.spyOn(
+    wagmi,
+    "useWaitForTransactionReceipt"
+  );
+  const mockUseGetVotableSupply = vi.spyOn(
+    useGetVotableSupplyHook,
+    "useGetVotableSupply"
+  );
+  const mockUseQueryClient = vi.spyOn(tanstackQuery, "useQueryClient");
+
+  // Mock data
+  const mockAddress = "0x123" as `0x${string}`;
+  const mockOwnerAddress = "0x123" as `0x${string}`;
+  const mockPresentVotableSupply = "116799850939014514601948447";
+  const mockVotableSupplyOracle = "116799799048035407924717724";
+  const mockTxHash = "0xabc" as `0x${string}`;
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient;
+  const mockRefetch = vi.fn();
+  const mockWriteContractAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseAccount.mockReturnValue({
+      address: mockAddress,
+    } as UseAccountReturnType);
+
+    // Fix the useReadContract mock implementation
+    mockUseReadContract.mockImplementation((params: any) => {
+      // Access functionName safely with type assertion
+      const functionName = params?.functionName;
+
+      if (functionName === "votableSupply") {
+        return {
+          data: mockVotableSupplyOracle,
+          refetch: mockRefetch,
+        } as unknown as UseReadContractReturnType<any, any>;
+      }
+      if (functionName === "owner") {
+        return {
+          data: mockOwnerAddress,
+        } as unknown as UseReadContractReturnType<any, any>;
+      }
+      return {} as UseReadContractReturnType<any, any>;
+    });
+
+    mockUseWriteContract.mockReturnValue({
+      writeContractAsync: mockWriteContractAsync,
+      isPending: false,
+    } as unknown as UseWriteContractReturnType<any>);
+
+    mockUseWaitForTransactionReceipt.mockReturnValue({
+      isSuccess: false,
+      data: undefined,
+    } as UseWaitForTransactionReceiptReturnType<any, any, any>);
+
+    mockUseGetVotableSupply.mockReturnValue({
+      data: mockPresentVotableSupply,
+    } as unknown as ReturnType<
+      typeof useGetVotableSupplyHook.useGetVotableSupply
+    >);
+
+    mockUseQueryClient.mockReturnValue(mockQueryClient);
+
+    mockWriteContractAsync.mockResolvedValue(mockTxHash);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders correctly with data", () => {
+    render(<UpdateVotableSupplyOracle />);
+
+    // Check if the component renders the formatted supply values
+    expect(screen.getByText(/Current votable supply:/)).toBeDefined();
+    expect(screen.getByText(/Current value in oracle:/)).toBeDefined();
+    expect(screen.getByText("Update Votable Supply")).toBeDefined();
+  });
+
+  test("does not render if user is not the owner", () => {
+    mockUseAccount.mockReturnValue({
+      address: "0x456" as `0x${string}`, // Different from owner
+    } as UseAccountReturnType);
+
+    const { container } = render(<UpdateVotableSupplyOracle />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("handles update supply correctly", async () => {
+    render(<UpdateVotableSupplyOracle />);
+
+    // Click the update button using testId instead of text
+    fireEvent.click(screen.getByTestId("update-supply-button"));
+
+    // Check if writeContractAsync was called with correct arguments
+    expect(mockWriteContractAsync).toHaveBeenCalledWith({
+      address: "0xvotableSupplyOracle",
+      abi: [],
+      functionName: "_updateVotableSupply",
+      args: [BigInt(mockPresentVotableSupply)],
+    });
+  });
+
+  test("shows loading state during update", () => {
+    mockUseWriteContract.mockReturnValue({
+      writeContractAsync: mockWriteContractAsync,
+      isPending: true,
+    } as unknown as UseWriteContractReturnType<any>);
+
+    render(<UpdateVotableSupplyOracle />);
+
+    // Check if the button shows loading state using testId
+    const button = screen.getByTestId("update-supply-button");
+    expect(button).toHaveTextContent("Updating...");
+    expect(button).toHaveProperty("disabled", true);
+  });
+
+  test("refreshes data after transaction confirmation", async () => {
+    const { rerender } = render(<UpdateVotableSupplyOracle />);
+
+    // Simulate transaction confirmation with type assertion
+    mockUseWaitForTransactionReceipt.mockReturnValue({
+      isSuccess: true,
+      data: { transactionHash: mockTxHash },
+    } as UseWaitForTransactionReceiptReturnType<any, any, any>);
+
+    // Re-render with confirmed transaction
+    rerender(<UpdateVotableSupplyOracle />);
+
+    // Check if data was refreshed
+    expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [useGetVotableSupplyHook.VOTABLE_SUPPLY_QK],
+    });
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+});

--- a/src/app/proposals/draft/components/stages/SubmitForm.tsx
+++ b/src/app/proposals/draft/components/stages/SubmitForm.tsx
@@ -10,6 +10,7 @@ import { useManager } from "@/hooks/useManager";
 import { DraftProposal, PLMConfig, ProposalGatingType } from "../../types";
 import Tenant from "@/lib/tenant/tenant";
 import { useGetVotes } from "@/hooks/useGetVotes";
+import { UpdateVotableSupplyOracle } from "@/app/proposals/components/UpdateVotableSupplyOracle";
 
 const Actions = ({ proposalDraft }: { proposalDraft: DraftProposal }) => {
   const tenant = Tenant.current();
@@ -56,6 +57,9 @@ const Actions = ({ proposalDraft }: { proposalDraft: DraftProposal }) => {
 
   return (
     <div className="mt-6">
+      {tenant.contracts.votableSupplyOracle?.address && (
+        <UpdateVotableSupplyOracle />
+      )}
       {canAddressSponsor ? (
         <SponsorActions draftProposal={proposalDraft} />
       ) : (

--- a/src/hooks/useGetVotableSupply.ts
+++ b/src/hooks/useGetVotableSupply.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import Tenant from "@/lib/tenant/tenant";
+
+export const VOTABLE_SUPPLY_QK = "votableSupply";
+
+export const useGetVotableSupply = () => {
+  const { contracts } = Tenant.current();
+  const address = contracts.token.address;
+
+  const { data, isFetching, isFetched } = useQuery({
+    enabled: !!address,
+    queryKey: [VOTABLE_SUPPLY_QK, address],
+    queryFn: async () => {
+      try {
+        // Fetch votable supply from the API endpoint
+        const response = await fetch(`/api/common/votableSupply`);
+        const data = await response.json();
+        // If the response contains votable_supply property, use it
+        const supplyValue = data?.votable_supply || data || "0";
+
+        // Convert the string response to BigInt
+        return supplyValue;
+      } catch (error) {
+        console.error("Error fetching votable supply:", error);
+        return "0";
+      }
+    },
+    staleTime: 60000, // 1 minute cache
+  });
+
+  return { data, isFetching, isFetched };
+};

--- a/src/lib/contracts/common/interfaces/IVotableSupplyOracleContract.ts
+++ b/src/lib/contracts/common/interfaces/IVotableSupplyOracleContract.ts
@@ -1,0 +1,23 @@
+import type { TypedContractMethod } from "@/lib/contracts/generated/common";
+import type { BaseContract, AddressLike } from "ethers";
+
+export interface IVotableSupplyOracleContract extends BaseContract {
+  // Function to update the votable supply
+  _updateVotableSupply: TypedContractMethod<
+    [newVotableSupply: bigint],
+    [void],
+    "nonpayable"
+  >;
+
+  // Function to update the votable supply at a specific index
+  _updateVotableSupplyAt: TypedContractMethod<
+    [index: bigint, newVotableSupply: bigint],
+    [void],
+    "nonpayable"
+  >;
+
+  "votableSupply()": TypedContractMethod<[], [bigint], "view">;
+
+  // Current owner of the contract
+  owner: TypedContractMethod<[], [string], "view">;
+}

--- a/src/lib/tenant/configs/contracts/optimism.ts
+++ b/src/lib/tenant/configs/contracts/optimism.ts
@@ -4,6 +4,7 @@ import {
   OptimismGovernor__factory,
   ProposalTypesConfigurator__factory,
   AgoraTimelock__factory,
+  VotableSupplyOracle__factory,
 } from "@/lib/contracts/generated";
 import { AlchemyProvider, BaseContract } from "ethers";
 import { IAlligatorContract } from "@/lib/contracts/common/interfaces/IAlligatorContract";
@@ -14,6 +15,7 @@ import { optimism } from "viem/chains";
 import { createTokenContract } from "@/lib/tokenUtils";
 import { ITimelockContract } from "@/lib/contracts/common/interfaces/ITimelockContract";
 import { DELEGATION_MODEL } from "@/lib/constants";
+import { IVotableSupplyOracleContract } from "@/lib/contracts/common/interfaces/IVotableSupplyOracleContract";
 
 interface Props {
   isProd: boolean;
@@ -41,6 +43,10 @@ export const optimismTenantContractConfig = ({
   const TIMELOCK = isProd
     ? "0x0eDd4B2cCCf41453D8B5443FBB96cc577d1d06bF"
     : "0x85c118971C058677DC502854d56A483BF5548042";
+
+  const VOTABLE_ORACLE = isProd
+    ? "0x1b7CA7437748375302bAA8954A2447fC3FBE44CC"
+    : "0x73b07b799Abfb7965f2C1014120019CbffaAcae7";
 
   const provider = new AlchemyProvider("optimism", alchemyId);
   const chain = optimism;
@@ -86,6 +92,14 @@ export const optimismTenantContractConfig = ({
       address: TIMELOCK,
       chain,
       contract: AgoraTimelock__factory.connect(TIMELOCK, provider),
+      provider,
+    }),
+
+    votableSupplyOracle: new TenantContract<IVotableSupplyOracleContract>({
+      abi: VotableSupplyOracle__factory.abi,
+      address: VOTABLE_ORACLE,
+      chain,
+      contract: VotableSupplyOracle__factory.connect(VOTABLE_ORACLE, provider),
       provider,
     }),
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -45,6 +45,7 @@ export type TenantContracts = {
     isERC721: () => this is TenantContract<IMembershipContract>;
   };
 
+  votableSupplyOracle?: TenantContract<IVotableSupplyOracleContract>;
   staker?: TenantContract<IStaker>;
   timelock?: TenantContract<BaseContract>;
   alligator?: TenantContract<IAlligatorContract>;


### PR DESCRIPTION
 * Add new contract return type for tenants to use votable supply oracle
 * Add a new component UpdateVotableSupplyOracle
 * Render the component ifn submit form and only if tenant has votable supply oracle contract
 * Return null if connected address is not the owner