### PR TITLE
Update switcher styling globally

### DIFF
--- a/src/components/shared/Switch.tsx
+++ b/src/components/shared/Switch.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const optionStyle =
-  "p-[5px] flex-1 text-center cursor-pointer rounded font-medium hover:bg-line hover:font-semibold text-primary/30 transition-colors transition-shadow";
+  "p-[5px] flex-1 text-center cursor-pointer rounded font-medium hover:bg-neutral hover:font-semibold text-primary/30 transition-colors transition-shadow";
 
 const selectedStyle =
   "text-primary font-semibold border border-line shadow-switcher transition-colors transition-shadow bg-neutral";
@@ -24,7 +24,7 @@ export function Switch({
   return (
     <div
       className={cn(
-        "flex text-sm flex-row gap-2 rounded-md border border-line overflow-hidden w-full p-1 bg-line",
+        "flex text-sm flex-row gap-2 rounded-md border border-line overflow-hidden w-full p-1 bg-line/50",
         className
       )}
     >

--- a/src/components/shared/Switch.tsx
+++ b/src/components/shared/Switch.tsx
@@ -10,9 +10,10 @@ type Props = {
 };
 
 const optionStyle =
-  "p-[5px] flex-1 text-center cursor-pointer rounded text-primary/30 font-medium hover:bg-line hover:font-semibold transition-all";
+  "p-[5px] flex-1 text-center cursor-pointer rounded text-primary/30 font-medium hover:bg-line hover:font-semibold transition-colors transition-shadow";
 
-const selectedStyle = "bg-tertiary/20 text-secondary font-semibold";
+const selectedStyle =
+  "bg-tertiary/20 text-secondary font-semibold border border-line shadow-md transition-colors transition-shadow";
 
 export function Switch({
   onSelectionChanged,

--- a/src/components/shared/Switch.tsx
+++ b/src/components/shared/Switch.tsx
@@ -10,10 +10,10 @@ type Props = {
 };
 
 const optionStyle =
-  "p-[5px] flex-1 text-center cursor-pointer rounded text-primary/30 font-medium hover:bg-line hover:font-semibold transition-colors transition-shadow";
+  "p-[5px] flex-1 text-center cursor-pointer rounded font-medium hover:bg-line hover:font-semibold text-primary/30 transition-colors transition-shadow";
 
 const selectedStyle =
-  "bg-tertiary/20 text-secondary font-semibold border border-line shadow-md transition-colors transition-shadow";
+  "text-primary font-semibold border border-line shadow-switcher transition-colors transition-shadow bg-neutral";
 
 export function Switch({
   onSelectionChanged,
@@ -24,7 +24,7 @@ export function Switch({
   return (
     <div
       className={cn(
-        "flex text-sm flex-row gap-2 rounded-md border border-line overflow-hidden w-full p-1",
+        "flex text-sm flex-row gap-2 rounded-md border border-line overflow-hidden w-full p-1 bg-line",
         className
       )}
     >
@@ -35,9 +35,7 @@ export function Switch({
             e.preventDefault();
             onSelectionChanged(option);
           }}
-          className={`${optionStyle}  ${
-            selection === option ? selectedStyle : ""
-          }`}
+          className={cn(optionStyle, selection === option && selectedStyle)}
         >
           {option}
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -349,6 +349,8 @@ module.exports = {
         "2xl": "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
         inner: "inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)",
         outline: "0 0 0 3px rgba(66, 153, 225, 0.5)",
+        switcher:
+          "0px 4px 12px 0px rgba(0, 0, 0, 0.04), 0px 4px 8px 0px rgba(0, 0, 0, 0.06)",
         none: "none",
       },
       maxWidth: {


### PR DESCRIPTION
Update switcher styles with border and shadow for active state.

Testing notes:
Tested on xai, cyber and b3.
<img width="453" alt="Screenshot 2025-03-14 at 5 38 12 PM" src="https://github.com/user-attachments/assets/e63f180d-4a82-44c9-b619-efbf38161647" />
<img width="490" alt="Screenshot 2025-03-14 at 5 39 39 PM" src="https://github.com/user-attachments/assets/ea2c8c0d-5e04-40b0-8eff-87307758c19f" />


<img width="483" alt="Screenshot 2025-03-14 at 5 48 20 PM" src="https://github.com/user-attachments/assets/aa2cd325-9920-45fc-9db9-2a42045be1ce" />

Changes can be seen on
1. Create draft page selection of type of proposal
2. In approval proposal creation form for threshold and top choices.
3. votes panel for has and hasn't voted. 
