### PR TITLE
ENG-1524 tactical fix delegate from table

### DIFF
--- a/src/app/api/common/delegations/getDelegations.ts
+++ b/src/app/api/common/delegations/getDelegations.ts
@@ -188,7 +188,8 @@ async function getCurrentDelegatorsForAddress({
                                     AND ghost."from" = $2`;
     }
 
-    if (namespace === TENANT_NAMESPACES.OPTIMISM) { // This case is actually, just any tenant that has a delegatees_mat view working and compatible.
+    if (namespace === TENANT_NAMESPACES.OPTIMISM) {
+      // This case is actually, just any tenant that has a delegatees_mat view working and compatible.
       directDelegatorsSubQry = `  SELECT
                                     "from",
                                     "to",
@@ -203,7 +204,7 @@ async function getCurrentDelegatorsForAddress({
                                       address = $3 AND
                                       "to" = $1
                                   ORDER BY
-                                    block_number DESC`
+                                    block_number DESC`;
     } else if (contracts.delegationModel === DELEGATION_MODEL.PARTIAL) {
       directDelegatorsSubQry = `WITH ghost as (SELECT
                   null::text as "from",
@@ -287,7 +288,6 @@ async function getCurrentDelegatorsForAddress({
                 transaction_index DESC`;
     }
 
-
     const delegatorsQry = `
         WITH advanced_delegatees AS ( ${advancedDelegatorsSubQry} ),
              direct_delegatees AS ( ${directDelegatorsSubQry} )
@@ -296,7 +296,7 @@ async function getCurrentDelegatorsForAddress({
         SELECT * FROM direct_delegatees
         OFFSET $4
         LIMIT $5;
-      `
+      `;
 
     const [delegators, latestBlock] = await Promise.all([
       paginateResult(async (skip: number, take: number) => {

--- a/src/app/api/common/delegations/getDelegations.ts
+++ b/src/app/api/common/delegations/getDelegations.ts
@@ -188,7 +188,23 @@ async function getCurrentDelegatorsForAddress({
                                     AND ghost."from" = $2`;
     }
 
-    if (contracts.delegationModel === DELEGATION_MODEL.PARTIAL) {
+    if (namespace === TENANT_NAMESPACES.OPTIMISM) { // This case is actually, just any tenant that has a delegatees_mat view working and compatible.
+      directDelegatorsSubQry = `  SELECT
+                                    "from",
+                                    "to",
+                                    NULL::numeric AS allowance,
+                                    'DIRECT' AS type,
+                                    block_number,
+                                    'FULL' AS amount,
+                                    transaction_hash
+                                  FROM
+                                    ${namespace}.delegatees_mat
+                                  WHERE
+                                      address = $3 AND
+                                      "to" = $1
+                                  ORDER BY
+                                    block_number DESC`
+    } else if (contracts.delegationModel === DELEGATION_MODEL.PARTIAL) {
       directDelegatorsSubQry = `WITH ghost as (SELECT
                   null::text as "from",
                   null::text as "to",


### PR DESCRIPTION
This PR changes out the delegate delegate-from table query, for Optimism.

Doing a full-scan of the 1.5Gb table is just too much to do.  There is a pending data-layer change that adds a materialized view to support.

# How it was tested

* Compared from-delegate table for 1 large OP User vs Prod -> and visually inspected for deltas
* Wrote a python script to run the old and new sub-query for direct delegates, comparing the # of records for 1 large delegate.

# Post Production Deployment Testing

- [ ] Navigate to each tenant, attempt to load 1 delegate state