### PR TITLE
Add filter to remove undelegation from `findDelegatee`

### DIFF
--- a/src/app/api/common/delegations/getDelegations.ts
+++ b/src/app/api/common/delegations/getDelegations.ts
@@ -244,7 +244,7 @@ async function getCurrentDelegatorsForAddress({
                                                      'DIRECT' as type,
                                                      block_number,
                                                      'FULL' as amount,
-                                                     transaction_hash from latest_delegations where to_delegate = LOWER($1) or delegator = LOWER($1)`;
+                                                     transaction_hash from latest_delegations where LOWER(to_delegate) = LOWER($1)`;
     } else {
       directDelegatorsSubQry = `
               SELECT

--- a/src/lib/prismaUtils.ts
+++ b/src/lib/prismaUtils.ts
@@ -15,6 +15,9 @@ export function findDelagatee({
     where: {
       delegator: address.toLowerCase(),
       contract,
+      delegatee: {
+        not: "0x0000000000000000000000000000000000000000",
+      },
     },
   };
 


### PR DESCRIPTION
This PR filters out undelegation records from from the `findDelegatee`.

### Before

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/f55fe104-0528-4413-96a9-e3d6980581d8" />

<img width="1326" alt="image" src="https://github.com/user-attachments/assets/3dd358a0-45fd-487d-b688-59870c30cc74" />

### After

# How this was tested

I ran it locally, set up the case where I delegated and then undelegated using 0xa622279f76ddbed4f2cc986c09244262dba8f4ba, on one tenant.

