### PR TITLE
Fix: Invalidate delegate cache on saving email preferences

### DIFF
--- a/src/app/api/common/notifications/updateNotificationPreferencesForAddress.ts
+++ b/src/app/api/common/notifications/updateNotificationPreferencesForAddress.ts
@@ -2,7 +2,8 @@ import { prismaWeb2Client } from "@/app/lib/prisma";
 import Tenant from "@/lib/tenant/tenant";
 import { cache } from "react";
 import { z } from "zod";
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateDelegateAddressPage } from "@/app/delegates/actions";
 
 const NotificationPreferencesOptionsSchema = z.object({
   wants_proposal_created_email: z.union([
@@ -55,8 +56,7 @@ const updateNotificationPreferencesForAddress = async (
       },
     });
 
-    // Invalidate the delegate cache for this specific address
-    revalidateTag(`delegate-${validatedAddress}`);
+    revalidateDelegateAddressPage(validatedAddress);
 
     return result;
   } catch (error) {

--- a/src/app/delegates/actions.ts
+++ b/src/app/delegates/actions.ts
@@ -115,8 +115,7 @@ export async function submitDelegateStatement({
     scwAddress,
   });
 
-  revalidateTag("delegate");
-  revalidateTag("delegateStatement");
+  revalidateDelegateAddressPage(address.toLowerCase());
   revalidatePath("/delegates/create", "page");
   return response;
 }
@@ -177,7 +176,7 @@ export const fetchConnectedDelegate = async (address: string) => {
 export const revalidateDelegateAddressPage = async (
   delegateAddress: string
 ) => {
-  revalidateTag("delegate");
+  revalidateTag(`delegate-${delegateAddress}`);
   revalidatePath(`/delegates/${delegateAddress}`, "page");
 };
 

--- a/src/app/delegates/actions.ts
+++ b/src/app/delegates/actions.ts
@@ -25,16 +25,25 @@ import Tenant from "@/lib/tenant/tenant";
 import { PaginationParams } from "../lib/pagination";
 import { fetchUpdateNotificationPreferencesForAddress } from "@/app/api/common/notifications/updateNotificationPreferencesForAddress";
 
-export const fetchDelegate = unstable_cache(
-  async (address: string) => {
-    return await apiFetchDelegate(address);
-  },
-  ["delegate"],
-  {
-    revalidate: 180, // 10 minute cache
-    tags: ["delegate"],
+export const fetchDelegate = async (address: string) => {
+  try {
+    const cachedFetchDelegate = unstable_cache(
+      async () => {
+        return await apiFetchDelegate(address);
+      },
+      [`delegate-${address.toLowerCase()}`],
+      {
+        revalidate: 180, // 3 minutes
+        tags: [`delegate-${address.toLowerCase()}`],
+      }
+    );
+
+    return await cachedFetchDelegate();
+  } catch (error) {
+    console.error("Error fetching delegate data:", error);
+    throw error;
   }
-);
+};
 
 export const fetchVoterStats = unstable_cache(
   async (address: string, blockNumber?: number) => {

--- a/src/components/Notifications/SubscribeDialog.tsx
+++ b/src/components/Notifications/SubscribeDialog.tsx
@@ -59,7 +59,7 @@ const SubscribeDialog = ({
   const { address } = useAccount();
   const [isHovering, setIsHovering] = useState(false);
   const [email, setEmail] = useState<string | undefined>(undefined);
-  const { data: delegate } = useDelegate({ address: address });
+  const { data: delegate, refetch } = useDelegate({ address: address });
   const existingEmail = delegate?.statement.email;
   const hasEmail = existingEmail && existingEmail !== "";
 
@@ -107,6 +107,8 @@ const SubscribeDialog = ({
                   wants_proposal_ending_soon_email: "prompted",
                 }
               );
+              // refresh delegate data
+              await refetch();
               closeDialog();
             } catch (error) {
               toast.error("Error updating notification preferences.");
@@ -127,6 +129,7 @@ const SubscribeDialog = ({
           No thanks
         </Button>
         <Button
+          disabled={!(existingEmail || email)}
           className="w-full"
           onMouseOver={() => {
             setIsHovering(true);
@@ -144,6 +147,8 @@ const SubscribeDialog = ({
                   wants_proposal_ending_soon_email: true,
                 }
               );
+              // refresh delegate data
+              await refetch();
               closeDialog();
               toast.success("Preferences saved.");
             } catch (error) {

--- a/src/hooks/useConnectedDelegate.ts
+++ b/src/hooks/useConnectedDelegate.ts
@@ -46,7 +46,7 @@ const useConnectedDelegate = () => {
             queryKey: [DELEGATE_QK, address],
           }),
         ]).finally(() => {
-          revalidateDelegateAddressPage(refetchDelegate.address);
+          revalidateDelegateAddressPage(refetchDelegate.address.toLowerCase());
         });
       }
       setLastVotingPower(delegate.votingPower.total);

--- a/src/hooks/useDelegate.tsx
+++ b/src/hooks/useDelegate.tsx
@@ -1,6 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchDelegate } from "@/app/delegates/actions";
 import { Delegate } from "@/app/api/common/delegates/delegate";
+import { useCallback } from "react";
 
 const CACHE_TIME = 180000; // 3 minute cache
 
@@ -10,7 +11,7 @@ interface Props {
 export const DELEGATE_QK = "delegate";
 
 export const useDelegate = ({ address }: Props) => {
-  const { data, isFetching, isFetched } = useQuery({
+  const { data, isFetching, isFetched, refetch } = useQuery({
     enabled: !!address,
     queryKey: [DELEGATE_QK, address],
     queryFn: async () => {
@@ -19,5 +20,5 @@ export const useDelegate = ({ address }: Props) => {
     staleTime: CACHE_TIME,
   });
 
-  return { data, isFetching, isFetched };
+  return { data, isFetching, isFetched, refetch };
 };

--- a/src/hooks/useDelegate.tsx
+++ b/src/hooks/useDelegate.tsx
@@ -1,7 +1,6 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { fetchDelegate } from "@/app/delegates/actions";
 import { Delegate } from "@/app/api/common/delegates/delegate";
-import { useCallback } from "react";
 
 const CACHE_TIME = 180000; // 3 minute cache
 


### PR DESCRIPTION
* Add a tag with address for API
* Invalidate delegate tag on saving preferences
* Refetch client side settings on saving preferences

Testing notes:

1. Changed DB entry for a wallet with "prompt" as preferences, with email address linked in profile.
2. Open preview, should show the prompt. 
3. Click on notify me, wait for success message.
4. switch to voters tab, come back to proposals. Should not see prompt again.

Repeat same steps till 3 and  instead of step 4 refresh the page, should not see prompt again.

Same as both cases but have no mail address linked in delegate profile, and repeat the steps.