### PR TITLE
Fix: Delegate participation in delegates table.

### DIFF
--- a/src/components/Delegates/DelegateCardList/DelegateTableRow.tsx
+++ b/src/components/Delegates/DelegateCardList/DelegateTableRow.tsx
@@ -17,6 +17,15 @@ export default function DelegateTableRow({
     address: delegate.address as `0x${string}`,
   });
 
+  const numProposals = voterStats?.total_proposals || 0;
+  const participation = Number(
+    Math.round(
+      ((voterStats?.last_10_props || 0) / Math.min(10, numProposals)) *
+        100 *
+        100
+    ) / 100
+  ).toFixed(2);
+
   return (
     <TableRow
       className="font-semibold cursor-pointer bg-neutral text-secondary"
@@ -34,7 +43,7 @@ export default function DelegateTableRow({
       </TableCell>
       <TableCell>{formatNumber(delegate.votingPower.total)}</TableCell>
       <TableCell>
-        {!isVoterStatsPending && `${(voterStats?.last_10_props || 0) * 10}%`}
+        {!isVoterStatsPending && numProposals > 0 && `${participation}%`}
       </TableCell>
       {/* @ts-ignore */}
       <TableCell>


### PR DESCRIPTION
 * Consider total proposal in calculating participation percentage. This matches the card layout calculation
 
 Jira: [Ticket](https://voteagora.atlassian.net/browse/ENG-1527) 
 Tested on scroll:
 
<img width="1800" alt="Screenshot 2025-04-18 at 3 55 16 PM" src="https://github.com/user-attachments/assets/b5f4ca93-4a9e-42eb-9948-4521b4e67c6c" />

<img width="1800" alt="Screenshot 2025-04-18 at 3 55 31 PM" src="https://github.com/user-attachments/assets/e3f95a29-98a7-4691-a697-615135497b8a" />
