### PR TITLE
Update delegate statement handling and enhancements

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model DelegateStatements {
   twitter                  String?
   discord                  String?
   email                    String?
-  message_hash             String?
+  message_hash             String
   createdAt                DateTime?   @default(now()) @map("created_at") @db.Date
   updatedAt                DateTime?   @default(now()) @map("updated_at") @db.Date
   warpcast                 String?
@@ -27,7 +27,7 @@ model DelegateStatements {
   scw_address              String?
   notification_preferences Json?
 
-  @@id([address, dao_slug, stage])
+  @@id([address, dao_slug, stage, message_hash])
   @@index([email], map: "idx_delegate_statements_email")
   @@map("delegate_statements")
   @@schema("agora")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ enum stageStatus {
   published
 
   @@schema("agora")
+  @@map("stage_status")
 }
 
 model Contracts {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,7 @@ model DelegateStatements {
   scw_address              String?
   notification_preferences Json?
 
-  @@id([address, dao_slug, stage, message_hash])
+  @@id([address, dao_slug, message_hash])
   @@index([email], map: "idx_delegate_statements_email")
   @@map("delegate_statements")
   @@schema("agora")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
 model DelegateStatements {
   address                  String
   dao_slug                 DaoSlug
-  stage                    StageStatus @default(published)
+  stage                    stageStatus @default(published)
   signature                String
   payload                  Json
   twitter                  String?
@@ -33,7 +33,7 @@ model DelegateStatements {
   @@schema("agora")
 }
 
-enum StageStatus {
+enum stageStatus {
   draft
   published
 

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -140,7 +140,7 @@ describe("publishDelegateStatementDraft", () => {
       messageHash: messageHash,
     });
   });
-  it("should publish a draft", async () => {
+  it("should publish a draft with a message hash", async () => {
     // Given an address and a message hash, flip the stage to 'published'
 
     // The delegate statement should be draft before our call
@@ -155,6 +155,34 @@ describe("publishDelegateStatementDraft", () => {
     await publishDelegateStatementDraft({
       address: mockAddress,
       messageOrMessageHash: { type: "MESSAGE_HASH", value: messageHash },
+    });
+
+    // Check the delegate statement is now published
+    const postResult = await getDelegateStatement(mockAddress, {
+      type: "MESSAGE_HASH",
+      value: messageHash,
+    });
+
+    expect(postResult!!.stage).toBe(stageStatus.PUBLISHED);
+  });
+  it("should publish a draft with a message", async () => {
+    // Given an address and a message hash, flip the stage to 'published'
+
+    // The delegate statement should be draft before our call
+    const preResult = await getDelegateStatement(mockAddress, {
+      type: "MESSAGE_HASH",
+      value: messageHash,
+    });
+
+    expect(preResult!!.stage).toBe(stageStatus.DRAFT);
+
+    // Call utility function with a non-hash message
+    await publishDelegateStatementDraft({
+      address: mockAddress,
+      messageOrMessageHash: {
+        type: "MESSAGE",
+        value: mockMessage,
+      },
     });
 
     // Check the delegate statement is now published

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, vi, expect } from "vitest"; // Import from vitest
+import { createDelegateStatement } from "@/app/api/common/delegateStatement/createDelegateStatement";
+import Tenant from "@/lib/tenant/tenant";
+import { stageStatus } from "@prisma/client";
+const { slug } = Tenant.current();
+
+vi.mock("server-only", () => ({})); // Mock server-only module
+
+vi.mock("@/app/api/common/delegateStatement/createDelegateStatement", () => ({
+  createDelegateStatement: vi.fn(),
+}));
+
+// Define default values for the schema
+const mockDelegateStatement = {
+  discord: null,
+  email: "mock-email@example.com",
+  twitter: null,
+  warpcast: null,
+  address: "0xabcdef1234567890",
+  dao_slug: "OP", // Example DaoSlug
+  stage: stageStatus.published, // Example stage value
+  signature: "0xsomesignaturemock",
+  payload: {}, // Include this field (default to empty object for now)
+  message_hash: "mock-message-hash", // Mocked hash
+  createdAt: new Date().toISOString(), // Serialized Date
+  updatedAt: new Date().toISOString(), // Serialized Date
+  notification_preferences: {
+    wants_proposal_created_email: "prompt",
+    wants_proposal_ending_soon_email: "prompt",
+    last_updated_at: new Date().toISOString(),
+  },
+};
+
+describe("createDelegateStatement basic setup", () => {
+  it("should call createDelegateStatement with the correct data", async () => {
+    const args = {
+      address: "0xabcdef1234567890" as `0x${string}`,
+      delegateStatement: {
+        discord: null,
+        email: "mock-email@example.com",
+        twitter: null,
+        warpcast: null,
+        notificationPreferences: {
+          wants_proposal_created_email: "prompt",
+          wants_proposal_ending_soon_email: "prompt",
+        },
+      },
+      signature: "0xsomesignaturemock",
+      message: "mock-message",
+      stage: stageStatus.published,
+    };
+
+    // Mock `createDelegateStatement` to resolve its Promise
+    const mockedFn = vi.mocked(createDelegateStatement);
+    mockedFn.mockResolvedValueOnce(undefined); // Since the function resolves without a return
+
+    // Call the function
+    await createDelegateStatement(args);
+
+    // Assertions
+    expect(mockedFn).toHaveBeenCalledTimes(1); // Validate it was called exactly once
+    expect(mockedFn).toHaveBeenCalledWith(args); // Validate it was called with the right arguments
+  });
+});

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -5,10 +5,9 @@ import Tenant from "@/lib/tenant/tenant";
 import { stageStatus } from "@/app/lib/sharedEnums";
 import { stageStatus as prismaStageStatus } from "@prisma/client";
 import { DelegateStatement } from "@/app/api/common/delegateStatement/delegateStatement";
-const { ui } = Tenant.current();
+const { ui, slug } = Tenant.current();
 import { prismaWeb2Client } from "@/app/lib/prisma";
 import { createHash } from "crypto";
-// import { cleanup } from "@testing-library/react";
 
 vi.mock("server-only", () => ({})); // Mock server-only module
 
@@ -16,6 +15,7 @@ vi.mock("server-only", () => ({})); // Mock server-only module
 //   createDelegateStatement: vi.fn(),
 // }));
 
+// Because we aren't signing a message onchain, we cannot verify, and most skip over this check.
 vi.mock("@/lib/serverVerifyMessage", () => ({
   default: vi.fn(),
 }));
@@ -24,7 +24,6 @@ vi.mock("@/lib/serverVerifyMessage", () => ({
 const mockAddress =
   "0xcC0B26236AFa80673b0859312a7eC16d2b72C1e3" as `0x${string}`;
 const mockStage = stageStatus.PUBLISHED as stageStatus;
-const mockSlug = "DEMO";
 
 // Define default values for the schema
 const mockDelegateStatement = {
@@ -55,7 +54,7 @@ const setDefaultValues = (delegateStatement: DelegateStatement | null) => {
   return {
     agreeCodeConduct: !requireCodeOfConduct,
     agreeDaoPrinciples: !requireDaoPrinciples,
-    daoSlug: mockSlug,
+    daoSlug: slug,
     discord: delegateStatement?.discord || "",
     delegateStatement:
       (delegateStatement?.payload as { delegateStatement?: string })
@@ -221,7 +220,7 @@ describe("createDelegateStatement basic setup", () => {
 
     // Assert the record exists and matches the input data
     expect(result?.address.toLowerCase()).toBe(args.address.toLowerCase());
-    expect(result?.dao_slug).toBe(mockSlug);
+    expect(result?.dao_slug).toBe(slug);
     expect(result?.stage).toBe(args.stage);
     expect(result?.signature).toBe(args.signature);
     expect(result?.message_hash).toBe(messageHash);
@@ -232,7 +231,7 @@ describe("createDelegateStatement basic setup", () => {
       where: {
         address_dao_slug_stage: {
           address: args.address,
-          dao_slug: mockSlug,
+          dao_slug: slug,
           stage: args.stage,
         },
       },

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -3,10 +3,10 @@ import { createDelegateStatement } from "@/app/api/common/delegateStatement/crea
 import verifyMessage from "@/lib/serverVerifyMessage";
 import Tenant from "@/lib/tenant/tenant";
 import { stageStatus } from "@/app/lib/sharedEnums";
-import { DelegateStatement } from "@/app/api/common/delegateStatement/delegateStatement";
-const { ui, slug } = Tenant.current();
+const { slug } = Tenant.current();
 import { prismaWeb2Client } from "@/app/lib/prisma";
 import { createHash } from "crypto";
+import { setDefaultValues } from "@/app/api/common/delegateStatement/__tests__/sharedTestInfra";
 
 import { getDraftMessageHash } from "@/app/api/common/delegateStatement/createDelegateStatement";
 
@@ -46,115 +46,6 @@ const mockDelegateStatement = {
     wants_proposal_ending_soon_email: "prompt",
     last_updated_at: Date.now(),
   },
-};
-const requireCodeOfConduct = !!ui.toggle("delegates/code-of-conduct")?.enabled;
-const requireDaoPrinciples = !!ui.toggle("delegates/dao-principles")?.enabled;
-const topIssues = ui.governanceIssues;
-const defaultIssues = !topIssues;
-
-const setDefaultValues = (delegateStatement: DelegateStatement | null) => {
-  return {
-    agreeCodeConduct: !requireCodeOfConduct,
-    agreeDaoPrinciples: !requireDaoPrinciples,
-    daoSlug: slug,
-    discord: delegateStatement?.discord || "",
-    delegateStatement:
-      (delegateStatement?.payload as { delegateStatement?: string })
-        ?.delegateStatement || "",
-    email: delegateStatement?.email || "",
-    twitter: delegateStatement?.twitter || "",
-    warpcast: delegateStatement?.warpcast || "",
-    scwAddress: delegateStatement?.scw_address || "",
-    topIssues: Array.isArray(
-      (
-        delegateStatement?.payload as {
-          topIssues: { value: string; type: string }[];
-        }
-      )?.topIssues
-    )
-      ? (
-          delegateStatement?.payload as {
-            topIssues: { value: string; type: string }[];
-          }
-        )?.topIssues
-      : defaultIssues
-        ? [] // Convert boolean `defaultIssues` to an empty array
-        : [],
-
-    topStakeholders:
-      (
-        delegateStatement?.payload as {
-          topStakeholders: {
-            value: string;
-            type: string;
-          }[];
-        }
-      )?.topStakeholders?.length > 0
-        ? (
-            delegateStatement?.payload as {
-              topStakeholders: {
-                value: string;
-                type: string;
-              }[];
-            }
-          )?.topStakeholders
-        : [],
-
-    openToSponsoringProposals:
-      (
-        delegateStatement?.payload as {
-          openToSponsoringProposals?: "yes" | "no" | null;
-        }
-      )?.openToSponsoringProposals || null,
-    mostValuableProposals: Array.isArray(
-      (
-        delegateStatement?.payload as {
-          mostValuableProposals?: { number: string }[];
-        }
-      )?.mostValuableProposals
-    )
-      ? (
-          (
-            delegateStatement?.payload as {
-              mostValuableProposals?: object[];
-            }
-          )?.mostValuableProposals as { number: string }[]
-        ).filter(
-          (proposal) =>
-            typeof proposal === "object" &&
-            "number" in proposal &&
-            typeof proposal.number === "string"
-        )
-      : [],
-    leastValuableProposals: Array.isArray(
-      (
-        delegateStatement?.payload as {
-          leastValuableProposals?: { number: string }[];
-        }
-      )?.leastValuableProposals
-    )
-      ? (
-          (
-            delegateStatement?.payload as {
-              leastValuableProposals?: object[];
-            }
-          )?.leastValuableProposals as { number: string }[]
-        ).filter(
-          (proposal) =>
-            typeof proposal === "object" &&
-            "number" in proposal &&
-            typeof proposal.number === "string"
-        )
-      : [],
-    notificationPreferences: (delegateStatement?.notification_preferences as {
-      wants_proposal_created_email: "prompt" | "prompted" | boolean;
-      wants_proposal_ending_soon_email: "prompt" | "prompted" | boolean;
-    }) || {
-      wants_proposal_created_email: "prompt",
-      wants_proposal_ending_soon_email: "prompt",
-    },
-    last_updated: new Date().toISOString(),
-  };
 };
 
 const mockDelegateStatementFV = setDefaultValues(mockDelegateStatement);

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -196,16 +196,20 @@ describe("publishDelegateStatementDraft", () => {
 
   it("Gracefully handles a non-existent message", async () => {
     // Call utility function with a message that doesn't exist - non-hashed
+    const nonExistentMessage = "Non-existent message";
+    const nonExistentMessageHash = createHash("sha256")
+      .update(nonExistentMessage)
+      .digest("hex");
     await expect(
       publishDelegateStatementDraft({
         address: mockAddress,
         messageOrMessageHash: {
           type: "MESSAGE",
-          value: "Non-existent message",
+          value: nonExistentMessage,
         },
       })
     ).rejects.toThrow(
-      `No draft found for the given address (${mockAddress.toLowerCase()}), DAO (${slug}), and message hash (${messageHash}).`
+      `No draft found for the given address (${mockAddress.toLowerCase()}), DAO (${slug}), and message hash (${nonExistentMessageHash}).`
     );
   });
 

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -233,4 +233,21 @@ describe("publishDelegateStatementDraft", () => {
       `No draft found for the given address (${mockAddress.toLowerCase()}), DAO (${slug}), and message hash (${nonExistentMessageHash}).`
     );
   });
+
+  it("Gracefully handles a non-existent Address", async () => {
+    // Call utility function with an address that doesn't exist
+    const fakeAddress = "0x0000000000000000000000000000000000000000";
+
+    await expect(
+      publishDelegateStatementDraft({
+        address: fakeAddress,
+        messageOrMessageHash: {
+          type: "MESSAGE_HASH",
+          value: messageHash,
+        },
+      })
+    ).rejects.toThrow(
+      `No draft found for the given address (${fakeAddress.toLowerCase()}), DAO (${slug}), and message hash (${messageHash}).`
+    );
+  });
 });

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -200,6 +200,7 @@ describe("publishDelegateStatementDraft", () => {
     const nonExistentMessageHash = createHash("sha256")
       .update(nonExistentMessage)
       .digest("hex");
+
     await expect(
       publishDelegateStatementDraft({
         address: mockAddress,
@@ -213,16 +214,23 @@ describe("publishDelegateStatementDraft", () => {
     );
   });
 
-  it("Gracefull handles a non-existent message hash", async () => {
+  it("Gracefully handles a non-existent message hash", async () => {
     // Call utility function with a message that doesn't exist - non-hashed
+    const nonExistentMessage = "Non-existent message";
+    const nonExistentMessageHash = createHash("sha256")
+      .update(nonExistentMessage)
+      .digest("hex");
+
     await expect(
-      await publishDelegateStatementDraft({
+      publishDelegateStatementDraft({
         address: mockAddress,
         messageOrMessageHash: {
           type: "MESSAGE_HASH",
-          value: "Non-existent message",
+          value: nonExistentMessageHash,
         },
       })
-    ).rejects.toThrow("Could not publish the delegate statement draft.");
+    ).rejects.toThrow(
+      `No draft found for the given address (${mockAddress.toLowerCase()}), DAO (${slug}), and message hash (${nonExistentMessageHash}).`
+    );
   });
 });

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -33,18 +33,31 @@ const mockDelegateStatement = {
 
 describe("createDelegateStatement basic setup", () => {
   it("should call createDelegateStatement with the correct data", async () => {
+    const mockDelegateStatment = {
+      discord: null,
+      email: "mock-email@example.com",
+      twitter: null,
+      warpcast: null,
+      address: "0xabcdef1234567890" as `0x${string}`,
+      dao_slug: slug,
+      stage: stageStatus.published,
+      signature: "0xabcdef1234567890" as `0x${string}`,
+      payload: {},
+      message_hash: "value",
+      createdAt: new Date().toISOString(), // Serialize Date to ISO string
+      updatedAt: new Date().toISOString(),
+      notification_preferences: {
+        wants_proposal_created_email: "prompt",
+        wants_proposal_ending_soon_email: "prompt",
+        last_updated_at: new Date(),
+      },
+      endorsed: false,
+      scw_address: null,
+    };
+
     const args = {
       address: "0xabcdef1234567890" as `0x${string}`,
-      delegateStatement: {
-        discord: null,
-        email: "mock-email@example.com",
-        twitter: null,
-        warpcast: null,
-        notificationPreferences: {
-          wants_proposal_created_email: "prompt",
-          wants_proposal_ending_soon_email: "prompt",
-        },
-      },
+      delegateStatement: mockDelegateStatment,
       signature: "0xsomesignaturemock",
       message: "mock-message",
       stage: stageStatus.published,
@@ -52,7 +65,7 @@ describe("createDelegateStatement basic setup", () => {
 
     // Mock `createDelegateStatement` to resolve its Promise
     const mockedFn = vi.mocked(createDelegateStatement);
-    mockedFn.mockResolvedValueOnce(undefined); // Since the function resolves without a return
+    mockedFn.mockResolvedValueOnce(mockDelegateStatment); // Since the function resolves without a return
 
     // Call the function
     await createDelegateStatement(args);

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -250,4 +250,28 @@ describe("publishDelegateStatementDraft", () => {
       `No draft found for the given address (${fakeAddress.toLowerCase()}), DAO (${slug}), and message hash (${messageHash}).`
     );
   });
+
+  it("Should throw the appropriate error if the connection to the database fails", async () => {
+    // Mock the prisma db connection so that it fails to connect
+    const mockPrismaError = {
+      code: "P1001",
+      message: "The database server was unable to be reached.",
+      clientVersion: "5.2.0", // Example client version
+    };
+
+    vi.spyOn(
+      prismaWeb2Client.delegateStatements,
+      "update"
+    ).mockRejectedValueOnce(mockPrismaError);
+
+    await expect(
+      publishDelegateStatementDraft({
+        address: mockAddress,
+        messageOrMessageHash: {
+          type: "MESSAGE_HASH",
+          value: messageHash,
+        },
+      })
+    ).rejects.toThrow("Failed to connect to database");
+  });
 });

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -6,6 +6,7 @@ import { stageStatus as prismaStageStatus } from "@prisma/client";
 import { DelegateStatement } from "@/app/api/common/delegateStatement/delegateStatement";
 const { ui } = Tenant.current();
 import { prismaWeb2Client } from "@/app/lib/prisma";
+import { createHash } from "crypto";
 
 vi.mock("server-only", () => ({})); // Mock server-only module
 
@@ -195,6 +196,15 @@ describe("createDelegateStatement basic setup", () => {
     });
 
     console.log("result", result);
+    const messageHash = createHash("sha256").update(args.message).digest("hex");
+
+    // Assert the record exists and matches the input data
+    expect(result?.address).toBe(args.address);
+    expect(result?.dao_slug).toBe(mockSlug);
+    expect(result?.stage).toBe(args.stage);
+    expect(result?.signature).toBe(args.signature);
+    expect(result?.message_hash).toBe(messageHash);
+    expect(result?.payload).toEqual(args.delegateStatement);
 
     // clean up after ourselves
     prismaWeb2Client.delegateStatements.delete({

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -126,10 +126,9 @@ describe("createDelegateStatement happy path", () => {
     );
     await prismaWeb2Client.delegateStatements.delete({
       where: {
-        address_dao_slug_stage_message_hash: {
+        address_dao_slug_message_hash: {
           address: args.address.toLowerCase(),
           dao_slug: slug,
-          stage: args.stage,
           message_hash: messageHash,
         },
       },

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -2,6 +2,7 @@ import { describe, it, vi, expect } from "vitest"; // Import from vitest
 import { createDelegateStatement } from "@/app/api/common/delegateStatement/createDelegateStatement";
 import Tenant from "@/lib/tenant/tenant";
 import { stageStatus } from "@/app/lib/sharedEnums";
+import { stageStatus as prismaStageStatus } from "@prisma/client";
 import { DelegateStatement } from "@/app/api/common/delegateStatement/delegateStatement";
 const { ui } = Tenant.current();
 import { prismaWeb2Client } from "@/app/lib/prisma";
@@ -185,25 +186,25 @@ describe("createDelegateStatement basic setup", () => {
     await createDelegateStatement(args);
 
     // validate the function exists
-    // const result = await prismaWeb2Client.delegateStatements.findFirst({
-    //   where: {
-    //     address: args.address,
-    //     dao_slug: mockSlug,
-    //     stage: mockStage,
-    //   },
-    // });
-    //
-    // console.log("result", result);
+    const result = await prismaWeb2Client.delegateStatements.findFirst({
+      where: {
+        address: args.address,
+        dao_slug: mockSlug,
+        stage: args.stage as prismaStageStatus,
+      },
+    });
+
+    console.log("result", result);
 
     // clean up after ourselves
-    // prismaWeb2Client.delegateStatements.delete({
-    //   where: {
-    //     address_dao_slug_stage: {
-    //       address: args.address,
-    //       dao_slug: mockSlug,
-    //       stage: args.stage,
-    //     },
-    //   },
-    // });
+    prismaWeb2Client.delegateStatements.delete({
+      where: {
+        address_dao_slug_stage: {
+          address: args.address,
+          dao_slug: mockSlug,
+          stage: args.stage,
+        },
+      },
+    });
   });
 });

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -165,7 +165,7 @@ describe("publishDelegateStatementDraft", () => {
 
     expect(postResult!!.stage).toBe(stageStatus.PUBLISHED);
   });
-  it("should publish a draft with a message", async () => {
+  it("Should publish a draft with a message", async () => {
     // Given an address and a message hash, flip the stage to 'published'
 
     // The delegate statement should be draft before our call
@@ -192,5 +192,33 @@ describe("publishDelegateStatementDraft", () => {
     });
 
     expect(postResult!!.stage).toBe(stageStatus.PUBLISHED);
+  });
+
+  it("Gracefully handles a non-existent message", async () => {
+    // Call utility function with a message that doesn't exist - non-hashed
+    await expect(
+      publishDelegateStatementDraft({
+        address: mockAddress,
+        messageOrMessageHash: {
+          type: "MESSAGE",
+          value: "Non-existent message",
+        },
+      })
+    ).rejects.toThrow(
+      `No draft found for the given address (${mockAddress.toLowerCase()}), DAO (${slug}), and message hash (${messageHash}).`
+    );
+  });
+
+  it("Gracefull handles a non-existent message hash", async () => {
+    // Call utility function with a message that doesn't exist - non-hashed
+    await expect(
+      await publishDelegateStatementDraft({
+        address: mockAddress,
+        messageOrMessageHash: {
+          type: "MESSAGE_HASH",
+          value: "Non-existent message",
+        },
+      })
+    ).rejects.toThrow("Could not publish the delegate statement draft.");
   });
 });

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -111,6 +111,12 @@ describe("getDraftMessage", () => {
 
     expect(response!!.toLowerCase()).toBe(messageHash.toLowerCase());
   });
+  it("should return null on a failed result", async () => {
+    const response = await getDraftMessageHash(
+      "0x0000000000000000000000000000000000000000"
+    );
+    expect(response).toBe(null);
+  });
 });
 
 describe("publishDelegateStatementDraft", () => {

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -229,12 +229,17 @@ describe("createDelegateStatement basic setup", () => {
     expect(result?.payload).toEqual(args.delegateStatement);
 
     // clean up after ourselves
-    prismaWeb2Client.delegateStatements.delete({
+    console.log("cleaning up");
+    console.log(
+      `Address: ${args.address}, DAO Slug: ${slug}, Message Hash: ${messageHash}, Stage: ${args.stage}`
+    );
+    await prismaWeb2Client.delegateStatements.delete({
       where: {
-        address_dao_slug_stage: {
-          address: args.address,
+        address_dao_slug_stage_message_hash: {
+          address: args.address.toLowerCase(),
           dao_slug: slug,
           stage: args.stage,
+          message_hash: messageHash,
         },
       },
     });

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -3,11 +3,12 @@ import { createDelegateStatement } from "@/app/api/common/delegateStatement/crea
 import verifyMessage from "@/lib/serverVerifyMessage";
 import Tenant from "@/lib/tenant/tenant";
 import { stageStatus } from "@/app/lib/sharedEnums";
-import { stageStatus as prismaStageStatus } from "@prisma/client";
 import { DelegateStatement } from "@/app/api/common/delegateStatement/delegateStatement";
 const { ui, slug } = Tenant.current();
 import { prismaWeb2Client } from "@/app/lib/prisma";
 import { createHash } from "crypto";
+
+import { getDraftMessageHash } from "@/app/api/common/delegateStatement/createDelegateStatement";
 
 vi.mock("server-only", () => ({})); // Mock server-only module
 
@@ -22,8 +23,9 @@ vi.mock("@/lib/serverVerifyMessage", () => ({
 
 // Add some default values that are refrenced multiple times
 const mockAddress =
-  "0xcC0B26236AFa80673b0859312a7eC16d2b72C1e3" as `0x${string}`;
+  "0xcC0B26236AFa80673b0859312a7eC16d2b72C1e4" as `0x${string}`;
 const mockStage = stageStatus.PUBLISHED as stageStatus;
+const mockMessage = "test";
 
 // Define default values for the schema
 const mockDelegateStatement = {
@@ -197,7 +199,7 @@ describe("createDelegateStatement basic setup", () => {
       address: mockAddress,
       delegateStatement: mockDelegateStatementFV,
       signature: "0xsomesignaturemock" as `0x${string}`,
-      message: "mock-message",
+      message: mockMessage,
       stage: mockStage,
     };
     const mockVerifyMessage = vi.mocked(verifyMessage);
@@ -236,5 +238,18 @@ describe("createDelegateStatement basic setup", () => {
         },
       },
     });
+  });
+});
+
+describe("getDraftMessage", () => {
+  it("should return the message hash on a successful result", async () => {
+    const messageHash = createHash("sha256").update(mockMessage).digest("hex");
+
+    const response = await getDraftMessageHash(mockAddress);
+
+    console.log("response:", response);
+    console.log("messageHash:", messageHash);
+
+    expect(response!!.toLowerCase()).toBe(messageHash.toLowerCase());
   });
 });

--- a/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/createDelegateStatement.test.ts
@@ -159,7 +159,7 @@ const setDefaultValues = (delegateStatement: DelegateStatement | null) => {
 
 const mockDelegateStatementFV = setDefaultValues(mockDelegateStatement);
 
-describe("createDelegateStatement basic setup", () => {
+describe("createDelegateStatement happy path", () => {
   // afterEach(() => {
   //   vi.clearAllMocks();
   //   cleanup();

--- a/src/app/api/common/delegateStatement/__tests__/deleteDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/deleteDelegateStatement.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, vi } from "vitest";
+import { stageStatus } from "@/app/lib/sharedEnums";
+import { setDefaultValues } from "@/app/api/common/delegateStatement/__tests__/sharedTestInfra";
+import { createHash } from "crypto";
+import verifyMessage from "@/lib/serverVerifyMessage";
+import { createDelegateStatement } from "@/app/api/common/delegateStatement/createDelegateStatement";
+import { deleteDelegateStatement } from "@/app/api/common/delegateStatement/deleteDelegateStatement";
+
+vi.mock("server-only", () => ({})); // Mock server-only module
+
+// Because we aren't signing a message onchain, we cannot verify, and most skip over this check.
+vi.mock("@/lib/serverVerifyMessage", () => ({
+  default: vi.fn(),
+}));
+
+// Add some default values that are refrenced multiple times
+const mockAddress =
+  "0xcC0B26236AFa80673b0859312a7eC16d2b72C1e4" as `0x${string}`;
+const mockStage = stageStatus.PUBLISHED as stageStatus;
+const mockMessage = "test";
+
+// Define default values for the schema
+const mockDelegateStatement = {
+  address: mockAddress,
+  stage: mockStage,
+  created_at: Date.now(),
+  discord: "discord",
+  endorsed: false,
+  payload: { delegateStatement: "A delegate, I am" },
+  signature: "0xstring" as `0x${string}`,
+  twitter: "twitter",
+  updated_at: Date.now(),
+  warpcast: "warpcast",
+  scw_address: null,
+  email: null,
+  notification_preferences: {
+    wants_proposal_created_email: "prompt",
+    wants_proposal_ending_soon_email: "prompt",
+    last_updated_at: Date.now(),
+  },
+};
+
+const mockDelegateStatementFV = setDefaultValues(mockDelegateStatement);
+
+describe("deleteDelegateStatement", () => {
+  it("should delete a specified delegate statement given it's primary key attributes", async () => {
+    let args = {
+      address: mockAddress,
+      delegateStatement: mockDelegateStatementFV,
+      signature: "0xsomesignaturemock" as `0x${string}`,
+      message: mockMessage,
+      stage: mockStage,
+    };
+
+    const messageHash = createHash("sha256").update(args.message).digest("hex");
+
+    const mockVerifyMessage = vi.mocked(verifyMessage);
+    mockVerifyMessage.mockResolvedValueOnce(true);
+
+    // Create a delegate statement
+    await createDelegateStatement(args);
+
+    // Check the value is found
+
+    // Delete the statement
+    await deleteDelegateStatement({
+      address: args.address,
+      messageHash: messageHash,
+      stage: args.stage,
+    });
+
+    // Check the value is not found
+  });
+});

--- a/src/app/api/common/delegateStatement/__tests__/deleteDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/deleteDelegateStatement.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, vi } from "vitest";
+import { describe, it, vi, expect } from "vitest";
 import { stageStatus } from "@/app/lib/sharedEnums";
 import { setDefaultValues } from "@/app/api/common/delegateStatement/__tests__/sharedTestInfra";
 import { createHash } from "crypto";
 import verifyMessage from "@/lib/serverVerifyMessage";
 import { createDelegateStatement } from "@/app/api/common/delegateStatement/createDelegateStatement";
 import { deleteDelegateStatement } from "@/app/api/common/delegateStatement/deleteDelegateStatement";
+import {
+  getDelegateStatementForAddress,
+  getDelegateStatementsForAddress,
+} from "@/app/api/common/delegateStatement/getDelegateStatement";
 
 vi.mock("server-only", () => ({})); // Mock server-only module
 
@@ -61,14 +65,26 @@ describe("deleteDelegateStatement", () => {
     await createDelegateStatement(args);
 
     // Check the value is found
+    const createRes = await getDelegateStatementForAddress({
+      address: args.address,
+      messageOrMessageHash: { type: "MESSAGE_HASH", value: messageHash },
+    });
+
+    expect(createRes).exist;
 
     // Delete the statement
     await deleteDelegateStatement({
       address: args.address,
       messageHash: messageHash,
-      stage: args.stage,
     });
 
     // Check the value is not found
+
+    const deleteRes = await getDelegateStatementForAddress({
+      address: args.address,
+      messageOrMessageHash: { type: "MESSAGE_HASH", value: messageHash },
+    });
+
+    expect(deleteRes).not.exist;
   });
 });

--- a/src/app/api/common/delegateStatement/__tests__/deleteDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/deleteDelegateStatement.test.ts
@@ -109,16 +109,16 @@ describe("safeDeleteDelegateStatement", () => {
       messageOrMessageHash: { type: "MESSAGE_HASH", value: messageHash },
     });
 
+    // Mock the verifyMessage function to return true
+    const mockVerifyMessage = vi.mocked(verifyMessage);
+    mockVerifyMessage.mockResolvedValue(true);
+
     expect(createRes).exist;
     await safeDeleteDelegateStatement({
       address: mockAddress,
       signature: args.signature,
       message: mockMessage,
     });
-
-    // Mock the verifyMessage function to return true
-    const mockVerifyMessage = vi.mocked(verifyMessage);
-    mockVerifyMessage.mockResolvedValue(true);
 
     // Check the value is not found
     const deleteRes = await getDelegateStatementForAddress({

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -5,7 +5,10 @@ import { vi } from "vitest";
 import verifyMessage from "@/lib/serverVerifyMessage";
 import { createDelegateStatement } from "@/app/api/common/delegateStatement/createDelegateStatement";
 import { createHash } from "crypto";
-import { getDelegateStatementsForAddress } from "@/app/api/common/delegateStatement/getDelegateStatement";
+import {
+  getDelegateStatementForAddress,
+  getDelegateStatementsForAddress,
+} from "@/app/api/common/delegateStatement/getDelegateStatement";
 import { prismaWeb2Client } from "@/app/lib/prisma";
 import Tenant from "@/lib/tenant/tenant";
 const { slug } = Tenant.current();
@@ -114,6 +117,22 @@ describe("getDelegateStatementForAddress", () => {
   afterEach(async () => {
     // Delete the delegate statements to clean up
     await deleteTwoMockDelegateStatement();
+  });
+
+  it("should return a delegate statement given it's primary key attributes (hashed message)", async () => {
+    const delegateStatement = await getDelegateStatementForAddress({
+      address: mockAddress,
+      messageOrMessageHash: { type: "MESSAGE_HASH", value: messageHash1 },
+    });
+    expect(delegateStatement!!.message_hash).toBe(messageHash1);
+  });
+
+  it("should return a delegate statement given it's primary key attributes (non-hashed message)", async () => {
+    const delegateStatement = await getDelegateStatementForAddress({
+      address: mockAddress,
+      messageOrMessageHash: { type: "MESSAGE", value: mockMessage },
+    });
+    expect(delegateStatement!!.message_hash).toBe(messageHash1);
   });
 });
 describe("getDelegateStatements", () => {

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -11,9 +11,11 @@ import {
   getDelegateStatements,
   getDelegateStatementsForAddress,
   getLatestPublishedDelegateStatement,
+  getLatestPublishedDelegateStatementInSpan,
 } from "@/app/api/common/delegateStatement/getDelegateStatement";
 import { prismaWeb2Client } from "@/app/lib/prisma";
 import Tenant from "@/lib/tenant/tenant";
+import * as logging from "@/app/lib/logging";
 const { slug } = Tenant.current();
 
 vi.mock("server-only", () => ({})); // Mock server-only module
@@ -227,5 +229,18 @@ describe("getLatestPublishedDelegateStatement", async () => {
   it("Should get the latest published delegate statement", async () => {
     const res = await getLatestPublishedDelegateStatement(mockAddress);
     expect(res!!.message_hash).toBe(messageHash1);
+  });
+
+  it("Should get the latest published delegate statement in span", async () => {
+    const doInSpanSpy = vi.spyOn(logging, "doInSpan");
+
+    const res = await getLatestPublishedDelegateStatementInSpan(mockAddress);
+    expect(res!!.message_hash).toBe(messageHash1);
+
+    // Assert that doInSpan was called with the expected metadata
+    expect(doInSpanSpy).toHaveBeenCalledWith(
+      { name: "getLatestPublishedDelegateStatement" },
+      expect.any(Function) // Ensure that the second argument is any function
+    );
   });
 });

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -1,0 +1,3 @@
+describe("getDelegteStatement", () => {
+  it("should return a delegate statement", () => {});
+});

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest"; // Import from vitest
+import { describe, it, expect } from "vitest"; // Import from vitest
 import { stageStatus } from "@/app/lib/sharedEnums";
 import { setDefaultValues } from "@/app/api/common/delegateStatement/__tests__/sharedTestInfra";
 import { vi } from "vitest";
@@ -80,8 +80,13 @@ describe("getDelegteStatement", () => {
       stage: mockStage,
     });
 
-    // Verify they are as expected
-    // TODO
+    // Verify they are as expected, check message hashes
+    const expectedHashes = [messageHash1, messageHash2];
+
+    const statementHashes = delegateStatements!!.map(
+      (statement) => statement.message_hash
+    );
+    expect(statementHashes).toEqual(expectedHashes);
 
     // Delete the delegate statements to clean up
     await prismaWeb2Client.delegateStatements.delete({

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -8,6 +8,7 @@ import { createHash } from "crypto";
 import {
   getDelegateStatement,
   getDelegateStatementForAddress,
+  getDelegateStatements,
   getDelegateStatementsForAddress,
 } from "@/app/api/common/delegateStatement/getDelegateStatement";
 import { prismaWeb2Client } from "@/app/lib/prisma";
@@ -74,8 +75,9 @@ const createTwoMockDelegateStatement = async () => {
 
   // Create a delegate statement
   await createDelegateStatement(args);
-  // Create a second delegate statement
+  // Create a second delegate as draft statement
   args.message = "second-message";
+  args.stage = stageStatus.DRAFT;
   await createDelegateStatement(args);
 
   messageHash2 = createHash("sha256").update(args.message).digest("hex");
@@ -160,6 +162,27 @@ describe("getDelegateStatements", () => {
   afterEach(async () => {
     // Delete the delegate statements to clean up
     await deleteTwoMockDelegateStatement();
+  });
+
+  it("Should get all delegate statements at a given a published stage", async () => {
+    const res = await getDelegateStatements(mockAddress, stageStatus.PUBLISHED);
+    expect(res!!.length).toBe(1);
+    res!!.forEach((delegateStatement) => {
+      expect(delegateStatement.stage).toBe(stageStatus.PUBLISHED);
+    });
+  });
+
+  it("Should get all delegate statements at a given a draft stage", async () => {
+    const res = await getDelegateStatements(mockAddress, stageStatus.DRAFT);
+    expect(res!!.length).toBe(1);
+    res!!.forEach((delegateStatement) => {
+      expect(delegateStatement.stage).toBe(stageStatus.DRAFT);
+    });
+  });
+
+  it("Should get all delegate statements when no stage given", async () => {
+    const res = await getDelegateStatements(mockAddress);
+    expect(res!!.length).toBe(2);
   });
 });
 describe("getDelegateStatementsForAddress", () => {

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -114,4 +114,6 @@ describe("getDelegteStatement", () => {
     );
     expect(statementHashes).toEqual(expectedHashes);
   });
+
+  it("should return a ");
 });

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -14,6 +14,11 @@ import Tenant from "@/lib/tenant/tenant";
 const { slug } = Tenant.current();
 
 vi.mock("server-only", () => ({})); // Mock server-only module
+// Mock the `cache` function from React
+vi.mock("react", () => ({
+  // Provide a mock implementation of `cache` as a passthrough
+  cache: vi.fn((fn) => fn),
+}));
 
 // Because we aren't signing a message onchain, we cannot verify, and most skip over this check.
 vi.mock("@/lib/serverVerifyMessage", () => ({

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -6,6 +6,7 @@ import verifyMessage from "@/lib/serverVerifyMessage";
 import { createDelegateStatement } from "@/app/api/common/delegateStatement/createDelegateStatement";
 import { createHash } from "crypto";
 import {
+  getDelegateStatement,
   getDelegateStatementForAddress,
   getDelegateStatementsForAddress,
 } from "@/app/api/common/delegateStatement/getDelegateStatement";
@@ -101,7 +102,7 @@ const deleteTwoMockDelegateStatement = async () => {
   });
 };
 
-describe("getDelegteStatement", () => {
+describe("getDelegateStatement", () => {
   beforeEach(async () => {
     // Create a couple delegate statements
     await createTwoMockDelegateStatement();
@@ -110,6 +111,16 @@ describe("getDelegteStatement", () => {
   afterEach(async () => {
     // Delete the delegate statements to clean up
     await deleteTwoMockDelegateStatement();
+  });
+
+  it("Should get a single delegate statement", async () => {
+    const res = await getDelegateStatement(mockAddress, {
+      type: "MESSAGE_HASH",
+      value: messageHash1,
+    });
+
+    expect(res!!.message_hash).toBe(messageHash1);
+    expect(res!!.address).toBe(mockAddress.toLowerCase());
   });
 });
 

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -79,20 +79,18 @@ describe("getDelegteStatement", () => {
     // Delete the delegate statements to clean up
     await prismaWeb2Client.delegateStatements.delete({
       where: {
-        address_dao_slug_stage_message_hash: {
+        address_dao_slug_message_hash: {
           address: args.address.toLowerCase(),
           dao_slug: slug,
-          stage: args.stage,
           message_hash: messageHash1,
         },
       },
     });
     await prismaWeb2Client.delegateStatements.delete({
       where: {
-        address_dao_slug_stage_message_hash: {
+        address_dao_slug_message_hash: {
           address: args.address.toLowerCase(),
           dao_slug: slug,
-          stage: args.stage,
           message_hash: messageHash2,
         },
       },

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -1,3 +1,108 @@
+import { describe, it } from "vitest"; // Import from vitest
+import { stageStatus } from "@/app/lib/sharedEnums";
+import { setDefaultValues } from "@/app/api/common/delegateStatement/__tests__/sharedTestInfra";
+import { vi } from "vitest";
+import verifyMessage from "@/lib/serverVerifyMessage";
+import { createDelegateStatement } from "@/app/api/common/delegateStatement/createDelegateStatement";
+import { createHash } from "crypto";
+import { getDelegateStatementsForAddress } from "@/app/api/common/delegateStatement/getDelegateStatement";
+import { prismaWeb2Client } from "@/app/lib/prisma";
+import Tenant from "@/lib/tenant/tenant";
+const { slug } = Tenant.current();
+
+vi.mock("server-only", () => ({})); // Mock server-only module
+
+// Because we aren't signing a message onchain, we cannot verify, and most skip over this check.
+vi.mock("@/lib/serverVerifyMessage", () => ({
+  default: vi.fn(),
+}));
+
+// Add some default values that are refrenced multiple times
+const mockAddress =
+  "0xcC0B26236AFa80673b0859312a7eC16d2b72C1e4" as `0x${string}`;
+const mockStage = stageStatus.PUBLISHED as stageStatus;
+const mockMessage = "test";
+
+// Define default values for the schema
+const mockDelegateStatement = {
+  address: mockAddress,
+  stage: mockStage,
+  created_at: Date.now(),
+  discord: "discord",
+  endorsed: false,
+  payload: { delegateStatement: "A delegate, I am" },
+  signature: "0xstring" as `0x${string}`,
+  twitter: "twitter",
+  updated_at: Date.now(),
+  warpcast: "warpcast",
+  scw_address: null,
+  email: null,
+  notification_preferences: {
+    wants_proposal_created_email: "prompt",
+    wants_proposal_ending_soon_email: "prompt",
+    last_updated_at: Date.now(),
+  },
+};
+
+const mockDelegateStatementFV = setDefaultValues(mockDelegateStatement);
+
 describe("getDelegteStatement", () => {
-  it("should return a delegate statement", () => {});
+  it("should return all delegate statements ", async () => {
+    let args = {
+      address: mockAddress,
+      delegateStatement: mockDelegateStatementFV,
+      signature: "0xsomesignaturemock" as `0x${string}`,
+      message: mockMessage,
+      stage: mockStage,
+    };
+
+    const messageHash1 = createHash("sha256")
+      .update(args.message)
+      .digest("hex");
+
+    const mockVerifyMessage = vi.mocked(verifyMessage);
+    mockVerifyMessage.mockResolvedValueOnce(true);
+    mockVerifyMessage.mockResolvedValueOnce(true); // for second create
+
+    // Create a delegate statement
+    await createDelegateStatement(args);
+    // Create a second delegate statement
+    args.message = "second-message";
+    await createDelegateStatement(args);
+
+    const messageHash2 = createHash("sha256")
+      .update(args.message)
+      .digest("hex");
+
+    // Get the statements
+    const delegateStatements = await getDelegateStatementsForAddress({
+      address: mockAddress,
+      stage: mockStage,
+    });
+
+    // Verify they are as expected
+    // TODO
+
+    // Delete the delegate statements to clean up
+    await prismaWeb2Client.delegateStatements.delete({
+      where: {
+        address_dao_slug_stage_message_hash: {
+          address: args.address.toLowerCase(),
+          dao_slug: slug,
+          stage: args.stage,
+          message_hash: messageHash1,
+        },
+      },
+    });
+    await prismaWeb2Client.delegateStatements.delete({
+      where: {
+        address_dao_slug_stage_message_hash: {
+          address: args.address.toLowerCase(),
+          dao_slug: slug,
+          stage: args.stage,
+          message_hash: messageHash2,
+        },
+      },
+    });
+  });
 });

--- a/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
+++ b/src/app/api/common/delegateStatement/__tests__/getDelegateStatement.test.ts
@@ -10,6 +10,7 @@ import {
   getDelegateStatementForAddress,
   getDelegateStatements,
   getDelegateStatementsForAddress,
+  getLatestPublishedDelegateStatement,
 } from "@/app/api/common/delegateStatement/getDelegateStatement";
 import { prismaWeb2Client } from "@/app/lib/prisma";
 import Tenant from "@/lib/tenant/tenant";
@@ -209,5 +210,22 @@ describe("getDelegateStatementsForAddress", () => {
       (statement) => statement.message_hash
     );
     expect(statementHashes).toEqual(expectedHashes);
+  });
+});
+
+describe("getLatestPublishedDelegateStatement", async () => {
+  beforeEach(async () => {
+    // Create a couple delegate statements
+    await createTwoMockDelegateStatement();
+  });
+
+  afterEach(async () => {
+    // Delete the delegate statements to clean up
+    await deleteTwoMockDelegateStatement();
+  });
+
+  it("Should get the latest published delegate statement", async () => {
+    const res = await getLatestPublishedDelegateStatement(mockAddress);
+    expect(res!!.message_hash).toBe(messageHash1);
   });
 });

--- a/src/app/api/common/delegateStatement/__tests__/sharedTestInfra.ts
+++ b/src/app/api/common/delegateStatement/__tests__/sharedTestInfra.ts
@@ -1,0 +1,122 @@
+import { DelegateStatement } from "@/app/api/common/delegateStatement/delegateStatement";
+
+// This is a shared test infrastructure for the delegate statement API.
+// It is used by both the delegate statement API and the delegate statement
+// form.
+
+import Tenant from "@/lib/tenant/tenant";
+const { slug, ui } = Tenant.current();
+
+const requireCodeOfConduct = !!ui.toggle("delegates/code-of-conduct")?.enabled;
+const requireDaoPrinciples = !!ui.toggle("delegates/dao-principles")?.enabled;
+const topIssues = ui.governanceIssues;
+const defaultIssues = !topIssues;
+
+// This (setDefaultValues) could live outside createDelegateStatement,
+// but it's only used there, so it's here.'
+export const setDefaultValues = (
+  delegateStatement: DelegateStatement | null
+) => {
+  return {
+    agreeCodeConduct: !requireCodeOfConduct,
+    agreeDaoPrinciples: !requireDaoPrinciples,
+    daoSlug: slug,
+    discord: delegateStatement?.discord || "",
+    delegateStatement:
+      (delegateStatement?.payload as { delegateStatement?: string })
+        ?.delegateStatement || "",
+    email: delegateStatement?.email || "",
+    twitter: delegateStatement?.twitter || "",
+    warpcast: delegateStatement?.warpcast || "",
+    scwAddress: delegateStatement?.scw_address || "",
+    topIssues: Array.isArray(
+      (
+        delegateStatement?.payload as {
+          topIssues: { value: string; type: string }[];
+        }
+      )?.topIssues
+    )
+      ? (
+          delegateStatement?.payload as {
+            topIssues: { value: string; type: string }[];
+          }
+        )?.topIssues
+      : defaultIssues
+        ? [] // Convert boolean `defaultIssues` to an empty array
+        : [],
+
+    topStakeholders:
+      (
+        delegateStatement?.payload as {
+          topStakeholders: {
+            value: string;
+            type: string;
+          }[];
+        }
+      )?.topStakeholders?.length > 0
+        ? (
+            delegateStatement?.payload as {
+              topStakeholders: {
+                value: string;
+                type: string;
+              }[];
+            }
+          )?.topStakeholders
+        : [],
+
+    openToSponsoringProposals:
+      (
+        delegateStatement?.payload as {
+          openToSponsoringProposals?: "yes" | "no" | null;
+        }
+      )?.openToSponsoringProposals || null,
+    mostValuableProposals: Array.isArray(
+      (
+        delegateStatement?.payload as {
+          mostValuableProposals?: { number: string }[];
+        }
+      )?.mostValuableProposals
+    )
+      ? (
+          (
+            delegateStatement?.payload as {
+              mostValuableProposals?: object[];
+            }
+          )?.mostValuableProposals as { number: string }[]
+        ).filter(
+          (proposal) =>
+            typeof proposal === "object" &&
+            "number" in proposal &&
+            typeof proposal.number === "string"
+        )
+      : [],
+    leastValuableProposals: Array.isArray(
+      (
+        delegateStatement?.payload as {
+          leastValuableProposals?: { number: string }[];
+        }
+      )?.leastValuableProposals
+    )
+      ? (
+          (
+            delegateStatement?.payload as {
+              leastValuableProposals?: object[];
+            }
+          )?.leastValuableProposals as { number: string }[]
+        ).filter(
+          (proposal) =>
+            typeof proposal === "object" &&
+            "number" in proposal &&
+            typeof proposal.number === "string"
+        )
+      : [],
+    notificationPreferences: (delegateStatement?.notification_preferences as {
+      wants_proposal_created_email: "prompt" | "prompted" | boolean;
+      wants_proposal_ending_soon_email: "prompt" | "prompted" | boolean;
+    }) || {
+      wants_proposal_created_email: "prompt",
+      wants_proposal_ending_soon_email: "prompt",
+    },
+    last_updated: new Date().toISOString(),
+  };
+};

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -140,14 +140,19 @@ export const publishDelegateStatementDraft = ({
       })
       .catch((error) => {
         if (error instanceof PrismaClientKnownRequestError) {
-          if (error.code === "P2025") {
-            throw new Error(
-              `No draft found for the given address (${address.toLowerCase()}), DAO (${slug}), and message hash (${messageHash}).`
-            );
+          switch (error.code) {
+            case "P2025":
+              throw new Error(
+                `No draft found for the given address (${address.toLowerCase()}), DAO (${slug}), and message hash (${messageHash}).`
+              );
+            case "P1001":
+              throw new Error("Cannot connect to database, please retry.");
+            default:
+              throw new Error(
+                "Prisma failed to publish the delegate statement draft with the following error: " +
+                  error.message
+              );
           }
-          throw new Error(
-            "Prisma failed to publish the delegate statement draft."
-          );
         }
       });
   } catch (error) {

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -94,12 +94,7 @@ export async function createDelegateStatement({
  * @param ${address} address - The address of the delegate
  * @param ${daoSlug} daoSlug - slug of DAO site
  * */
-const publishDelegateStatementDraft = ({
-  address,
-}: {
-  address: string;
-  daoSlug: string;
-}) => {
+const publishDelegateStatementDraft = ({ address }: { address: string }) => {
   try {
     return prismaWeb2Client.delegateStatements.update({
       where: {

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -117,7 +117,9 @@ const publishDelegateStatementDraft = ({ address }: { address: string }) => {
   }
 };
 
-export const getDraftMessageHash = async (address: string): string | null => {
+export const getDraftMessageHash = async (
+  address: string
+): Promise<string | null> => {
   try {
     const result = await prismaWeb2Client.delegateStatements.findFirst({
       where: {
@@ -126,10 +128,9 @@ export const getDraftMessageHash = async (address: string): string | null => {
         stage: stageStatus.DRAFT,
       },
     });
-    console.log(result);
-
+    // No result found, return null
     return result ? result.message_hash : null;
   } catch (error) {
-    console.log(error);
+    throw new Error("Error retrieving draft message hash");
   }
 };

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -49,6 +49,7 @@ export async function createDelegateStatement({
     delegateStatement: sanitizeContent(delegateStatement.delegateStatement),
   };
 
+  // Default stage to published
   stage = stage ?? stageStatus.PUBLISHED;
 
   const data = {
@@ -69,6 +70,22 @@ export async function createDelegateStatement({
     stage,
   };
 
+  // Only update a draft proposal (can only be one)
+  if (stage === stageStatus.DRAFT) {
+    return prismaWeb2Client.delegateStatements.upsert({
+      where: {
+        address_dao_slug_stage: {
+          address: address.toLowerCase(),
+          dao_slug: slug,
+          stage: stage,
+        },
+      },
+      update: data,
+      create: data,
+    });
+  }
+
+  // Otherwise create a new published proposal
   return prismaWeb2Client.delegateStatements.create({ data });
 }
 

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -74,12 +74,12 @@ export async function createDelegateStatement({
   if (stage === stageStatus.DRAFT) {
     return prismaWeb2Client.delegateStatements.upsert({
       where: {
-        address_dao_slug_stage_message_hash: {
+        address_dao_slug_message_hash: {
           address: address.toLowerCase(),
           dao_slug: slug,
-          stage: stage,
           message_hash: messageHash,
         },
+        stage: stage,
       },
       update: data,
       create: data,
@@ -99,12 +99,12 @@ const publishDelegateStatementDraft = ({ address }: { address: string }) => {
   try {
     return prismaWeb2Client.delegateStatements.update({
       where: {
-        address_dao_slug_stage_message_hash: {
+        address_dao_slug_message_hash: {
           address: address.toLowerCase(),
           dao_slug: slug,
-          stage: stageStatus.DRAFT, // Ensures we're only updating drafts
           message_hash: "Test",
         },
+        stage: stageStatus.DRAFT, // Ensures we're only updating drafts
       },
       data: {
         stage: stageStatus.PUBLISHED, // Transition to published

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -74,10 +74,11 @@ export async function createDelegateStatement({
   if (stage === stageStatus.DRAFT) {
     return prismaWeb2Client.delegateStatements.upsert({
       where: {
-        address_dao_slug_stage: {
+        address_dao_slug_stage_message_hash: {
           address: address.toLowerCase(),
           dao_slug: slug,
           stage: stage,
+          message_hash: messageHash,
         },
       },
       update: data,
@@ -98,10 +99,11 @@ const publishDelegateStatementDraft = ({ address }: { address: string }) => {
   try {
     return prismaWeb2Client.delegateStatements.update({
       where: {
-        address_dao_slug_stage: {
+        address_dao_slug_stage_message_hash: {
           address: address.toLowerCase(),
           dao_slug: slug,
           stage: stageStatus.DRAFT, // Ensures we're only updating drafts
+          message_hash: "Test",
         },
       },
       data: {
@@ -112,5 +114,22 @@ const publishDelegateStatementDraft = ({ address }: { address: string }) => {
     // Graceful error handling
     console.error("Error updating draft to published:", error);
     throw new Error("Could not publish the delegate statement draft.");
+  }
+};
+
+export const getDraftMessageHash = async (address: string): string | null => {
+  try {
+    const result = await prismaWeb2Client.delegateStatements.findFirst({
+      where: {
+        address: address.toLowerCase(),
+        dao_slug: slug,
+        stage: stageStatus.DRAFT,
+      },
+    });
+    console.log(result);
+
+    return result ? result.message_hash : null;
+  } catch (error) {
+    console.log(error);
   }
 };

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -156,7 +156,7 @@ export const publishDelegateStatementDraft = ({
         }
       });
   } catch (error) {
-    // unkown error handling
+    // unknown error handling
     console.error("Unknown Error updating draft to published:", error);
     throw new Error("Could not publish the delegate statement draft.");
   }

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -12,7 +12,14 @@ import { MessageOrMessageHash } from "@/app/api/common/delegateStatement/delegat
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 
 const { slug } = Tenant.current();
-
+/** This function is used to create a new delegate statement.
+ * @param address The address of the delegate
+ * @param daoSlug Slug of DAO site
+ * @param message Textual message statement
+ * @param signature Signature of the message
+ * @param scwAddress Optional SCW address
+ * @param stage Optional stage of the statement
+ * */
 export async function createDelegateStatement({
   address,
   delegateStatement,
@@ -162,6 +169,9 @@ export const publishDelegateStatementDraft = ({
   }
 };
 
+/** This function is to retrieve the draft message hash for a given address.
+ * @param address
+ * An address at the given DAO slug should have only one draft. */
 export const getDraftMessageHash = async (
   address: string
 ): Promise<string | null> => {

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -166,16 +166,21 @@ export const getDraftMessageHash = async (
   address: string
 ): Promise<string | null> => {
   try {
-    const result = await prismaWeb2Client.delegateStatements.findFirst({
-      where: {
-        address: address.toLowerCase(),
-        dao_slug: slug,
-        stage: stageStatus.DRAFT,
-      },
-    });
+    const result = await prismaWeb2Client.delegateStatements
+      .findFirst({
+        where: {
+          address: address.toLowerCase(),
+          dao_slug: slug,
+          stage: stageStatus.DRAFT,
+        },
+      })
+      .catch((error) => {
+        console.error("Error retrieving draft message hash:", error);
+        throw new Error("Could not retrieve draft message hash.");
+      });
     // No result found, return null
     return result ? result.message_hash : null;
   } catch (error) {
-    throw new Error("Error retrieving draft message hash");
+    throw new Error(`Unknown Error retrieving draft message hash: ${error}`);
   }
 };

--- a/src/app/api/common/delegateStatement/createDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/createDelegateStatement.ts
@@ -7,6 +7,9 @@ import Tenant from "@/lib/tenant/tenant";
 import { Prisma } from "@prisma/client";
 import { sanitizeContent } from "@/lib/sanitizationUtils";
 import { createHash } from "crypto";
+import { stageStatus } from "@/app/lib/sharedEnums";
+
+const { slug } = Tenant.current();
 
 export async function createDelegateStatement({
   address,
@@ -14,16 +17,18 @@ export async function createDelegateStatement({
   signature,
   message,
   scwAddress,
+  // used if wallet is multisig
+  stage,
 }: {
   address: `0x${string}`;
   delegateStatement: DelegateStatementFormValues;
   signature: `0x${string}`;
   message: string;
   scwAddress?: string;
+  stage?: stageStatus;
 }) {
   const { twitter, warpcast, discord, email, notificationPreferences } =
     delegateStatement;
-  const { slug } = Tenant.current();
 
   const valid = await verifyMessage({
     address,
@@ -44,6 +49,8 @@ export async function createDelegateStatement({
     delegateStatement: sanitizeContent(delegateStatement.delegateStatement),
   };
 
+  stage = stage ?? stageStatus.PUBLISHED;
+
   const data = {
     address: address.toLowerCase(),
     dao_slug: slug,
@@ -59,18 +66,39 @@ export async function createDelegateStatement({
       ...notificationPreferences,
       last_updated: new Date().toISOString(),
     },
+    stage,
   };
 
-  return prismaWeb2Client.delegateStatements.upsert({
-    where: {
-      address_dao_slug: {
-        address: address.toLowerCase(),
-        dao_slug: slug,
-        message_hash: messageHash,
-        stage: stage,
-      },
-    },
-    update: data,
-    create: data,
-  });
+  return prismaWeb2Client.delegateStatements.create({ data });
 }
+
+/** This function is used to update an existing draft statement.
+ * This function is likely to transition a multisig delegate statement from 'draft' to 'published'.
+ * @param ${address} address - The address of the delegate
+ * @param ${daoSlug} daoSlug - slug of DAO site
+ * */
+const publishDelegateStatementDraft = ({
+  address,
+}: {
+  address: string;
+  daoSlug: string;
+}) => {
+  try {
+    return prismaWeb2Client.delegateStatements.update({
+      where: {
+        address_dao_slug_stage: {
+          address: address.toLowerCase(),
+          dao_slug: slug,
+          stage: stageStatus.DRAFT, // Ensures we're only updating drafts
+        },
+      },
+      data: {
+        stage: stageStatus.PUBLISHED, // Transition to published
+      },
+    });
+  } catch (error) {
+    // Graceful error handling
+    console.error("Error updating draft to published:", error);
+    throw new Error("Could not publish the delegate statement draft.");
+  }
+};

--- a/src/app/api/common/delegateStatement/delegateStatement.d.ts
+++ b/src/app/api/common/delegateStatement/delegateStatement.d.ts
@@ -4,3 +4,7 @@ export type DelegateStatement = Omit<
   DelegateStatements,
   "createdAt" | "updatedAt" | "signature" | "dao_slug" | "message_hash"
 >;
+
+export type MessageOrMessageHash =
+  | { type: "MESSAGE"; value: string }
+  | { type: "MESSAGE_HASH"; value: string };

--- a/src/app/api/common/delegateStatement/deleteDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/deleteDelegateStatement.ts
@@ -7,7 +7,7 @@ import { createHash } from "crypto";
 import { doInSpan } from "@/app/lib/logging";
 const { slug } = Tenant.current();
 
-async function deleteDelegateStatement({
+export async function deleteDelegateStatement({
   address,
   messageHash,
   stage,
@@ -19,12 +19,12 @@ async function deleteDelegateStatement({
   return prismaWeb2Client.delegateStatements
     .delete({
       where: {
-        address_dao_slug_stage: {
+        address_dao_slug_stage_message_hash: {
           address: address.toLowerCase(),
           dao_slug: slug,
           stage: stage,
+          message_hash: messageHash,
         },
-        message_hash: messageHash,
       },
     })
     .catch((error) => console.error(error));

--- a/src/app/api/common/delegateStatement/deleteDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/deleteDelegateStatement.ts
@@ -1,0 +1,89 @@
+import "server-only";
+
+import Tenant from "@/lib/tenant/tenant";
+import { stageStatus } from "@/app/lib/sharedEnums";
+import verifyMessage from "@/lib/serverVerifyMessage";
+import { createHash } from "crypto";
+import { doInSpan } from "@/app/lib/logging";
+const { slug } = Tenant.current();
+
+async function deleteDelegateStatement({
+  address,
+  messageHash,
+  stage,
+}: {
+  address: `0x${string}`;
+  messageHash: string;
+  stage: stageStatus;
+}) {
+  return prismaWeb2Client.delegateStatements
+    .delete({
+      where: {
+        address_dao_slug_stage: {
+          address: address.toLowerCase(),
+          dao_slug: slug,
+          stage: stage,
+        },
+        message_hash: messageHash,
+      },
+    })
+    .catch((error) => console.error(error));
+}
+
+/** This function is used to Delete an existing statement.
+ * @param ${address} address - The address of the delegate
+ * @param ${daoSlug} daoSlug - Slug of DAO site
+ * @param ${message} message - Textual message statement
+ * @param ${stage} stage - Stage of message, usually 'published'
+ * */
+export async function safeDeleteDelegateStatement({
+  address,
+  signature,
+  message,
+  stage,
+}: {
+  address: `0x${string}`;
+  signature: `0x${string}`;
+  message: string;
+  stage: stageStatus;
+}) {
+  // Kick out if invalid
+  const valid = await verifyMessage({
+    address,
+    message,
+    signature,
+  });
+  if (!valid) {
+    throw new Error("Invalid signature");
+  }
+
+  // create messageHash for db matches
+  const messageHash = createHash("sha256").update(message).digest("hex");
+
+  deleteDelegateStatement({ address, messageHash, stage });
+}
+
+export const safeDeleteDelegateStatementTracked = ({
+  address,
+  signature,
+  message,
+  stage,
+}: {
+  address: `0x${string}`;
+  signature: `0x${string}`;
+  message: string;
+  stage: stageStatus;
+}) => {
+  return doInSpan(
+    {
+      name: "deleteDelegateStatement",
+    },
+    () =>
+      safeDeleteDelegateStatement({
+        address: address,
+        signature: signature,
+        message: message,
+        stage: stage,
+      })
+  );
+};

--- a/src/app/api/common/delegateStatement/deleteDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/deleteDelegateStatement.ts
@@ -54,7 +54,7 @@ export async function safeDeleteDelegateStatement({
   // create messageHash for db matches
   const messageHash = createHash("sha256").update(message).digest("hex");
 
-  deleteDelegateStatement({ address, messageHash });
+  await deleteDelegateStatement({ address, messageHash });
 }
 
 export const safeDeleteDelegateStatementTracked = ({

--- a/src/app/api/common/delegateStatement/deleteDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/deleteDelegateStatement.ts
@@ -10,19 +10,16 @@ const { slug } = Tenant.current();
 export async function deleteDelegateStatement({
   address,
   messageHash,
-  stage,
 }: {
   address: `0x${string}`;
   messageHash: string;
-  stage: stageStatus;
 }) {
   return prismaWeb2Client.delegateStatements
     .delete({
       where: {
-        address_dao_slug_stage_message_hash: {
+        address_dao_slug_message_hash: {
           address: address.toLowerCase(),
           dao_slug: slug,
-          stage: stage,
           message_hash: messageHash,
         },
       },
@@ -34,18 +31,15 @@ export async function deleteDelegateStatement({
  * @param ${address} address - The address of the delegate
  * @param ${daoSlug} daoSlug - Slug of DAO site
  * @param ${message} message - Textual message statement
- * @param ${stage} stage - Stage of message, usually 'published'
  * */
 export async function safeDeleteDelegateStatement({
   address,
   signature,
   message,
-  stage,
 }: {
   address: `0x${string}`;
   signature: `0x${string}`;
   message: string;
-  stage: stageStatus;
 }) {
   // Kick out if invalid
   const valid = await verifyMessage({
@@ -60,19 +54,17 @@ export async function safeDeleteDelegateStatement({
   // create messageHash for db matches
   const messageHash = createHash("sha256").update(message).digest("hex");
 
-  deleteDelegateStatement({ address, messageHash, stage });
+  deleteDelegateStatement({ address, messageHash });
 }
 
 export const safeDeleteDelegateStatementTracked = ({
   address,
   signature,
   message,
-  stage,
 }: {
   address: `0x${string}`;
   signature: `0x${string}`;
   message: string;
-  stage: stageStatus;
 }) => {
   return doInSpan(
     {
@@ -83,7 +75,6 @@ export const safeDeleteDelegateStatementTracked = ({
         address: address,
         signature: signature,
         message: message,
-        stage: stage,
       })
   );
 };

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -17,7 +17,7 @@ export const getDelegateStatement = (
     () =>
       getDelegateStatementForAddress({
         address: addressOrENSName,
-        stage: stageStatus,
+        stage: stage,
       })
   );
 };

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -63,7 +63,7 @@ export const fetchDelegateStatement = cache(getDelegateStatement);
 
 export const getDelegateStatements = (
   addressOrENSName: string,
-  stage: stageStatus
+  stage?: stageStatus
 ) => {
   return doInSpan(
     {
@@ -85,19 +85,30 @@ export async function getDelegateStatementsForAddress({
   stage,
 }: {
   address: string;
-  stage: stageStatus;
+  stage?: stageStatus;
 }) {
   const { slug } = Tenant.current();
 
-  return prismaWeb2Client.delegateStatements
-    .findMany({
-      where: {
-        address: address.toLowerCase(),
-        dao_slug: slug,
-        stage: stage,
-      },
-    })
-    .catch((error) => console.error(error));
+  if (!stage) {
+    return prismaWeb2Client.delegateStatements
+      .findMany({
+        where: {
+          address: address.toLowerCase(),
+          dao_slug: slug,
+        },
+      })
+      .catch((error) => console.error(error));
+  } else {
+    return prismaWeb2Client.delegateStatements
+      .findMany({
+        where: {
+          address: address.toLowerCase(),
+          dao_slug: slug,
+          stage: stage,
+        },
+      })
+      .catch((error) => console.error(error));
+  }
 }
 
 export const fetchDelegateStatements = cache(getDelegateStatements);

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -56,7 +56,7 @@ export async function getDelegateStatementForAddress({
     .catch((error) => console.error(error));
 }
 
-// export const fetchDelegateStatement = cache(getDelegateStatement);
+export const fetchDelegateStatement = cache(getDelegateStatement);
 
 // This section will handle fetching multiple delegates as drafts become permissible.
 // The above will remain for now to maintain reverse compatibility, but may be depricated in the future.
@@ -100,4 +100,4 @@ export async function getDelegateStatementsForAddress({
     .catch((error) => console.error(error));
 }
 
-// export const fetchDelegateStatements = cache(getDelegateStatements);
+export const fetchDelegateStatements = cache(getDelegateStatements);

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -61,7 +61,7 @@ export const getDelegateStatements = (
     () =>
       getDelegateStatementsForAddress({
         address: addressOrENSName,
-        stage: stageStatus,
+        stage: stage,
       })
   );
 };

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -45,7 +45,7 @@ async function getDelegateStatementForAddress({
     .catch((error) => console.error(error));
 }
 
-export const fetchDelegateStatement = cache(getDelegateStatement);
+// export const fetchDelegateStatement = cache(getDelegateStatement);
 
 // This section will handle fetching multiple delegates as drafts become permissible.
 // The above will remain for now to maintain reverse compatibility, but may be depricated in the future.
@@ -69,7 +69,7 @@ export const getDelegateStatements = (
 /*
   Gets multiple delegate statements from Postgres
 */
-async function getDelegateStatementsForAddress({
+export async function getDelegateStatementsForAddress({
   address,
   stage,
 }: {
@@ -89,4 +89,4 @@ async function getDelegateStatementsForAddress({
     .catch((error) => console.error(error));
 }
 
-export const fetchDelegateStatements = cache(getDelegateStatements);
+// export const fetchDelegateStatements = cache(getDelegateStatements);

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -6,6 +6,7 @@ import Tenant from "@/lib/tenant/tenant";
 import { stageStatus } from "@/app/lib/sharedEnums";
 import { doInSpan } from "@/app/lib/logging";
 import { createHash } from "crypto";
+import { MessageOrMessageHash } from "@/app/api/common/delegateStatement/delegateStatement";
 
 export const getDelegateStatement = (
   addressOrENSName: string,
@@ -22,10 +23,6 @@ export const getDelegateStatement = (
       })
   );
 };
-
-type MessageOrMessageHash =
-  | { type: "MESSAGE"; value: string }
-  | { type: "MESSAGE_HASH"; value: string };
 
 /*
   Get a single delegate statement from Postgres or DynamoDB if not found

--- a/src/app/api/common/delegateStatement/getDelegateStatement.ts
+++ b/src/app/api/common/delegateStatement/getDelegateStatement.ts
@@ -8,6 +8,40 @@ import { doInSpan } from "@/app/lib/logging";
 import { createHash } from "crypto";
 import { MessageOrMessageHash } from "@/app/api/common/delegateStatement/delegateStatement";
 
+export const getLatestPublishedDelegateStatementInSpan = (
+  addressOrENSName: string
+) => {
+  return doInSpan(
+    {
+      name: "getLatestPublishedDelegateStatement",
+    },
+    () => getLatestPublishedDelegateStatement(addressOrENSName)
+  );
+};
+export const getLatestPublishedDelegateStatement = async (
+  addressOrENSName: string
+) => {
+  const { slug } = Tenant.current();
+
+  try {
+    return prismaWeb2Client.delegateStatements.findFirst({
+      where: {
+        address: addressOrENSName.toLowerCase(),
+        dao_slug: slug,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+  } catch (error) {
+    return console.error(error);
+  }
+};
+
+export const fetchLatestPublishedDelegateStatement = cache(
+  cache(getLatestPublishedDelegateStatementInSpan)
+);
+
 export const getDelegateStatement = (
   addressOrENSName: string,
   messageOrMessageHash: MessageOrMessageHash

--- a/src/app/api/common/delegates/delegate.d.ts
+++ b/src/app/api/common/delegates/delegate.d.ts
@@ -1,5 +1,6 @@
 import { DelegateStatement } from "@/app/api/delegateStatement/delegateStatement";
 import { Prisma } from "@prisma/client";
+import { stageStatus } from "@/app/lib/sharedEnums";
 
 export type Delegate = {
   address: string;
@@ -60,6 +61,8 @@ type DelegateStatement = {
     wants_proposal_ending_soon_email: "prompt" | "prompted" | true | false;
     last_updated_at: Date;
   };
+  stage: stageStatus;
+  message_hash: string | null;
 };
 
 export type DelegateStats = {

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -181,6 +181,7 @@ async function getDelegates({
           select address
           from agora.delegate_statements
           where dao_slug='${slug}'
+          and status = 'published'
         ),
         filtered_delegates as (
           select d.*

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -181,7 +181,7 @@ async function getDelegates({
           select address
           from agora.delegate_statements
           where dao_slug='${slug}'
---           and status = 'published'
+--           and status = 'published
         ),
         filtered_delegates as (
           select d.*

--- a/src/app/api/common/delegates/getDelegates.ts
+++ b/src/app/api/common/delegates/getDelegates.ts
@@ -181,7 +181,7 @@ async function getDelegates({
           select address
           from agora.delegate_statements
           where dao_slug='${slug}'
-          and status = 'published'
+--           and status = 'published'
         ),
         filtered_delegates as (
           select d.*

--- a/src/app/delegates/actions.ts
+++ b/src/app/delegates/actions.ts
@@ -16,6 +16,7 @@ import {
 import {
   fetchDelegateStatement as apiFetchDelegateStatement,
   fetchDelegateStatements as apiFetchDelegateStatements,
+  fetchLatestPublishedDelegateStatement as apiFetchLatestPublishedDelegateStatement,
 } from "@/app/api/common/delegateStatement/getDelegateStatement";
 import {
   fetchAllDelegatorsInChains,
@@ -28,6 +29,7 @@ import Tenant from "@/lib/tenant/tenant";
 import { PaginationParams } from "../lib/pagination";
 import { fetchUpdateNotificationPreferencesForAddress } from "@/app/api/common/notifications/updateNotificationPreferencesForAddress";
 import { stageStatus } from "@/app/lib/sharedEnums";
+import { MessageOrMessageHash } from "@/app/api/common/delegateStatement/delegateStatement";
 
 export const fetchDelegate = async (address: string) => {
   try {
@@ -63,8 +65,8 @@ export const fetchVoterStats = unstable_cache(
 );
 
 export const fetchDelegateStatement = unstable_cache(
-  async (address: string, stage: stageStatus) => {
-    return apiFetchDelegateStatement(address, stage);
+  async (address: string, messageOrMessageHash: MessageOrMessageHash) => {
+    return apiFetchDelegateStatement(address, messageOrMessageHash);
   },
   ["delegateStatement"],
   {
@@ -76,7 +78,7 @@ export const fetchDelegateStatement = unstable_cache(
 );
 
 export const fetchDelegateStatements = unstable_cache(
-  async (address: string, stage: stageStatus) => {
+  async (address: string, stage?: stageStatus) => {
     return apiFetchDelegateStatements(address, stage);
   },
   ["delegateStatements"],
@@ -85,6 +87,17 @@ export const fetchDelegateStatements = unstable_cache(
     // often and invalidated with every delegate statement update
     revalidate: 600, // 10 minute cache
     tags: ["delegateStatements"],
+  }
+);
+
+export const fetchLatestPublishedDelegateStatement = unstable_cache(
+  async (addressOrENSName: string) => {
+    return apiFetchLatestPublishedDelegateStatement(addressOrENSName);
+  },
+  ["latestPublishedDelegateStatement"],
+  {
+    revalidate: 600, // 10 minute cache
+    tags: ["latestPublishedDelegateStatement"],
   }
 );
 

--- a/src/components/DelegateStatement/CurrentDelegateStatement.tsx
+++ b/src/components/DelegateStatement/CurrentDelegateStatement.tsx
@@ -2,10 +2,7 @@
 
 import { useAccount } from "wagmi";
 import { useEffect, useState } from "react";
-import {
-  fetchDelegateStatement,
-  fetchDelegateStatements,
-} from "@/app/delegates/actions";
+import { fetchDelegateStatement } from "@/app/delegates/actions";
 import ResourceNotFound from "@/components/shared/ResourceNotFound/ResourceNotFound";
 import { DelegateStatement } from "@/app/api/common/delegateStatement/delegateStatement";
 import * as z from "zod";
@@ -197,19 +194,9 @@ export default function CurrentDelegateStatement() {
       setLoading(false);
     }
 
-    async function _getDelegateStatements() {
-      const _stmnts = await fetchDelegateStatements(
-        address as string,
-        stageStatus.PUBLISHED
-      ).catch((error) => console.error(error));
-
-      console.log(`STATEMENTS: ${_stmnts}`);
-    }
-
     if (address) {
       setLoading(true);
       _getDelegateStatement();
-      _getDelegateStatements();
     }
   }, [address, reset]);
 


### PR DESCRIPTION
---

### Description

This pull request includes improvements to the delegate statments. We added stage (can be either draft or published) for the sue with safe multisigs. There are also new helper functions for retreiving single, multiple, or latest delegate statements. The new functinos have unit tests associated with them mostly ccentered around their ability to miniuplate the DB, some mocking was done to mimic function calls internally. 

- Added caching for retrieving the latest delegate statement.
- Introduced utility functions for fetching published delegate statements.
- Enhanced test coverage to validate delegate statement retrieval and deletion.
- Improved error handling for Prisma calls and database interactions.
- Refactored schema to include stage and message_hash where applicable.
- Updated test cases to reflect changes in schema and logic.


---