### PR TITLE
Consume vote history from dao-node

### DIFF
--- a/src/app/api/common/proposals/proposal.d.ts
+++ b/src/app/api/common/proposals/proposal.d.ts
@@ -40,6 +40,15 @@ export type OptimismProposals = {
 }
 */
 
+interface VotingRecord {
+  block_number: number;
+  transaction_index: number;
+  voter: string;
+  support: number;
+  votes: number;
+  reason: string;
+}
+
 export type ProposalPayloadFromDAONode = {
   id: string;
 
@@ -98,6 +107,8 @@ export type ProposalPayloadFromDAONode = {
   // So, DAO Node might be forced to re-cast large integers as strings, where they exist.
   // We'll make this decision later, after tests are up and running. -- Jeff M, 2025-04-29
   decoded_proposal_data?: Object;
+  voting_record: VotingRecord[];
+  proposal_type?: number;
 };
 
 export type ProposalPayloadFromDB = {

--- a/src/app/api/common/votes/getVotes.ts
+++ b/src/app/api/common/votes/getVotes.ts
@@ -3,8 +3,12 @@ import {
   paginateResult,
   PaginationParams,
 } from "@/app/lib/pagination";
-import { parseProposalData } from "@/lib/proposalUtils";
-import { parseSnapshotVote, parseVote } from "@/lib/voteUtils";
+import {
+  getProposalTotalValue,
+  getTitleFromProposalDescription,
+  parseProposalData,
+} from "@/lib/proposalUtils";
+import { parseSnapshotVote, parseSupport, parseVote } from "@/lib/voteUtils";
 import { cache } from "react";
 import {
   SnapshotVote,
@@ -22,6 +26,11 @@ import { TENANT_NAMESPACES } from "@/lib/constants";
 import { Block } from "ethers";
 import { withMetrics } from "@/lib/metricWrapper";
 import { unstable_cache } from "next/cache";
+import {
+  adaptDAONodeResponse,
+  getProposalFromDaoNode,
+} from "@/app/lib/dao-node/client";
+import { getHumanBlockTime } from "@/lib/blockTimes";
 
 const getVotesForDelegate = ({
   addressOrENSName,
@@ -317,6 +326,62 @@ async function getVotesForProposal({
     "getVotesForProposal",
     async () => {
       const { namespace, contracts, ui } = Tenant.current();
+      const useDaoNode = ui.toggle("dao-node/proposal-votes")?.enabled ?? false;
+
+      const latestBlockPromise: Promise<Block> = ui.toggle(
+        "use-l1-block-number"
+      )?.enabled
+        ? contracts.providerForTime?.getBlock("latest")
+        : contracts.token.provider.getBlock("latest");
+
+      if (useDaoNode) {
+        try {
+          const proposal = (await getProposalFromDaoNode(proposalId)).proposal;
+          if (!proposal) {
+            // Will be caught and ignored below and move on to DB fallback
+            throw new Error("Proposal not found");
+          }
+          const parsedProposal = adaptDAONodeResponse(proposal);
+          const latestBlock = await latestBlockPromise;
+          const votes = proposal.voting_record
+            ?.map((vote) => {
+              return {
+                transactionHash: null,
+                address: vote.voter,
+                proposalId,
+                support: parseSupport(
+                  String(vote.support),
+                  parsedProposal.proposal_type,
+                  String(proposal.start_block)
+                ),
+                weight: vote.votes.toString(),
+                reason: vote.reason,
+                params: [],
+                proposalValue:
+                  getProposalTotalValue(parsedProposal.proposal_data) ??
+                  BigInt(0),
+                proposalTitle: getTitleFromProposalDescription(
+                  proposal.description
+                ),
+                proposalType: parsedProposal.proposal_type,
+                timestamp: getHumanBlockTime(vote.block_number, latestBlock),
+                blockNumber: BigInt(vote.block_number),
+                transaction_index: vote.transaction_index,
+              };
+            })
+            .sort((a, b) => Number(b.weight) - Number(a.weight));
+          return {
+            meta: {
+              has_next: false,
+              total_returned: votes.length,
+              next_offset: 0,
+            },
+            data: votes,
+          };
+        } catch (error) {
+          // skip error
+        }
+      }
 
       let eventsViewName;
 
@@ -399,12 +464,6 @@ async function getVotesForProposal({
         );
       };
 
-      const latestBlockPromise: Promise<Block> = ui.toggle(
-        "use-l1-block-number"
-      )?.enabled
-        ? contracts.providerForTime?.getBlock("latest")
-        : contracts.token.provider.getBlock("latest");
-
       const [{ meta, data: votes }, latestBlock] = await Promise.all([
         doInSpan({ name: "getVotesForProposal" }, async () =>
           paginateResult(queryFunction, pagination)
@@ -446,6 +505,53 @@ async function getUserVotesForProposal({
 }) {
   return withMetrics("getUserVotesForProposal", async () => {
     const { namespace, contracts, ui } = Tenant.current();
+    const useDaoNode = ui.toggle("dao-node/proposal-votes")?.enabled ?? false;
+
+    const latestBlock = ui.toggle("use-l1-block-number")?.enabled
+      ? await contracts.providerForTime?.getBlock("latest")
+      : await contracts.token.provider.getBlock("latest");
+
+    if (useDaoNode) {
+      try {
+        const proposal = (await getProposalFromDaoNode(proposalId)).proposal;
+        if (!proposal) {
+          // Will be caught and ignored below and move on to DB fallback
+          throw new Error("Proposal not found");
+        }
+        const parsedProposal = adaptDAONodeResponse(proposal);
+        const votes = proposal.voting_record
+          ?.filter((vote) => vote.voter === address.toLowerCase())
+          .map((vote) => {
+            return {
+              transactionHash: null,
+              address: vote.voter,
+              proposalId,
+              support: parseSupport(
+                String(vote.support),
+                parsedProposal.proposal_type,
+                String(proposal.start_block)
+              ),
+              weight: vote.votes.toString(),
+              reason: vote.reason,
+              params: [],
+              proposalValue:
+                getProposalTotalValue(parsedProposal.proposal_data) ??
+                BigInt(0),
+              proposalTitle: getTitleFromProposalDescription(
+                proposal.description
+              ),
+              proposalType: parsedProposal.proposal_type,
+              timestamp: getHumanBlockTime(vote.block_number, latestBlock),
+              blockNumber: BigInt(vote.block_number),
+              transaction_index: vote.transaction_index,
+            };
+          });
+        return votes;
+      } catch (error) {
+        // skip error
+      }
+    }
+
     const queryFunciton = prismaWeb3Client.$queryRawUnsafe<VotePayload[]>(
       `
       SELECT
@@ -471,10 +577,6 @@ async function getUserVotesForProposal({
       { name: "getUserVotesForProposal" },
       async () => queryFunciton
     );
-
-    const latestBlock = ui.toggle("use-l1-block-number")?.enabled
-      ? await contracts.providerForTime?.getBlock("latest")
-      : await contracts.token.provider.getBlock("latest");
 
     const data = Promise.all(
       votes.map((vote) =>

--- a/src/app/api/common/votes/vote.d.ts
+++ b/src/app/api/common/votes/vote.d.ts
@@ -8,7 +8,7 @@ export type VotesSort = "weight" | "block_number";
 export type VotePayload = OptimismVotes | LineaVotes;
 
 export type Vote = {
-  transactionHash: string;
+  transactionHash: string | null;
   address: string;
   proposalId: string;
   support: Support;
@@ -20,6 +20,7 @@ export type Vote = {
   proposalType: ProposalType;
   timestamp: Date | null;
   blockNumber?: bigint;
+  transaction_index?: number;
 };
 
 export type SnapshotVotePayload = {

--- a/src/app/api/proposals/getVotesChart.ts
+++ b/src/app/api/proposals/getVotesChart.ts
@@ -2,13 +2,35 @@ import Tenant from "@/lib/tenant/tenant";
 import { TENANT_NAMESPACES } from "@/lib/constants";
 import { prismaWeb3Client } from "@/app/lib/prisma";
 import { VotePayload } from "@/app/api/common/votes/vote";
+import { getProposalFromDaoNode } from "@/app/lib/dao-node/client";
 
 export async function getVotesChart({
   proposalId,
 }: {
   proposalId: string;
 }): Promise<any[]> {
-  const { namespace, contracts } = Tenant.current();
+  const { namespace, contracts, ui } = Tenant.current();
+  const useDaoNode = ui.toggle("dao-node/votes-chart")?.enabled ?? false;
+  if (useDaoNode) {
+    try {
+      const proposal = (await getProposalFromDaoNode(proposalId)).proposal;
+      if (!proposal) {
+        // Will be caught and ignored below and move on to DB fallback
+        throw new Error("Proposal not found");
+      }
+      const votes = proposal.voting_record?.map((vote) => {
+        return {
+          voter: vote.voter,
+          support: String(vote.support),
+          weight: vote.votes.toString(),
+          block_number: String(vote.block_number),
+        };
+      });
+      return votes;
+    } catch (error) {
+      // skip error
+    }
+  }
 
   let eventsViewName;
 

--- a/src/app/lib/dao-node/client.ts
+++ b/src/app/lib/dao-node/client.ts
@@ -4,8 +4,8 @@ import {
 } from "@/app/api/common/proposals/proposal";
 import Tenant from "@/lib/tenant/tenant";
 import { cache } from "react";
-import { PaginatedResult } from "../pagination";
 import { ProposalType } from "@prisma/client";
+import { unstable_cache } from "next/cache";
 
 const { contracts, namespace } = Tenant.current();
 
@@ -300,3 +300,19 @@ export const getCachedAllProposalsFromDaoNode = cache(
     proposal_type: 'STANDARD'
   }
   */
+
+export const getProposalFromDaoNode = unstable_cache(
+  async (proposalId: string) => {
+    const url = getDaoNodeURLForNamespace(namespace);
+    const response = await fetch(`${url}v1/proposal/${proposalId}`);
+    const data: {
+      proposal: ProposalPayloadFromDAONode;
+    } = await response.json();
+    return data;
+  },
+  ["proposalFromDaoNode"],
+  {
+    tags: ["proposalFromDaoNode"],
+    revalidate: 60, // 1 minute
+  }
+);

--- a/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalSingleVote.tsx
+++ b/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalSingleVote.tsx
@@ -20,6 +20,8 @@ import Tenant from "@/lib/tenant/tenant";
 import { fontMapper } from "@/styles/fonts";
 import Link from "next/link";
 import { HoverCard, HoverCardTrigger } from "@/components/ui/hover-card";
+import { useBnAndTidToHash } from "@/hooks/useBnAndTidToHash";
+import { useInView } from "react-intersection-observer";
 
 const { token, ui } = Tenant.current();
 
@@ -34,7 +36,17 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
     transactionHash,
   } = vote;
   const [hovered, setHovered] = useState(false);
-  const [hash1, hash2] = transactionHash.split("|");
+  const [hash1, hash2] = transactionHash?.split("|") ?? [];
+  const { ref, inView } = useInView({
+    triggerOnce: true,
+    threshold: 0.1,
+  });
+
+  const { data: hash } = useBnAndTidToHash({
+    blockNumber: Number(vote.blockNumber),
+    transactionIndex: vote.transaction_index,
+    enabled: inView && !!vote.blockNumber && !!vote.transaction_index,
+  });
 
   const { data } = useEnsName({
     chainId: 1,
@@ -51,7 +63,7 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
   };
 
   return (
-    <VStack>
+    <div className="flex flex-col" ref={ref}>
       <HoverCard
         openDelay={100}
         closeDelay={100}
@@ -75,13 +87,15 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
               )}
               {hovered && (
                 <>
-                  <a
-                    href={getBlockScanUrl(hash1)}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                  >
-                    <ArrowTopRightOnSquareIcon className="w-3 h-3 ml-1" />
-                  </a>
+                  {hash1 || hash ? (
+                    <a
+                      href={getBlockScanUrl(hash1 || (hash as string))}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      <ArrowTopRightOnSquareIcon className="w-3 h-3 ml-1" />
+                    </a>
+                  ) : null}
                   {hash2 && (
                     <a
                       href={getBlockScanUrl(hash2)}
@@ -143,6 +157,6 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
           </p>
         </div>
       )}
-    </VStack>
+    </div>
   );
 }

--- a/src/components/Votes/CastVoteInput/CastVoteContext.tsx
+++ b/src/components/Votes/CastVoteInput/CastVoteContext.tsx
@@ -213,8 +213,8 @@ const CastVoteContextProvider = ({
         data:
           missingVote === "NONE"
             ? {
-                standardTxHash: votes?.[0]?.transactionHash,
-                advancedTxHash: votes?.[1]?.transactionHash,
+                standardTxHash: votes?.[0]?.transactionHash ?? undefined,
+                advancedTxHash: votes?.[1]?.transactionHash ?? undefined,
               }
             : data,
       }}

--- a/src/components/Votes/ProposalVotesList/ProposalSingleVote.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalSingleVote.tsx
@@ -24,6 +24,8 @@ import Tenant from "@/lib/tenant/tenant";
 import { fontMapper } from "@/styles/fonts";
 import Link from "next/link";
 import { HoverCard, HoverCardTrigger } from "@/components/ui/hover-card";
+import { useInView } from "react-intersection-observer";
+import { useBnAndTidToHash } from "@/hooks/useBnAndTidToHash";
 
 const { token, ui } = Tenant.current();
 
@@ -37,7 +39,17 @@ const SUPPORT_TO_ICON: Record<Support, React.ReactNode> = {
 export function ProposalSingleVote({ vote }: { vote: Vote }) {
   const { address: connectedAddress } = useAccount();
   const [hovered, setHovered] = useState(false);
-  const [hash1, hash2] = vote.transactionHash.split("|");
+  const [hash1, hash2] = vote.transactionHash?.split("|") ?? [];
+  const { ref, inView } = useInView({
+    triggerOnce: true,
+    threshold: 0.1,
+  });
+
+  const { data: hash } = useBnAndTidToHash({
+    blockNumber: Number(vote.blockNumber),
+    transactionIndex: vote.transaction_index,
+    enabled: inView && !!vote.blockNumber && !!vote.transaction_index,
+  });
 
   const { data } = useEnsName({
     chainId: 1,
@@ -54,10 +66,10 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
   };
 
   return (
-    <VStack
+    <div
       key={vote.transactionHash}
-      gap={2}
-      className="text-xs text-tertiary px-0 py-1"
+      className="flex flex-col gap-2 text-xs text-tertiary px-0 py-1"
+      ref={ref}
     >
       <VStack>
         <HoverCard
@@ -82,13 +94,15 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
                 )}
                 {hovered && (
                   <>
-                    <a
-                      href={getBlockScanUrl(hash1)}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                    >
-                      <ArrowTopRightOnSquareIcon className="w-3 h-3" />
-                    </a>
+                    {hash1 || hash ? (
+                      <a
+                        href={getBlockScanUrl(hash1 || (hash as string))}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      >
+                        <ArrowTopRightOnSquareIcon className="w-3 h-3" />
+                      </a>
+                    ) : null}
                     {hash2 && (
                       <a
                         href={getBlockScanUrl(hash2)}
@@ -139,6 +153,6 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
       <pre className="text-xs font-medium whitespace-pre-wrap text-secondary w-fit break-all font-sans">
         {vote.reason}
       </pre>
-    </VStack>
+    </div>
   );
 }

--- a/src/hooks/useAdvancedVoting.tsx
+++ b/src/hooks/useAdvancedVoting.tsx
@@ -7,6 +7,7 @@ import { trackEvent } from "@/lib/analytics";
 import { ANALYTICS_EVENT_NAMES } from "@/lib/types.d";
 import { wrappedWaitForTransactionReceipt } from "@/lib/utils";
 import toast from "react-hot-toast";
+import { revalidateTag } from "next/cache";
 
 const useAdvancedVoting = ({
   proposalId,
@@ -76,6 +77,7 @@ const useAdvancedVoting = ({
             address: address as `0x${string}`,
           });
         if (status === "success") {
+          revalidateTag("proposalFromDaoNode");
           await trackEvent({
             event_name: ANALYTICS_EVENT_NAMES.STANDARD_VOTE,
             event_data: {
@@ -125,6 +127,7 @@ const useAdvancedVoting = ({
             address: address as `0x${string}`,
           });
         if (status === "success") {
+          revalidateTag("proposalFromDaoNode");
           await trackEvent({
             event_name: ANALYTICS_EVENT_NAMES.ADVANCED_VOTE,
             event_data: {

--- a/src/hooks/useBnAndTidToHash.ts
+++ b/src/hooks/useBnAndTidToHash.ts
@@ -1,0 +1,25 @@
+import { blockNumberAndTransactionIndexToHash } from "@/lib/serverUtils";
+import { useQuery } from "@tanstack/react-query";
+
+export const useBnAndTidToHash = ({
+  blockNumber,
+  transactionIndex,
+  enabled = false,
+}: {
+  blockNumber?: number;
+  transactionIndex?: number;
+  enabled?: boolean;
+}) => {
+  const { data, isPending, error } = useQuery({
+    queryKey: [
+      "blockNumberAndTransactionIndexToHash",
+      blockNumber,
+      transactionIndex,
+    ],
+    enabled: enabled,
+    queryFn: () =>
+      blockNumberAndTransactionIndexToHash(blockNumber, transactionIndex),
+  });
+
+  return { data, isPending, error };
+};

--- a/src/hooks/useSponsoredVoting.tsx
+++ b/src/hooks/useSponsoredVoting.tsx
@@ -9,6 +9,7 @@ import { useGovernorName } from "@/hooks/useGovernorName";
 import { trackEvent } from "@/lib/analytics";
 import { ANALYTICS_EVENT_NAMES } from "@/lib/types.d";
 import { useAccount } from "wagmi";
+import { revalidateTag } from "next/cache";
 
 const types = {
   Ballot: [
@@ -86,6 +87,7 @@ const useSponsoredVoting = ({
         });
 
         if (status === "success") {
+          revalidateTag("proposalFromDaoNode");
           setSponsoredVoteTxHash(voteTxHash);
           setSponsoredVoteSuccess(true);
           trackEvent({

--- a/src/hooks/useStandardVoting.tsx
+++ b/src/hooks/useStandardVoting.tsx
@@ -6,6 +6,7 @@ import { trackEvent } from "@/lib/analytics";
 import { useAccount } from "wagmi";
 import { ANALYTICS_EVENT_NAMES } from "@/lib/types.d";
 import { wrappedWaitForTransactionReceipt } from "@/lib/utils";
+import { revalidateTag } from "next/cache";
 
 const useStandardVoting = ({
   proposalId,
@@ -55,6 +56,7 @@ const useStandardVoting = ({
 
         if (status === "success") {
           setStandardTxHash(transactionHash);
+          revalidateTag("proposalFromDaoNode");
 
           await trackEvent({
             event_name: ANALYTICS_EVENT_NAMES.STANDARD_VOTE,

--- a/src/lib/serverUtils.ts
+++ b/src/lib/serverUtils.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { unstable_cache } from "next/cache";
+import { getPublicClient } from "./viem";
+
+export const blockNumberAndTransactionIndexToHash = unstable_cache(
+  async (blockNumber?: number, transactionIndex?: number) => {
+    if (!blockNumber || !transactionIndex) {
+      return null;
+    }
+    const publicClient = getPublicClient();
+    const block = await publicClient.getBlock({
+      blockNumber: BigInt(blockNumber),
+    });
+    return block.transactions[transactionIndex];
+  },
+  ["blockNumberAndTransactionIndexToHash"],
+  {
+    revalidate: 60 * 60 * 24 * 365, // 1 year cache
+  }
+);

--- a/src/lib/tenant/configs/ui/cyber.ts
+++ b/src/lib/tenant/configs/ui/cyber.ts
@@ -315,5 +315,13 @@ If you meet the proposal threshold or are the manager of the governor, then you 
       name: "use-daonode-for-votable-supply",
       enabled: true,
     },
+    {
+      name: "dao-node/votes-chart", // No approval vote support yet
+      enabled: false,
+    },
+    {
+      name: "dao-node/proposal-votes",
+      enabled: false,
+    },
   ],
 });

--- a/src/lib/tenant/configs/ui/derive.ts
+++ b/src/lib/tenant/configs/ui/derive.ts
@@ -308,5 +308,13 @@ If you meet the proposal threshold or are the manager of the governor, then you 
       name: "use-daonode-for-votable-supply",
       enabled: true,
     },
+    {
+      name: "dao-node/votes-chart",
+      enabled: true,
+    },
+    {
+      name: "dao-node/proposal-votes",
+      enabled: true,
+    },
   ],
 });

--- a/src/lib/tenant/configs/ui/ens.ts
+++ b/src/lib/tenant/configs/ui/ens.ts
@@ -292,5 +292,13 @@ For a full walkthrough of the proposal process, check out the [ENS DAO docs](htt
       name: "use-daonode-for-votable-supply",
       enabled: true,
     },
+    {
+      name: "dao-node/votes-chart",
+      enabled: true,
+    },
+    {
+      name: "dao-node/proposal-votes",
+      enabled: true,
+    },
   ],
 });

--- a/src/lib/tenant/configs/ui/etherfi.ts
+++ b/src/lib/tenant/configs/ui/etherfi.ts
@@ -157,5 +157,13 @@ export const etherfiTenantUIConfig = new TenantUI({
       name: "use-daonode-for-votable-supply",
       enabled: false,
     },
+    {
+      name: "dao-node/votes-chart",
+      enabled: false,
+    },
+    {
+      name: "dao-node/proposal-votes",
+      enabled: false,
+    },
   ],
 });

--- a/src/lib/tenant/configs/ui/optimism.ts
+++ b/src/lib/tenant/configs/ui/optimism.ts
@@ -323,5 +323,13 @@ If you're using the OP Foundation multisig, you can queue several proposals at o
       name: "use-daonode-for-votable-supply",
       enabled: true,
     },
+    {
+      name: "dao-node/votes-chart", // No approval vote support yet
+      enabled: false,
+    },
+    {
+      name: "dao-node/proposal-votes",
+      enabled: false,
+    },
   ],
 });

--- a/src/lib/tenant/configs/ui/protocol-guild.ts
+++ b/src/lib/tenant/configs/ui/protocol-guild.ts
@@ -231,5 +231,13 @@ export const protocolGuildTenantUIConfig = new TenantUI({
       name: "use-daonode-for-votable-supply",
       enabled: true,
     },
+    {
+      name: "dao-node/votes-chart",
+      enabled: true,
+    },
+    {
+      name: "dao-node/proposal-votes",
+      enabled: true,
+    },
   ],
 });

--- a/src/lib/tenant/configs/ui/scroll.ts
+++ b/src/lib/tenant/configs/ui/scroll.ts
@@ -332,5 +332,13 @@ If you meet the proposal threshold or are the manager of the governor, then you 
       name: "use-daonode-for-votable-supply",
       enabled: true,
     },
+    {
+      name: "dao-node/votes-chart",
+      enabled: true,
+    },
+    {
+      name: "dao-node/proposal-votes",
+      enabled: true,
+    },
   ],
 });

--- a/src/lib/tenant/configs/ui/uniswap.ts
+++ b/src/lib/tenant/configs/ui/uniswap.ts
@@ -353,5 +353,13 @@ export const uniswapTenantUIConfig = new TenantUI({
       name: "use-daonode-for-votable-supply",
       enabled: true,
     },
+    {
+      name: "dao-node/votes-chart",
+      enabled: true,
+    },
+    {
+      name: "dao-node/proposal-votes",
+      enabled: true,
+    },
   ],
 });


### PR DESCRIPTION
- No support for tenants with approval voting yet
- Feature flagged
- Adds a blockNumberAndTransactionIndexToHash util
- Trigger data revalidation after vote is casted
- Uses dao-node in proposal votes chart and proposal voters list