### PR TITLE
Garrett/eng 1539 gov editability

### DIFF
--- a/src/components/Admin/GovernorSettings.tsx
+++ b/src/components/Admin/GovernorSettings.tsx
@@ -81,7 +81,7 @@ export default function GovernorSettings() {
     );
   }
 
-  const { data: setVotingPeriodConfig, isError: setVotingPeriodError } =
+  const { data: votingPeriodConfig, isError: votingPeriodError } =
     useSimulateContract({
       ...govContract,
       functionName: "setVotingPeriod",
@@ -101,7 +101,7 @@ export default function GovernorSettings() {
     isLoadingSetVotingPeriod || isLoadingSetVotingPeriodTransaction;
 
   const [votingDelay, setVotingDelay] = useState("");
-  const { data: setVotingDelayConfig, isError: setVotingDelayError } =
+  const { data: votingDelayConfig, isError: votingDelayError } =
     useSimulateContract({
       ...govContract,
       functionName: "setVotingDelay",
@@ -142,8 +142,9 @@ export default function GovernorSettings() {
               min={0}
               step={0.01}
               writeContract={writeSetVotingPeriod}
-              setConfig={setVotingPeriodConfig}
+              setConfig={votingPeriodConfig}
               period={"hours"}
+              isError={votingPeriodError}
             />
             <GovernorUnlockedSetting
               name={"Voting Delay"}
@@ -153,8 +154,9 @@ export default function GovernorSettings() {
               min={0}
               step={0.01}
               writeContract={writeSetVotingDelay}
-              setConfig={setVotingDelayConfig}
+              setConfig={votingDelayConfig}
               period={"hours"}
+              isError={votingDelayError}
             />
           </div>
         ) : (
@@ -219,6 +221,7 @@ interface GovernLockSettingProps {
   step?: number;
   writeContract?: any;
   setConfig?: any;
+  isError?: boolean;
 }
 
 function GovernorUnlockedSetting(props: GovernLockSettingProps) {
@@ -230,7 +233,7 @@ function GovernorUnlockedSetting(props: GovernLockSettingProps) {
           min={props.min}
           value={props.value}
           onChange={(e) => props.setValue!(e.target.value)}
-          disabled={/* isInitializing || */ props.disabled}
+          disabled={/* isInitializing || */ props.disabled || props.isError}
           step={props.step}
           type="number"
         />
@@ -244,7 +247,7 @@ function GovernorUnlockedSetting(props: GovernLockSettingProps) {
           loading={props.disabled}
           disabled={
             /* isInitializing || */ props.disabled ||
-            // setVotingPeriodError ||
+            props.isError ||
             props.value === ""
           }
           onClick={() => {

--- a/src/components/Admin/GovernorSettings.tsx
+++ b/src/components/Admin/GovernorSettings.tsx
@@ -120,9 +120,6 @@ export default function GovernorSettings() {
     isLoadingSetVotingDelay || isLoadingSetVotingDelayTransaction;
 
   const isAdmin = address === adminAddress;
-  console.log(
-    `Is Admin ${isAdmin}\nAddress: ${address}\nAdmin Address: ${adminAddress}`
-  );
 
   return (
     <div className="gl_box bg-neutral">

--- a/src/components/Admin/GovernorSettings.tsx
+++ b/src/components/Admin/GovernorSettings.tsx
@@ -166,7 +166,14 @@ export default function GovernorSettings() {
     if (periodTXError) {
       console.error("Transaction error - period:", periodTXError);
     }
-  }, [delayTXStatus, delayTXerror, periodTXStatus, periodTXError]);
+  }, [
+    delayTXStatus,
+    delayTXerror,
+    periodTXStatus,
+    periodTXError,
+    resultSetVotingDelay,
+    resultSetVotingPeriod,
+  ]);
 
   return (
     <div className="gl_box bg-neutral">

--- a/src/components/Admin/GovernorSettings.tsx
+++ b/src/components/Admin/GovernorSettings.tsx
@@ -123,74 +123,21 @@ export default function GovernorSettings() {
         <h1 className="font-extrabold text-2xl text-primary">
           Governor settings
         </h1>
-        <p className="text-secondary">Set how all proposals work</p>
       </section>
       <div className="my-4">
-        <div className="space-y-4 sm:space-y-0 sm:flex sm:justify-between sm:gap-4">
-          <div className="flex-1">
-            <Label>Voting period</Label>
-            <div className="relative flex items-center">
-              <Input
-                min={0}
-                value={votingPeriod}
-                onChange={(e) => setVotingPeriod(e.target.value)}
-                disabled={/* isInitializing || */ isDisabledSetVotingPeriod}
-                step={0.01}
-                type="number"
-              />
-              <p className="absolute text-sm text-tertiary right-[96px]">
-                Hours
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="absolute right-[6px] rounded-sm"
-                loading={isDisabledSetVotingPeriod}
-                disabled={
-                  /* isInitializing || */ isDisabledSetVotingPeriod ||
-                  setVotingPeriodError ||
-                  votingPeriod === ""
-                }
-                onClick={() => {
-                  writeSetVotingPeriod(setVotingPeriodConfig!.request);
-                }}
-              >
-                Update
-              </Button>
-            </div>
+        <div className="space-y-1 sm:space-y-0 text-sm sm:flex sm:justify-between sm:items-center sm:px-2">
+          <div className="flex items-center gap-2">
+            <p className="text-secondary">Voting Period</p>
+            <Lock className="w-4 h-4 text-primary/30" />
           </div>
-          <div className="flex-1">
-            <Label>Voting delay</Label>
-            <div className="relative flex items-center">
-              <Input
-                min={0}
-                value={votingDelay}
-                onChange={(e) => setVotingDelay(e.target.value)}
-                disabled={/* isInitializing || */ isDisabledSetVotingDelay}
-                step={0.01}
-                type="number"
-              />
-              <p className="absolute text-sm text-tertiary right-[96px]">
-                Hours
-              </p>
-              <Button
-                className="absolute right-[6px] rounded-sm"
-                variant="outline"
-                size="sm"
-                loading={isDisabledSetVotingDelay}
-                disabled={
-                  /* isInitializing || */ isDisabledSetVotingDelay ||
-                  setVotingDelayError ||
-                  votingDelay === ""
-                }
-                onClick={() => {
-                  writeSetVotingDelay(setVotingDelayConfig!.request);
-                }}
-              >
-                Update
-              </Button>
-            </div>
+          <p className="text-secondary truncate">{votingPeriod}</p>
+        </div>
+        <div className="text-sm sm:flex sm:justify-between sm:items-center sm:px-2 mt-4">
+          <div className="flex items-center gap-2">
+            <p className="text-secondary">Voting Delay</p>
+            <Lock className="w-4 h-4 text-primary/30" />
           </div>
+          <p className="text-secondary truncate">{votingDelay}</p>
         </div>
         <Separator className="my-8" />
         <div className="space-y-1 sm:space-y-0 text-sm sm:flex sm:justify-between sm:items-center sm:px-2">

--- a/src/components/Admin/GovernorSettings.tsx
+++ b/src/components/Admin/GovernorSettings.tsx
@@ -125,38 +125,32 @@ export default function GovernorSettings() {
         </h1>
       </section>
       <div className="my-4">
-        <div className="space-y-1 sm:space-y-0 text-sm sm:flex sm:justify-between sm:items-center sm:px-2">
-          <div className="flex items-center gap-2">
-            <p className="text-secondary">Voting Period</p>
-            <Lock className="w-4 h-4 text-primary/30" />
-          </div>
-          <p className="text-secondary truncate">{votingPeriod}</p>
-        </div>
-        <div className="text-sm sm:flex sm:justify-between sm:items-center sm:px-2 mt-4">
-          <div className="flex items-center gap-2">
-            <p className="text-secondary">Voting Delay</p>
-            <Lock className="w-4 h-4 text-primary/30" />
-          </div>
-          <p className="text-secondary truncate">{votingDelay}</p>
-        </div>
+        <GovernorLockedSetting name={"Voting Period"} value={votingPeriod} />
+        <GovernorLockedSetting name={"Voting Delay"} value={votingDelay} />
         <Separator className="my-8" />
-        <div className="space-y-1 sm:space-y-0 text-sm sm:flex sm:justify-between sm:items-center sm:px-2">
-          <div className="flex items-center gap-2">
-            <p className="text-secondary">Manager Address</p>
-            <Lock className="w-4 h-4 text-primary/30" />
-          </div>
-          <p className="text-secondary truncate">{manager}</p>
-        </div>
-        <div className="text-sm sm:flex sm:justify-between sm:items-center sm:px-2 mt-4">
-          <div className="flex items-center gap-2">
-            <p className="text-secondary">Admin Address</p>
-            <Lock className="w-4 h-4 text-primary/30" />
-          </div>
-          <p className="text-secondary truncate">
-            {adminAddress ? adminAddress : "0x..."}
-          </p>
-        </div>
+        <GovernorLockedSetting name={"Manager Address"} value={manager} />
+        {adminAddress && (
+          <GovernorLockedSetting name={"Admin Address"} value={adminAddress} />
+        )}
       </div>
+    </div>
+  );
+}
+
+function GovernorLockedSetting({
+  name,
+  value,
+}: {
+  name: string;
+  value: string;
+}) {
+  return (
+    <div className="space-y-1 sm:space-y-0 text-sm sm:flex sm:justify-between sm:items-center sm:px-2 mb-4">
+      <div className="flex items-center gap-2">
+        <p className="text-secondary">{name}</p>
+        <Lock className="w-4 h-4 text-primary/30" />
+      </div>
+      <p className="text-secondary truncate">{value}</p>
     </div>
   );
 }

--- a/src/components/Admin/GovernorSettings.tsx
+++ b/src/components/Admin/GovernorSettings.tsx
@@ -121,7 +121,7 @@ export default function GovernorSettings() {
     <div className="gl_box bg-neutral">
       <section>
         <h1 className="font-extrabold text-2xl text-primary">
-          Governor settings
+          Governor Settings
         </h1>
       </section>
       <div className="my-4">

--- a/src/components/Admin/ProposalTypeSettings.tsx
+++ b/src/components/Admin/ProposalTypeSettings.tsx
@@ -63,7 +63,7 @@ const RestrictedCallout = () => {
     !addressesToRender.some((addr) => addr.address === address)
   ) {
     return (
-      <div className="text-sm w-[800px] rounded border-2 p-4 bg-negative/10 border-negative text-negative mt-4">
+      <div className="text-sm max-w-[800px] rounded border-2 p-4 bg-negative/10 border-negative text-negative mt-4 overflow-x-auto overflow-y-hidden">
         Only the following addresses can create or update proposal types:
         <ul className="list-disc list-inside">
           {addressesToRender.map((addr) => (

--- a/src/components/Admin/ProposalTypeSettings.tsx
+++ b/src/components/Admin/ProposalTypeSettings.tsx
@@ -150,7 +150,7 @@ export default function ProposalTypeSettings({
   return (
     <section className="gl_box bg-neutral">
       <h1 className="font-extrabold text-2xl text-primary">
-        Proposal type settings
+        Proposal Type Settings
       </h1>
       <p className="text-secondary">
         Create and manage different types of proposals


### PR DESCRIPTION
This change removes the ability to edit the page to change the Voting Period and Voting Delay.

The GovernSettings was given a GovernorLockedSetting component to templatize the component.

Capitalized Headings. Open to reverting depending on site themes and standards, just a personal preference.

There is state functions in here for controlling the values for voting period and delay. I am purposely leaving that functionality in case it is used in the future. It seems to be interlaced with other in use functions so did not comment it out.