### PR TITLE
Fix: Use token decimal in conversion for optimistic proposals

### DIFF
--- a/src/components/Proposals/Proposal/OPOptimisticProposalStatus.jsx
+++ b/src/components/Proposals/Proposal/OPOptimisticProposalStatus.jsx
@@ -1,5 +1,6 @@
 import { formatUnits } from "ethers";
 import { disapprovalThreshold } from "@/lib/constants";
+import Tenant from "@/lib/tenant/tenant";
 
 function formatNumber(amount, decimals = 0, maximumSignificantDigits = 4) {
   const standardUnitAmount = Number(formatUnits(amount, decimals));
@@ -10,10 +11,15 @@ export default function OPOptimisticProposalStatus({
   proposal,
   votableSupply,
 }) {
+  const tokenDecimals = Tenant.current().token.decimals;
   const formattedVotableSupply = Number(
-    BigInt(votableSupply) / BigInt(10 ** 18)
+    BigInt(votableSupply) / BigInt(10 ** tokenDecimals)
   );
-  const againstLength = formatNumber(proposal.proposalResults.against, 18, 0);
+  const againstLength = formatNumber(
+    proposal.proposalResults.against,
+    tokenDecimals,
+    0
+  );
   const againstRelativeAmount =
     (Math.floor(againstLength / formattedVotableSupply) * 100) / 100;
   const status =

--- a/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/OPProposalOptimisticPage.jsx
@@ -5,23 +5,23 @@ import { formatUnits } from "ethers";
 import ProposalDescription from "../ProposalDescription/ProposalDescription";
 import { ProposalStateAdmin } from "@/app/proposals/components/ProposalStateAdmin";
 import OptimisticProposalVotesCard from "@/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticProposalVotesCard";
+import Tenant from "@/lib/tenant/tenant";
 
 export default async function OPProposalPage({ proposal }) {
   const votableSupply = await fetchVotableSupply();
+  const tokenDecimals = Tenant.current().token.decimals;
   const formattedVotableSupply = Number(
-    BigInt(votableSupply) / BigInt(10 ** 18)
+    BigInt(votableSupply) / BigInt(10 ** tokenDecimals)
   );
-
   const againstLengthString = formatNumber(
     proposal.proposalResults.against,
-    18,
+    tokenDecimals,
     0,
     true
   );
   const againstLength = Number(
-    formatUnits(proposal.proposalResults.against, 18)
+    formatUnits(proposal.proposalResults.against, tokenDecimals)
   );
-
   const againstRelativeAmount = parseFloat(
     ((againstLength / formattedVotableSupply) * 100).toFixed(2)
   );


### PR DESCRIPTION
Pguild: 
<img width="696" alt="Screenshot 2025-04-18 at 7 57 13 PM" src="https://github.com/user-attachments/assets/2b08675d-0d33-481a-b653-d1d0b3ebd52c" />

Op existing proposals
<img width="601" alt="Screenshot 2025-04-18 at 8 48 17 PM" src="https://github.com/user-attachments/assets/6e891b9b-587b-4174-96ed-fb2a2d118df8" />
