### PR TITLE
Fix: Uniswap and ENS proposal type selector showing empty selector

### DIFF
--- a/src/app/proposals/draft/components/stages/DraftForm/DraftFormClient.tsx
+++ b/src/app/proposals/draft/components/stages/DraftForm/DraftFormClient.tsx
@@ -155,20 +155,21 @@ const DraftFormClient = ({
         <FormCard>
           <FormCard.Section>
             <div className="flex flex-col space-y-6">
-              <div className="grid grid-cols-2 gap-4">
-                <SwitchInput
-                  control={control}
-                  label="Voting module"
-                  required={true}
-                  options={enabledProposalTypesFromConfigAndAPI}
-                  name="type"
-                />
+              {validProposalTypes.length > 0 && (
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <SwitchInput
+                    control={control}
+                    label="Voting module"
+                    required={true}
+                    options={enabledProposalTypesFromConfigAndAPI}
+                    name="type"
+                  />
 
-                <p className="text-sm self-center text-agora-stone-700 mt-6">
-                  {ProposalTypeMetadata[votingModuleType].description}
-                </p>
-              </div>
-
+                  <p className="text-sm self-center text-agora-stone-700 mt-6">
+                    {ProposalTypeMetadata[votingModuleType].description}
+                  </p>
+                </div>
+              )}
               {validProposalTypes.length > 1 ? (
                 <div className="relative">
                   <SelectInput


### PR DESCRIPTION
 * For Uniswap and ENS there are no proposal types to show. In case of empty types remove the tab selector from UI
 * change tab selector in UI to be grid col 1 for smaller screens so that proposal type tabs take up available space ([Ticket](https://voteagora.atlassian.net/browse/ENG-1434)).
 
 
<img width="1098" alt="Screenshot 2025-04-08 at 6 07 17 PM" src="https://github.com/user-attachments/assets/e83612f5-f2c9-4a5c-bfd2-9a4ce822dd3e" />
<img width="392" alt="Screenshot 2025-04-08 at 5 04 46 PM" src="https://github.com/user-attachments/assets/d17231dc-3e9a-40ab-bcf1-88a604b3db5d" />