### PR TITLE
Fix: Show short error messages on contract reverts

### DIFF
--- a/src/app/proposals/components/AgoraGovCancel.tsx
+++ b/src/app/proposals/components/AgoraGovCancel.tsx
@@ -37,7 +37,10 @@ export const AgoraGovCancel = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error cancelling proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error cancelling proposal ${errorMessage}`, {
         duration: 5000,
       });
     }

--- a/src/app/proposals/components/AgoraGovExecute.tsx
+++ b/src/app/proposals/components/AgoraGovExecute.tsx
@@ -57,7 +57,10 @@ export const AgoraGovExecute = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error executing proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error executing proposal ${errorMessage}`, {
         duration: 10000,
       });
     }

--- a/src/app/proposals/components/AgoraGovQueue.tsx
+++ b/src/app/proposals/components/AgoraGovQueue.tsx
@@ -28,7 +28,10 @@ export const AgoraGovQueue = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error queuing proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error queuing proposal ${errorMessage}`, {
         duration: 10000,
       });
     }

--- a/src/app/proposals/components/AgoraOptimismGovCancel.tsx
+++ b/src/app/proposals/components/AgoraOptimismGovCancel.tsx
@@ -79,7 +79,10 @@ export const AgoraOptimismGovCancel = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error cancelling proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error cancelling proposal ${errorMessage}`, {
         duration: 5000,
       });
     }

--- a/src/app/proposals/components/AgoraOptimismGovExecute.tsx
+++ b/src/app/proposals/components/AgoraOptimismGovExecute.tsx
@@ -81,7 +81,10 @@ export const AgoraOptimismGovExecute = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error executing proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error executing proposal ${errorMessage}`, {
         duration: 10000,
       });
     }

--- a/src/app/proposals/components/AgoraOptimismGovQueue.tsx
+++ b/src/app/proposals/components/AgoraOptimismGovQueue.tsx
@@ -53,7 +53,10 @@ export const AgoraOptimismGovQueue = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error queuing proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error queuing proposal ${errorMessage}`, {
         duration: 10000,
       });
     }

--- a/src/app/proposals/components/BravoGovCancel.tsx
+++ b/src/app/proposals/components/BravoGovCancel.tsx
@@ -39,7 +39,10 @@ export const BravoGovCancel = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error cancelling proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error cancelling proposal ${errorMessage}`, {
         duration: 5000,
       });
     }

--- a/src/app/proposals/components/BravoGovExecute.tsx
+++ b/src/app/proposals/components/BravoGovExecute.tsx
@@ -62,7 +62,10 @@ export const BravoGovExecute = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error executing proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error executing proposal ${errorMessage}`, {
         duration: 5000,
       });
     }

--- a/src/app/proposals/components/OZGovExecute.tsx
+++ b/src/app/proposals/components/OZGovExecute.tsx
@@ -78,7 +78,10 @@ export const OZGovExecute = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error executing proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error executing proposal ${errorMessage}`, {
         duration: 5000,
       });
     }

--- a/src/app/proposals/components/OZGovQueue.tsx
+++ b/src/app/proposals/components/OZGovQueue.tsx
@@ -28,7 +28,10 @@ export const OZGovQueue = ({ proposal }: Props) => {
       );
     }
     if (isError) {
-      toast.error(`Error queuing proposal ${error?.message}`, {
+      const errorMessage =
+        "shortMessage" in error ? error.shortMessage : error.message;
+
+      toast.error(`Error queuing proposal ${errorMessage}`, {
         duration: 5000,
       });
     }


### PR DESCRIPTION
 * Use short error message from error obj instead of message which has quite a lot of data such as gas etc.
 
<img width="571" alt="Screenshot 2025-04-10 at 8 06 44 PM" src="https://github.com/user-attachments/assets/2821bd2f-2509-4520-82ca-713985bb2d15" />
