### PR TITLE
XAI vote with vXAI showing 0 unexpectedly fix

### DIFF
--- a/src/lib/proposalUtils.ts
+++ b/src/lib/proposalUtils.ts
@@ -221,7 +221,7 @@ export async function parseProposal(
   return {
     id: proposal.proposal_id,
     proposer: proposal.proposer,
-    snapshotBlockNumber: Number(createdBlock),
+    snapshotBlockNumber: Number(proposal.created_block),
     createdTime:
       proposalData.key === "SNAPSHOT"
         ? new Date(proposalData.kind.created_ts * 1000)


### PR DESCRIPTION
Tested by hardcoding the address with the issue to the query in getVotingPowerForProposalByAddress.

Issue was caused by the conversion between l1 block and arb block. Checked all uses of snapshotBlockNumber and it's safe to make the change made here. snapshotBlockNumber is used just a few times throughout the codebase for comparisons with snaps blocks. The snaps blocks are using arb blocks.