### PR TITLE
Feat: Change proposal type tabs to be based on config and types from contract

### DIFF
--- a/src/app/proposals/draft/utils/__tests__/proposalTypes.ts
+++ b/src/app/proposals/draft/utils/__tests__/proposalTypes.ts
@@ -1,0 +1,198 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { getProposalTypeMetaDataForTenant } from "../proposalTypes";
+import Tenant from "@/lib/tenant/tenant";
+
+// Store the original Tenant.current implementation
+const originalTenantCurrent = Tenant.current;
+
+// Helper function to mock Tenant with specific proposal types
+const mockTenantWithProposalTypes = (
+  proposalTypes: { type: string }[] = []
+) => {
+  Tenant.current = vi.fn().mockReturnValue({
+    ui: {
+      toggle: vi.fn().mockImplementation((name: string) => ({
+        name: "proposal-lifecycle",
+        enabled: true,
+        config: {
+          proposalTypes,
+        },
+      })),
+    },
+  });
+};
+
+describe("getProposalTypeMetaDataForTenant", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    Tenant.current = originalTenantCurrent;
+  });
+
+  test("should return empty array when no proposal types are provided", () => {
+    mockTenantWithProposalTypes([
+      { type: "basic" },
+      { type: "approval" },
+      { type: "optimistic" },
+    ]);
+
+    const result = getProposalTypeMetaDataForTenant([]);
+    expect(result).toEqual([]);
+  });
+
+  test("should return only proposal types that are enabled in the tenant config", () => {
+    mockTenantWithProposalTypes([{ type: "basic" }, { type: "approval" }]);
+
+    const proposalTypes = [
+      {
+        id: "0x123|0",
+        name: "Regular Proposal",
+        proposal_type_id: "0",
+      },
+      {
+        id: "0x123|1",
+        name: "Approval Proposal",
+        proposal_type_id: "1",
+      },
+      {
+        id: "0x123|2",
+        name: "Optimistic Proposal",
+        proposal_type_id: "2",
+      },
+    ];
+
+    const result = getProposalTypeMetaDataForTenant(proposalTypes);
+
+    expect(result).toContain("basic");
+    expect(result).toContain("approval");
+    expect(result).not.toContain("optimistic");
+    expect(result.length).toBe(2);
+  });
+
+  test("should correctly categorize proposal types based on their names", () => {
+    mockTenantWithProposalTypes([
+      { type: "basic" },
+      { type: "approval" },
+      { type: "optimistic" },
+    ]);
+
+    const proposalTypes = [
+      {
+        id: "0x123|0",
+        name: "Treasury transfers",
+        proposal_type_id: "0",
+      },
+      {
+        id: "0x123|1",
+        name: "Approval Voting",
+        proposal_type_id: "1",
+      },
+      {
+        id: "0x123|2",
+        name: "Optimistic Governance",
+        proposal_type_id: "2",
+      },
+    ];
+
+    const result = getProposalTypeMetaDataForTenant(proposalTypes);
+
+    // Should include all three types
+    expect(result).toContain("basic");
+    expect(result).toContain("approval");
+    expect(result).toContain("optimistic");
+    expect(result.length).toBe(3);
+  });
+
+  test("should handle case when tenant config has no proposal types", () => {
+    mockTenantWithProposalTypes([]);
+
+    const proposalTypes = [
+      {
+        id: "0x123|0",
+        name: "Regular Proposal",
+        proposal_type_id: "0",
+      },
+    ];
+
+    const result = getProposalTypeMetaDataForTenant(proposalTypes);
+
+    // Should return empty array since no types are enabled in config
+    expect(result).toEqual([]);
+  });
+
+  test("should handle case when toggle or config is undefined", () => {
+    // Mock Tenant.current with undefined toggle
+    Tenant.current = vi.fn().mockReturnValue({
+      ui: {
+        toggle: vi.fn().mockReturnValue(undefined),
+      },
+    });
+
+    const proposalTypes = [
+      {
+        id: "0x123|0",
+        name: "Regular Proposal",
+        proposal_type_id: "0",
+      },
+    ];
+
+    const result = getProposalTypeMetaDataForTenant(proposalTypes);
+
+    // Should return empty array since config is undefined
+    expect(result).toEqual([]);
+  });
+
+  test("should be case-insensitive when matching proposal types", () => {
+    mockTenantWithProposalTypes([{ type: "BASIC" }, { type: "approval" }]);
+
+    const proposalTypes = [
+      {
+        id: "0x123|0",
+        name: "regular proposal", // lowercase
+        proposal_type_id: "0",
+      },
+      {
+        id: "0x123|1",
+        name: "APPROVAL VOTING", // uppercase
+        proposal_type_id: "1",
+      },
+    ];
+
+    const result = getProposalTypeMetaDataForTenant(proposalTypes);
+
+    expect(result).toContain("basic");
+    expect(result).toContain("approval");
+    expect(result.length).toBe(2);
+  });
+
+  test("should handle if more proposal types are provided than config types", () => {
+    mockTenantWithProposalTypes([{ type: "basic" }]);
+
+    const proposalTypes = [
+      {
+        id: "0x123|0",
+        name: "Regular Proposal",
+        proposal_type_id: "0",
+      },
+      {
+        id: "0x123|1",
+        name: "Approval Proposal",
+        proposal_type_id: "1",
+      },
+      {
+        id: "0x123|2",
+        name: "Optimistic Proposal",
+        proposal_type_id: "2",
+      },
+    ];
+
+    const result = getProposalTypeMetaDataForTenant(proposalTypes);
+
+    expect(result).toContain("basic");
+    expect(result).not.toContain("approval");
+    expect(result).not.toContain("optimistic");
+    expect(result.length).toBe(1);
+  });
+});

--- a/src/app/proposals/draft/utils/proposalTypes.ts
+++ b/src/app/proposals/draft/utils/proposalTypes.ts
@@ -1,0 +1,37 @@
+import Tenant from "@/lib/tenant/tenant";
+import { PLMConfig } from "../types";
+
+export const getProposalTypeMetaDataForTenant = (proposalTypes: any[]) => {
+  const { ui } = Tenant.current();
+  const plmToggle = ui.toggle("proposal-lifecycle");
+
+  const enabledProposalTypesFromConfig = (
+    (plmToggle?.config as PLMConfig)?.proposalTypes || []
+  ).map((pt: any) => pt.type);
+
+  const proposalTypeMap = new Map();
+
+  proposalTypes.forEach((proposalType) => {
+    const name = proposalType.name.toLowerCase();
+
+    if (name.includes("approval")) {
+      proposalTypeMap.set("approval", true);
+    } else if (name.includes("optimistic")) {
+      proposalTypeMap.set("optimistic", true);
+    } else if (name.includes("social")) {
+      proposalTypeMap.set("social", true);
+    } else {
+      proposalTypeMap.set("basic", true);
+    }
+  });
+
+  // Filter the mapped types based on what's enabled in the config
+  const enabledProposalTypesFromAPI = Array.from(proposalTypeMap.keys()).filter(
+    (type) =>
+      enabledProposalTypesFromConfig.some(
+        (configType) => configType.toLowerCase() === type
+      )
+  );
+
+  return enabledProposalTypesFromAPI;
+};


### PR DESCRIPTION
  * Filter options for tabs based on both types in config and contract
  * Add a util to take contract types and return filtered proposal types
  
  Testing Notes:
  Tested with b3 by adding and removing approval voting.
<img width="1045" alt="Screenshot 2025-03-06 at 5 10 10 PM" src="https://github.com/user-attachments/assets/398fc6e8-aed2-4ad7-991e-e787079da253" />
<img width="1233" alt="Screenshot 2025-03-06 at 5 10 59 PM" src="https://github.com/user-attachments/assets/4734fd42-d3f3-493f-82d1-1f3bbd128feb" />
