### PR TITLE
ENG-1571-Action-preview-truncates-to-only-function-call-and-doesn-t-show-params

### DIFF
--- a/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
+++ b/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
@@ -585,11 +585,14 @@ const ActionSummary = ({
               <div className="truncate text-xs break-all">
                 <p>{functionSignature.functionName}(</p>
                 {functionSignature.paramValues &&
-                  functionSignature.paramValues.map( (param, idx) => (
+                  functionSignature.paramValues.slice(0, 3).map( (param, idx) => (
                   <p key={idx} className="font-medium" style={{ marginLeft: '1em' }}
-                    >{param[0]}={param[1]}</p>
+                    >{param[0]}={param[1]},</p>
                   )
                 )}
+                {functionSignature.paramValues && functionSignature.paramValues.length > 3 &&
+                  <p className="font-medium" style={{ marginLeft: '1em' }}>...</p>
+                }
                 <p>)</p>
               </div>
             </TooltipTrigger>

--- a/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
+++ b/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
@@ -583,7 +583,10 @@ const ActionSummary = ({
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="truncate text-xs break-all">
-                <p>{functionSignature.functionName}(</p>
+                <p>
+                  {functionSignature.functionName}(
+                  {functionSignature.paramValues && functionSignature.paramValues.length === 0 && <span>)</span>}
+                </p>
                 {functionSignature.paramValues &&
                   functionSignature.paramValues.slice(0, 3).map( (param, idx) => (
                   <p key={idx} className="font-medium" style={{ marginLeft: '1em' }}
@@ -593,7 +596,9 @@ const ActionSummary = ({
                 {functionSignature.paramValues && functionSignature.paramValues.length > 3 &&
                   <p className="font-medium" style={{ marginLeft: '1em' }}>...</p>
                 }
-                <p>)</p>
+                {functionSignature.paramValues && functionSignature.paramValues.length > 0 &&
+                  <p>)</p>
+                }
               </div>
             </TooltipTrigger>
             <TooltipContent>

--- a/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
+++ b/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
@@ -583,12 +583,12 @@ const ActionSummary = ({
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="truncate text-xs break-all">
-                {functionSignature}
+                {functionSignature.stringValue}
               </div>
             </TooltipTrigger>
             <TooltipContent>
               <div className="text-xs break-all max-w-[400px]">
-                {functionSignature}
+                {functionSignature.stringValue}
               </div>
             </TooltipContent>
           </Tooltip>

--- a/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
+++ b/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
@@ -583,7 +583,14 @@ const ActionSummary = ({
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="truncate text-xs break-all">
-                {functionSignature.stringValue}
+                <p>{functionSignature.functionName}(</p>
+                {functionSignature.paramValues &&
+                  functionSignature.paramValues.map( (param, idx) => (
+                  <p key={idx} className="font-medium" style={{ marginLeft: '1em' }}
+                    >{param[0]}={param[1]}</p>
+                  )
+                )}
+                <p>)</p>
               </div>
             </TooltipTrigger>
             <TooltipContent>

--- a/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
+++ b/src/components/Proposals/ProposalPage/ApprovedTransactions/ProposalTransactionDisplay.tsx
@@ -595,7 +595,7 @@ const ActionSummary = ({
             </TooltipTrigger>
             <TooltipContent>
               <div className="text-xs break-all max-w-[400px]">
-                {functionSignature.stringValue}
+                {functionSignature.toStringValue()}
               </div>
             </TooltipContent>
           </Tooltip>

--- a/src/lib/seatbelt/checks/check-decode-calldata.ts
+++ b/src/lib/seatbelt/checks/check-decode-calldata.ts
@@ -217,7 +217,7 @@ async function prettifyCalldata(
       call.input as `0x${string}`
     );
     if (decoded && decoded.usedMethod !== "failed") {
-      const signature = getFunctionSignature(decoded);
+      const signature = getFunctionSignature(decoded)?.toStringValue() ?? "unknown";
       return `\`${call.from}\` calls \`${signature}\` on ${contractIdentifier} (decoded from ABI)`;
     }
 

--- a/src/lib/seatbelt/checks/check-decode-calldata.ts
+++ b/src/lib/seatbelt/checks/check-decode-calldata.ts
@@ -217,7 +217,9 @@ async function prettifyCalldata(
       call.input as `0x${string}`
     );
     if (decoded && decoded.usedMethod !== "failed") {
-      const signature = getFunctionSignature(decoded)?.toStringValue() ?? "unknown";
+      const signatureRaw = getFunctionSignature(decoded);
+      // Will try string value, followed by just the function name, falling back to unknown.
+      const signature = signatureRaw?.toStringValue() ?? signatureRaw?.functionName?? 'unknown';
       return `\`${call.from}\` calls \`${signature}\` on ${contractIdentifier} (decoded from ABI)`;
     }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -671,7 +671,14 @@ export function getFunctionSignature(
 
       // Build the function signature
       let signature = `${functionName}(`;
-      signature += filteredParams.map(p => `${p[0]}=${p[1]}`).join(",");
+      signature += filteredParams.map(p => {
+        let formattedValue;
+        if (p[0] && p[1]) {formattedValue = `${p[0]}=${p[1]}`} // Default, has both name and value
+        else if (p[0] && !p[1]) {formattedValue = `${p[0]}`} // Has only name
+        else if (!p[0] && p[1]) {formattedValue = `${p[1]}`} // Has only Value
+        else if (!p[0] && !p[1]) {formattedValue = `${p[1]}`} // Has neither name nor value, fallback type
+        return formattedValue;
+      }).join(",");
       signature += ")";
       return signature;
     };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,7 +3,7 @@ import { twMerge } from "tailwind-merge";
 import { useMemo } from "react";
 import Tenant from "./tenant/tenant";
 import { TENANT_NAMESPACES } from "./constants";
-import { http, fallback } from "wagmi";
+import { fallback, http } from "wagmi";
 import {
   DERIVE_MAINNET_RPC,
   DERIVE_TESTNET_RPC,
@@ -25,8 +25,8 @@ import {
   mainnet,
   optimism,
   polygon,
-  sepolia,
   scroll,
+  sepolia,
 } from "viem/chains";
 
 const { token } = Tenant.current();
@@ -631,8 +631,13 @@ export function getFunctionSignature(decodedData: any): string | null {
   try {
     let signature = `${decodedData.function}(`;
     const paramTypes = Object.entries(decodedData.parameters).map(
-      ([_, param]: [string, any]) => {
-        return param.type || "unknown";
+      // Takes the object name of the parameter and the value supplied and concatenates a string value
+      ([paramName, paramValue]: [string, any]) => {
+        // Force unknown if undefined
+        if (paramName === undefined || paramValue.value === undefined) {
+          return "unknown";
+        }
+        return ` ${paramName.toString()}=${paramValue.value}`;
       }
     );
     signature += paramTypes.join(",");

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -621,7 +621,7 @@ export const wrappedWaitForTransactionReceipt = async (
 
 interface FunctionSignature {
   functionName: string;
-  stringValue: string;
+  toStringValue: () => string;
   paramValues?: [string, string][] | null;
 }
 
@@ -655,9 +655,12 @@ export function getFunctionSignature(
 
     const functionName = decodedData.function.toString();
 
-    let signature = `${functionName}(`;
-    signature += paramTypes.map(p => p.stringValue).join(",");
-    signature += ")";
+    const toStringValue = () => {
+      let signature = `${functionName}(`;
+      signature += paramTypes.map(p => p.stringValue).join(",");
+      signature += ")";
+      return signature;
+    }
 
     // Filter out null values from the param values
     const paramValues = paramTypes
@@ -666,7 +669,7 @@ export function getFunctionSignature(
 
       return {
         functionName: functionName,
-        stringValue: signature,
+        toStringValue: toStringValue,
         paramValues: paramValues
       };
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -620,6 +620,7 @@ export const wrappedWaitForTransactionReceipt = async (
 };
 
 interface FunctionSignature {
+  functionName: string;
   stringValue: string;
   paramValues?: [string, string][] | null;
 }
@@ -652,7 +653,9 @@ export function getFunctionSignature(
       }
     );
 
-    let signature = `${decodedData.function}(`;
+    const functionName = decodedData.function.toString();
+
+    let signature = `${functionName}(`;
     signature += paramTypes.map(p => p.stringValue).join(",");
     signature += ")";
 
@@ -662,6 +665,7 @@ export function getFunctionSignature(
       .filter((p): p is [string, string] => p !== null);
 
       return {
+        functionName: functionName,
         stringValue: signature,
         paramValues: paramValues
       };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -673,10 +673,10 @@ export function getFunctionSignature(
       let signature = `${functionName}(`;
       signature += filteredParams.map(p => {
         let formattedValue;
-        if (p[0] && p[1]) {formattedValue = `${p[0]}=${p[1]}`} // Default, has both name and value
-        else if (p[0] && !p[1]) {formattedValue = `${p[0]}`} // Has only name
+        if (p[0] && p[1]) {formattedValue = `${p[0]}=${p[1]}`} // Default, has both Name and Value
+        else if (p[0] && !p[1]) {formattedValue = `${p[0]}`} // Has only Name
         else if (!p[0] && p[1]) {formattedValue = `${p[1]}`} // Has only Value
-        else if (!p[0] && !p[1]) {formattedValue = `${p[1]}`} // Has neither name nor value, fallback type
+        else if (!p[0] && !p[1]) {formattedValue = `${p[1]}`} // Has neither Name nor Value, fallback to Type
         return formattedValue;
       }).join(",");
       signature += ")";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -641,7 +641,7 @@ export function getFunctionSignature(
       paramValues: [string | null, string | null];
     }[] = Object.entries(decodedData.parameters).map(
       ([paramName, paramValue]: [string, any]) => {
-        // Force null if param value is undefined
+        //   Case where there is a name, but is no value, use name only
         if (paramName && paramValue.value === undefined) {
           return { paramValues: [paramName, null] };
         //   Case where there is no name, but is a value, use value only

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -638,12 +638,18 @@ export function getFunctionSignature(
 
   try {
     const paramTypes: {
-      paramValues: [string, string] | null;
+      paramValues: [string | null, string] | null;
     }[] = Object.entries(decodedData.parameters).map(
       ([paramName, paramValue]: [string, any]) => {
-        // Force null if undefined
-        if (paramName === undefined || paramValue.value === undefined) {
+        // Force null if param value is undefined
+        if (paramValue.value === undefined) {
           return { paramValues: null };
+        //   Case where there is no name, but is a value, use value only
+        } else if (!paramName && paramValue.value) {
+          return { paramValues: [null, paramValue.value]}
+        //   Case where neither name nor value, fall back to type as value
+        } else if (!paramName && paramValue.value === undefined) {
+          return { paramValues: [null, paramValue.type]}
         }
         return {
           paramValues: [paramName, paramValue.value],

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -638,12 +638,12 @@ export function getFunctionSignature(
 
   try {
     const paramTypes: {
-      paramValues: [string | null, string] | null;
+      paramValues: [string | null, string | null];
     }[] = Object.entries(decodedData.parameters).map(
       ([paramName, paramValue]: [string, any]) => {
         // Force null if param value is undefined
-        if (paramValue.value === undefined) {
-          return { paramValues: null };
+        if (paramName && paramValue.value === undefined) {
+          return { paramValues: [paramName, null] };
         //   Case where there is no name, but is a value, use value only
         } else if (!paramName && paramValue.value) {
           return { paramValues: [null, paramValue.value]}


### PR DESCRIPTION
This adds additional functionality to the action preview to show param variable names and values into the preview. If there are more than 3 parameters in the function signature, it will produce an ellipsis, but will still be seen from the tooltip.

The getFunctionSignature now returns an interface with the function name, the parameters in tuple format [name, value] if they exist, and a function to build a string representation of the functionSignature (used in the tooltip).