### PR TITLE
garrett/ENG-1538-UI-to-Transfer-the-Governor-Manager-Role

### DIFF
--- a/src/components/Admin/AdminAccountActions.tsx
+++ b/src/components/Admin/AdminAccountActions.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Fragment } from "react";
+
+export default function AdminAccountActions() {
+  const handleAccountTransfer = () => {};
+
+  return (
+    <section className="gl_box bg-neutral">
+      <h1 className="font-extrabold text-2xl text-primary">Account Actions</h1>
+      <p className="text-secondary">
+        Perform administrative actions on your account
+      </p>
+      <AccountActions
+        title={"Transfer"}
+        description={"Transfer account role to another address"}
+        actions={[{ title: "Transfer", onClick: handleAccountTransfer }]}
+      />
+    </section>
+  );
+}
+
+interface AccountActionButtonProps {
+  title: string;
+  onClick: () => void;
+}
+
+function AccountActionButton(props: AccountActionButtonProps) {
+  return (
+    <div className="flex ml-10">
+      <Button title={props.title} onClick={props.onClick}>
+        {props.title}
+      </Button>
+    </div>
+  );
+}
+
+interface AccountActionsProps {
+  title: string;
+  description: string;
+  actions: Array<{ title: string; onClick: () => void }>;
+}
+
+function AccountActions(props: AccountActionsProps) {
+  return (
+    <Fragment>
+      <div className="flex justify-between items-center">
+        <p className="text-sm font-semibold text-primary">{props.title}</p>
+        <p className="text-sm text-muted-foreground p-2">{props.description}</p>
+        {props.actions.map((action, index) => (
+          <AccountActionButton
+            key={index}
+            title={action.title}
+            onClick={action.onClick}
+          />
+        ))}
+      </div>
+    </Fragment>
+  );
+}

--- a/src/components/Admin/AdminAccountActions.tsx
+++ b/src/components/Admin/AdminAccountActions.tsx
@@ -14,6 +14,8 @@ export default function AdminAccountActions() {
     });
   };
 
+  // TODO - Conditional check governor contract for handling manager account transfer
+
   return (
     <section className="gl_box bg-neutral">
       <h1 className="font-extrabold text-2xl text-primary">Account Actions</h1>

--- a/src/components/Admin/AdminAccountActions.tsx
+++ b/src/components/Admin/AdminAccountActions.tsx
@@ -5,6 +5,7 @@ import { Fragment } from "react";
 import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
 import Tenant from "@/lib/tenant/tenant";
 import { useAccount, useReadContract } from "wagmi";
+import { useRouter } from "next/router";
 
 export default function AdminAccountActions() {
   const openDialog = useOpenDialog();
@@ -13,11 +14,22 @@ export default function AdminAccountActions() {
   };
   const { slug, contracts } = Tenant.current();
   const { address } = useAccount();
+  const router = useRouter();
+
+  const rerouteHome = () => {
+    try {
+      router.push("/");
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   const handleAccountTransfer = () => {
     openDialog({
       type: "ACCOUNT_ACTION",
-      params: {},
+      params: {
+        onSuccess: rerouteHome,
+      },
     });
   };
   const actionsToRender = [];

--- a/src/components/Admin/AdminAccountActions.tsx
+++ b/src/components/Admin/AdminAccountActions.tsx
@@ -5,7 +5,6 @@ import { Fragment } from "react";
 import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
 import Tenant from "@/lib/tenant/tenant";
 import { useAccount, useReadContract } from "wagmi";
-import { useRouter } from "next/router";
 
 export default function AdminAccountActions() {
   const openDialog = useOpenDialog();
@@ -14,22 +13,11 @@ export default function AdminAccountActions() {
   };
   const { slug, contracts } = Tenant.current();
   const { address } = useAccount();
-  const router = useRouter();
-
-  const rerouteHome = () => {
-    try {
-      router.push("/");
-    } catch (error) {
-      console.error(error);
-    }
-  };
 
   const handleAccountTransfer = () => {
     openDialog({
       type: "ACCOUNT_ACTION",
-      params: {
-        onSuccess: rerouteHome,
-      },
+      params: {},
     });
   };
   const actionsToRender = [];

--- a/src/components/Admin/AdminAccountActions.tsx
+++ b/src/components/Admin/AdminAccountActions.tsx
@@ -14,6 +14,14 @@ export default function AdminAccountActions() {
   const { slug, contracts } = Tenant.current();
   const { address } = useAccount();
 
+  const handleAccountTransfer = () => {
+    openDialog({
+      type: "ACCOUNT_ACTION",
+      params: {},
+    });
+  };
+  const actionsToRender = [];
+
   // Get the Manager and Admin Accounts to determine if features should render
   const { data: managerAddress } = useReadContract({
     address: contracts.governor?.address as `0x${string}`,
@@ -36,14 +44,6 @@ export default function AdminAccountActions() {
         accountActionToggles.transfer = true;
       }
   }
-
-  const handleAccountTransfer = () => {
-    openDialog({
-      type: "ACCOUNT_ACTION",
-      params: {},
-    });
-  };
-  const actionsToRender = [];
 
   if (accountActionToggles.transfer) {
     actionsToRender.push(

--- a/src/components/Admin/AdminAccountActions.tsx
+++ b/src/components/Admin/AdminAccountActions.tsx
@@ -2,9 +2,17 @@
 
 import { Button } from "@/components/ui/button";
 import { Fragment } from "react";
+import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
 
 export default function AdminAccountActions() {
-  const handleAccountTransfer = () => {};
+  const openDialog = useOpenDialog();
+
+  const handleAccountTransfer = () => {
+    openDialog({
+      type: "ACCOUNT_ACTION",
+      params: {},
+    });
+  };
 
   return (
     <section className="gl_box bg-neutral">

--- a/src/components/Admin/AdminAccountActions.tsx
+++ b/src/components/Admin/AdminAccountActions.tsx
@@ -45,10 +45,10 @@ export default function AdminAccountActions() {
         return adminAddress;
       case GOVERNOR_TYPE.ALLIGATOR:
         return managerAddress;
-      case GOVERNOR_TYPE.ENS:
-      //     todo
-      case GOVERNOR_TYPE.BRAVO:
-      //     todo
+      // case GOVERNOR_TYPE.ENS:
+      // // Not Implemented
+      // case GOVERNOR_TYPE.BRAVO:
+      // // Not Implemented
       default:
         return adminAddress;
     }

--- a/src/components/Admin/AdminForm.tsx
+++ b/src/components/Admin/AdminForm.tsx
@@ -2,6 +2,7 @@ import ProposalTypeSettings from "./ProposalTypeSettings";
 import GovernorSettings from "./GovernorSettings";
 import FAQs from "./FAQs";
 import { FormattedProposalType } from "@/lib/types";
+import AdminAccountActions from "@/components/Admin/AdminAccountActions";
 
 // TODO: Take init values from the chain
 export default function AdminForm({
@@ -19,6 +20,7 @@ export default function AdminForm({
           votableSupply={votableSupply}
           proposalTypes={proposalTypes}
         />
+        <AdminAccountActions />
       </div>
       <FAQs />
     </div>

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -1,4 +1,4 @@
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import {
   Form,
   FormControl,
@@ -20,6 +20,14 @@ export function CreateAccountActionDialog() {
 
   const [acknowledged, setAcknowledged] = useState(false);
 
+  // Watch the contractAddress field
+  const contractAddress = useWatch({
+    control: form.control,
+    name: "contractAddress",
+  });
+
+  const addressSupplied = !!contractAddress;
+
   return (
     <Fragment>
       <Form {...form}>
@@ -38,9 +46,16 @@ export function CreateAccountActionDialog() {
             )}
           />
           {acknowledged ? (
-            <Button>Transfer</Button>
+            <div>
+              {!addressSupplied && (
+                <p className="text-sm text-muted-foreground mt-1">
+                  Please supply an address
+                </p>
+              )}
+              <Button disabled={!addressSupplied}>Transfer</Button>
+            </div>
           ) : (
-            <Aknowledgement
+            <Acknowledgement
               handleAcknowledgement={() => setAcknowledged(true)}
             />
           )}
@@ -50,7 +65,7 @@ export function CreateAccountActionDialog() {
   );
 }
 
-function Aknowledgement({
+function Acknowledgement({
   handleAcknowledgement,
 }: {
   handleAcknowledgement: () => void;

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -26,6 +26,7 @@ export function CreateAccountActionDialog() {
     name: "contractAddress",
   });
 
+  // This could be validated further if required
   const addressSupplied = !!contractAddress;
 
   return (

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
 export function CreateAccountActionDialog() {
   const form = useForm({
@@ -21,28 +21,32 @@ export function CreateAccountActionDialog() {
   const [acknowledged, setAcknowledged] = useState(false);
 
   return (
-    <Form {...form}>
-      <form className="space-y-8 max-w-2xl mx-auto">
-        <FormField
-          control={form.control}
-          name="contractAddress"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Contract Address</FormLabel>
-              <FormControl>
-                <Input {...field} placeholder="0x..." className="h-10" />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
+    <Fragment>
+      <Form {...form}>
+        <form className="space-y-8 max-w-2xl mx-auto">
+          <FormField
+            control={form.control}
+            name="contractAddress"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Contract Address</FormLabel>
+                <FormControl>
+                  <Input {...field} placeholder="0x..." className="h-10" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {acknowledged ? (
+            <Button>Transfer</Button>
+          ) : (
+            <Aknowledgement
+              handleAcknowledgement={() => setAcknowledged(true)}
+            />
           )}
-        />
-        {acknowledged ? (
-          <Button>Transfer</Button>
-        ) : (
-          <Aknowledgement handleAcknowledgement={() => setAcknowledged(true)} />
-        )}
-      </form>
-    </Form>
+        </form>
+      </Form>
+    </Fragment>
   );
 }
 
@@ -53,8 +57,14 @@ function Aknowledgement({
 }) {
   return (
     <div>
-      <p>Warning: This is irreversible</p>
-      <Button variant="outline" onClick={handleAcknowledgement}>
+      <p>
+        <span className="text-orange-500">Warning</span>: This is irreversible
+      </p>
+      <Button
+        variant="outline"
+        className="bg-red-100 border-red-500 text-red-500 hover:bg-red-200"
+        onClick={handleAcknowledgement}
+      >
         Acknowledge
       </Button>
     </div>

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -11,7 +11,11 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Fragment, useState } from "react";
 
-export function CreateAccountActionDialog() {
+export function CreateAccountActionDialog({
+  closeDialog,
+}: {
+  closeDialog: () => void;
+}) {
   const form = useForm({
     defaultValues: {
       contractAddress: "" as `0x${string}`,

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -132,7 +132,8 @@ function Acknowledgement({
   return (
     <div>
       <p>
-        <span className="text-orange-500">Warning</span>: This is irreversible
+        <span className="text-orange-500">Warning</span>: This action is
+        irreversible!
       </p>
       <Button
         variant="outline"

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -17,10 +17,8 @@ import BlockScanUrls from "@/components/shared/BlockScanUrl";
 
 export function CreateAccountActionDialog({
   closeDialog,
-  onSuccess,
 }: {
   closeDialog: () => void;
-  onSuccess: () => void;
 }) {
   const { contracts } = Tenant.current();
   // Get contract to make calls against
@@ -71,7 +69,6 @@ export function CreateAccountActionDialog({
             );
             closeDialog();
             disconnect();
-            onSuccess();
           },
         }
       );

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -16,10 +16,8 @@ import { useDisconnect, useWriteContract } from "wagmi";
 import BlockScanUrls from "@/components/shared/BlockScanUrl";
 
 export function CreateAccountActionDialog({
-  onSuccess,
   closeDialog,
 }: {
-  onSuccess: () => void;
   closeDialog: () => void;
 }) {
   const { contracts } = Tenant.current();

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -1,3 +1,62 @@
+import { useForm } from "react-hook-form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+
 export function CreateAccountActionDialog() {
-  return <>Test</>;
+  const form = useForm({
+    defaultValues: {
+      contractAddress: "" as `0x${string}`,
+    },
+  });
+
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  return (
+    <Form {...form}>
+      <form className="space-y-8 max-w-2xl mx-auto">
+        <FormField
+          control={form.control}
+          name="contractAddress"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Contract Address</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="0x..." className="h-10" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {acknowledged ? (
+          <Button>Transfer</Button>
+        ) : (
+          <Aknowledgement handleAcknowledgement={() => setAcknowledged(true)} />
+        )}
+      </form>
+    </Form>
+  );
+}
+
+function Aknowledgement({
+  handleAcknowledgement,
+}: {
+  handleAcknowledgement: () => void;
+}) {
+  return (
+    <div>
+      <p>Warning: This is irreversible</p>
+      <Button variant="outline" onClick={handleAcknowledgement}>
+        Acknowledge
+      </Button>
+    </div>
+  );
 }

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -1,0 +1,3 @@
+export function CreateAccountActionDialog() {
+  return <>Test</>;
+}

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -61,7 +61,9 @@ export function CreateAccountActionDialog({
             toast.dismiss();
             toast.success(
               <div className="flex flex-col items-center gap-2 p-1">
-                <span className="text-sm font-semibold">Scope created</span>
+                <span className="text-sm font-semibold">
+                  Manager Account Transferred
+                </span>
                 {hash ? <BlockScanUrls hash1={hash} /> : null}
               </div>
             );
@@ -71,6 +73,7 @@ export function CreateAccountActionDialog({
         }
       );
     } catch (error: unknown) {
+      toast.dismiss();
       if (error instanceof Error) {
         toast.error(`Error Transferring Role: ${error.message}`);
       } else {

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Fragment, useState } from "react";
 import toast from "react-hot-toast";
 import Tenant from "@/lib/tenant/tenant";
-import { useWriteContract } from "wagmi";
+import { useDisconnect, useWriteContract } from "wagmi";
 import BlockScanUrls from "@/components/shared/BlockScanUrl";
 
 export function CreateAccountActionDialog({
@@ -26,6 +26,7 @@ export function CreateAccountActionDialog({
   // Get contract to make calls against
   const govContract = contracts.governor;
   const { writeContractAsync } = useWriteContract();
+  const { disconnect } = useDisconnect();
 
   const form = useForm({
     defaultValues: {
@@ -43,7 +44,6 @@ export function CreateAccountActionDialog({
 
   // This could be validated further if required
   const addressSupplied = !!managerAddress;
-  console.log(`Gov contract address: ${govContract?.address}`);
 
   const onSubmit = async () => {
     try {
@@ -68,6 +68,7 @@ export function CreateAccountActionDialog({
               </div>
             );
             closeDialog();
+            disconnect();
           },
         }
       );

--- a/src/components/Admin/CreateAccountActionDialog.tsx
+++ b/src/components/Admin/CreateAccountActionDialog.tsx
@@ -17,8 +17,10 @@ import BlockScanUrls from "@/components/shared/BlockScanUrl";
 
 export function CreateAccountActionDialog({
   closeDialog,
+  onSuccess,
 }: {
   closeDialog: () => void;
+  onSuccess: () => void;
 }) {
   const { contracts } = Tenant.current();
   // Get contract to make calls against
@@ -69,6 +71,7 @@ export function CreateAccountActionDialog({
             );
             closeDialog();
             disconnect();
+            onSuccess();
           },
         }
       );
@@ -76,6 +79,7 @@ export function CreateAccountActionDialog({
       toast.dismiss();
       if (error instanceof Error) {
         toast.error(`Error Transferring Role: ${error.message}`);
+        console.error(error);
       } else {
         toast.error("An unknown error occurred while creating the scope.");
       }

--- a/src/components/Dialogs/DialogProvider/dialogs.tsx
+++ b/src/components/Dialogs/DialogProvider/dialogs.tsx
@@ -269,8 +269,9 @@ export type CreateScopeDialogType = {
 
 export type AccountActionDialogType = {
   type: "ACCOUNT_ACTION";
-  //TODO
-  params: {};
+  params: {
+    onSuccess: () => void;
+  };
 };
 
 export const dialogs: DialogDefinitions<DialogType> = {
@@ -488,8 +489,13 @@ export const dialogs: DialogDefinitions<DialogType> = {
       />
     );
   },
-  ACCOUNT_ACTION: ({}, closeDialog) => {
-    return <CreateAccountActionDialog closeDialog={closeDialog} />;
+  ACCOUNT_ACTION: ({ onSuccess }, closeDialog) => {
+    return (
+      <CreateAccountActionDialog
+        closeDialog={closeDialog}
+        onSuccess={onSuccess}
+      />
+    );
   },
   // FAQ: () => {
   //   return <FaqDialog />;

--- a/src/components/Dialogs/DialogProvider/dialogs.tsx
+++ b/src/components/Dialogs/DialogProvider/dialogs.tsx
@@ -35,6 +35,7 @@ import { SimulationReportDialog } from "../SimulationReportDialog/SimulationRepo
 import { StructuredSimulationReport } from "@/lib/seatbelt/types";
 import { CreateScopeDialog } from "@/components/Admin/CreateScopeDialog";
 import { ScopeData } from "@/lib/types";
+import { CreateAccountActionDialog } from "@/components/Admin/CreateAccountActionDialog";
 
 export type DialogType =
   | AdvancedDelegateDialogType
@@ -56,7 +57,8 @@ export type DialogType =
   | SubscribeDialog
   | ShareVoteDialogType
   | SimulationReportDialogType
-  | CreateScopeDialogType;
+  | CreateScopeDialogType
+  | AccountActionDialogType;
 // | FaqDialogType
 
 export type DelegateDialogType = {
@@ -263,6 +265,12 @@ export type CreateScopeDialogType = {
     onSuccess: (scope: ScopeData) => void;
   };
   className?: string;
+};
+
+export type AccountActionDialogType = {
+  type: "ACCOUNT_ACTION";
+  //TODO
+  params: {};
 };
 
 export const dialogs: DialogDefinitions<DialogType> = {
@@ -479,6 +487,9 @@ export const dialogs: DialogDefinitions<DialogType> = {
         closeDialog={closeDialog}
       />
     );
+  },
+  ACCOUNT_ACTION: ({}) => {
+    return <CreateAccountActionDialog />;
   },
   // FAQ: () => {
   //   return <FaqDialog />;

--- a/src/components/Dialogs/DialogProvider/dialogs.tsx
+++ b/src/components/Dialogs/DialogProvider/dialogs.tsx
@@ -488,8 +488,8 @@ export const dialogs: DialogDefinitions<DialogType> = {
       />
     );
   },
-  ACCOUNT_ACTION: ({}) => {
-    return <CreateAccountActionDialog />;
+  ACCOUNT_ACTION: ({}, closeDialog) => {
+    return <CreateAccountActionDialog closeDialog={closeDialog} />;
   },
   // FAQ: () => {
   //   return <FaqDialog />;

--- a/src/components/Dialogs/DialogProvider/dialogs.tsx
+++ b/src/components/Dialogs/DialogProvider/dialogs.tsx
@@ -269,9 +269,7 @@ export type CreateScopeDialogType = {
 
 export type AccountActionDialogType = {
   type: "ACCOUNT_ACTION";
-  params: {
-    onSuccess: () => void;
-  };
+  params: {};
 };
 
 export const dialogs: DialogDefinitions<DialogType> = {
@@ -489,13 +487,8 @@ export const dialogs: DialogDefinitions<DialogType> = {
       />
     );
   },
-  ACCOUNT_ACTION: ({ onSuccess }, closeDialog) => {
-    return (
-      <CreateAccountActionDialog
-        closeDialog={closeDialog}
-        onSuccess={onSuccess}
-      />
-    );
+  ACCOUNT_ACTION: ({}, closeDialog) => {
+    return <CreateAccountActionDialog closeDialog={closeDialog} />;
   },
   // FAQ: () => {
   //   return <FaqDialog />;


### PR DESCRIPTION
Added a section to the admin page called Account Actions.

This will conditionally render a series of actions that can be performed on the account. If the user clicks the action button they will be prompted via a dialogue to transfer the manager address. They must input an address. Underneath is a warning that the action is reversible. They click acknowledge, and then the button changes to transfer which prompts the wallet to perform the tx. After success, it prompts a toast blockscan url, then logs out the user.

I tried to redirect the user back home but was not able to.