### PR TITLE
Fix: Remove vote reason text field if proposal is not active

### DIFF
--- a/src/components/Votes/CastVoteInput/CastVoteInput.tsx
+++ b/src/components/Votes/CastVoteInput/CastVoteInput.tsx
@@ -167,13 +167,15 @@ function CastVoteInputContent({
             <div className="bg-neutral border-t border-line px-3 ">
               {!isLoading && (
                 <div className="flex flex-col gap-2">
-                  <textarea
-                    placeholder="I believe..."
-                    value={reason || undefined}
-                    onChange={(e) => setReason(e.target.value)}
-                    rows={reason ? undefined : 1}
-                    className="text-sm text-primary bg-neutral resize-none rounded-lg border border-line rounded-b-lg focus:outline-none focus:inset-0 focus:shadow-none focus:outline-offset-0 mt-3"
-                  />
+                  {proposal.status === "ACTIVE" && (
+                    <textarea
+                      placeholder="I believe..."
+                      value={reason || undefined}
+                      onChange={(e) => setReason(e.target.value)}
+                      rows={reason ? undefined : 1}
+                      className="text-sm text-primary bg-neutral resize-none rounded-lg border border-line rounded-b-lg focus:outline-none focus:inset-0 focus:shadow-none focus:outline-offset-0 mt-3"
+                    />
+                  )}
                   <VoteButtons
                     proposalStatus={proposal.status}
                     isOptimistic={isOptimistic}


### PR DESCRIPTION
Only show text field for reasoning when proposal is active

Tested on [OP](https://agora-next-optimism-git-sudheer-eng-1386-vote-6bb27e-voteagora.vercel.app/proposals/84511922734478887667300419900648701566511387783615524992018614345859900443455)