### PR TITLE
Fixing Optimistic / Approval module cancellation

### DIFF
--- a/src/app/proposals/components/AgoraOptimismGovCancel.tsx
+++ b/src/app/proposals/components/AgoraOptimismGovCancel.tsx
@@ -52,6 +52,12 @@ export const AgoraOptimismGovCancel = ({ proposal }: Props) => {
           ? approvalModuleAddress
           : optimisticModuleAddress;
 
+      // When using cancelWithModule, the proposal data needs to be a hex string otherwise the bytecode
+      // won't match the proposal and the transaction will fail.
+      const proposalData = proposal.unformattedProposalData?.startsWith("0x")
+        ? proposal.unformattedProposalData
+        : `0x${proposal.unformattedProposalData}`;
+
       if (!moduleAddress) {
         throw new Error(
           `Module address not found for tenant ${Tenant.current().namespace}`
@@ -59,7 +65,7 @@ export const AgoraOptimismGovCancel = ({ proposal }: Props) => {
       }
       return [
         moduleAddress,
-        proposal.unformattedProposalData,
+        proposalData,
         keccak256(toUtf8Bytes(proposal.description!)),
       ];
     }


### PR DESCRIPTION
The issue turned out to be the missing ‘0x’ prefix in the unformattedProposalData. When cancelWithModule was called, the bytecode didn’t match, and the proposal cancellation failed. This affected Optimistic and Approval proposals. The Standard proposal types were unaffected, as they used the standard cancel method.

Testing 
- [x] Cancelled [Optimistic proposal](https://optimistic.etherscan.io/tx/0x33b2ebd23edae316e32cf0ae9a514367892e2b9d53645914b4656d831a0147d5)
- [x] Cancelled [Approval proposal](https://optimistic.etherscan.io/tx/0x8c71afb34f4e08a0bd3eab4742077c4b30d78f58f746f8e23e7371d2d2a9b945)
- [x] Cancelled [Standard proposal](https://optimistic.etherscan.io/tx/0x87cf0f41f18f1d47a5f8c63603fd54082ebd239c9d6d6f6ed3d13d7e5aec56f5)