### PR TITLE
Change dao metrics to be client side component

### DIFF
--- a/src/app/api/common/metrics/getMetrics.ts
+++ b/src/app/api/common/metrics/getMetrics.ts
@@ -3,11 +3,9 @@ import { cache } from "react";
 import { IMembershipContract } from "@/lib/contracts/common/interfaces/IMembershipContract";
 import { getPublicClient } from "@/lib/viem";
 import { findVotableSupply } from "@/lib/prismaUtils";
-import { unstable_cache } from "next/cache";
 
 async function getMetrics() {
   const { namespace, contracts, ui } = Tenant.current();
-
   try {
     const getTotalSupply = async () => {
       if (contracts.token.isERC20()) {
@@ -47,8 +45,4 @@ async function getMetrics() {
   }
 }
 
-export const fetchMetrics = unstable_cache(
-  getMetrics,
-  ["daoMetrics"],
-  { revalidate: 3600 } // 1 hour cache
-);
+export const fetchMetrics = cache(getMetrics);

--- a/src/app/api/common/metrics/route.ts
+++ b/src/app/api/common/metrics/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { fetchMetrics } from "./getMetrics";
+
+export async function GET() {
+  try {
+    const metrics = await fetchMetrics();
+    return NextResponse.json(metrics);
+  } catch (error) {
+    console.error("Error fetching metrics:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch metrics" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import "@/styles/globals.scss";
-import "@/styles/globals.scss";
 import ClientLayout from "./Web3Provider";
 import Header from "@/components/Header/Header";
 import { fetchMetrics } from "@/app/api/common/metrics/getMetrics";
@@ -51,7 +50,6 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const metrics = await fetchDaoMetrics();
   const { ui } = Tenant.current();
 
   const primary = ui?.customization?.primary || defaults.primary;
@@ -135,7 +133,7 @@ export default async function RootLayout({
         <ClientLayout>
           <Header />
           {children}
-          <DAOMetricsHeader metrics={metrics} />
+          <DAOMetricsHeader />
         </ClientLayout>
       </NuqsAdapter>
       {ui.googleAnalytics && <GoogleAnalytics gaId={ui.googleAnalytics} />}

--- a/src/components/Metrics/DAOMetricsHeader.jsx
+++ b/src/components/Metrics/DAOMetricsHeader.jsx
@@ -13,10 +13,12 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
+import { useDAOMetrics } from "@/hooks/useDAOMetrics";
 
-export default function DAOMetricsHeader({ metrics }) {
+export default function DAOMetricsHeader() {
   const { token, ui, contracts } = Tenant.current();
   const [isClient, setIsClient] = useState(false);
+  const { votableSupply, totalSupply, isLoading } = useDAOMetrics();
 
   const governanceForumLink = ui.link("governance-forum");
   const bugsLink = ui.link("bugs");
@@ -35,8 +37,8 @@ export default function DAOMetricsHeader({ metrics }) {
   }, []);
 
   const formattedMetrics = {
-    votableSupply: formatNumber(metrics.votableSupply),
-    totalSupply: formatNumber(metrics.totalSupply),
+    votableSupply: formatNumber(votableSupply),
+    totalSupply: formatNumber(totalSupply),
   };
 
   if (!isClient) {
@@ -59,7 +61,8 @@ export default function DAOMetricsHeader({ metrics }) {
                   <HoverCard openDelay={100} closeDelay={100}>
                     <HoverCardTrigger>
                       <span className="cursor-default">
-                        {formattedMetrics.totalSupply} {token.symbol} total
+                        {isLoading ? "-" : formattedMetrics.totalSupply}{" "}
+                        {token.symbol} total
                         <span className="hidden sm:inline">&nbsp;supply</span>
                       </span>
                     </HoverCardTrigger>
@@ -75,8 +78,8 @@ export default function DAOMetricsHeader({ metrics }) {
                     <HoverCard openDelay={100} closeDelay={100}>
                       <HoverCardTrigger>
                         <span className="cursor-default">
-                          {formattedMetrics.votableSupply} {token.symbol}{" "}
-                          votable
+                          {isLoading ? "-" : formattedMetrics.votableSupply}{" "}
+                          {token.symbol} votable
                           <span className="hidden sm:inline">&nbsp;supply</span>
                         </span>
                       </HoverCardTrigger>

--- a/src/hooks/useDAOMetrics.js
+++ b/src/hooks/useDAOMetrics.js
@@ -15,7 +15,7 @@ const fetchMetrics = async () => {
 
 export function useDAOMetrics() {
   const { data, isLoading, error } = useQuery({
-    queryKey: ["daoMetrics"],
+    queryKey: ["tokenMetrics"],
     queryFn: fetchMetrics,
     cacheTime: 300,
     refetchOnWindowFocus: true,

--- a/src/hooks/useDAOMetrics.js
+++ b/src/hooks/useDAOMetrics.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+const fetchMetrics = async () => {
+  try {
+    const response = await fetch(`/api/common/metrics`);
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Error in fetchMetrics:", error);
+    throw error;
+  }
+};
+
+export function useDAOMetrics() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["daoMetrics"],
+    queryFn: fetchMetrics,
+    cacheTime: 300,
+    refetchOnWindowFocus: true,
+    initialData: {
+      votableSupply: "0",
+      totalSupply: "0",
+    },
+  });
+
+  return {
+    ...data,
+    isLoading,
+    error,
+  };
+}


### PR DESCRIPTION
* Change requests in metrics to be parallel
* Render Dao metrics component on client
* Add useGetMetrics hook for metrics data
* Add route for metrics to expose data to client

Since the proposal page is invalidated every 1 min but /info page is cached indefinitely there is a mismatch on the data. Changing this be client side request to sync the data between pages, since invalidating /info page seems unnecessary 