### PR TITLE
garrett/ENG-1632-passed-proposal-should-not-be-cancellable

### DIFF
--- a/src/app/proposals/components/ProposalStateAdmin.tsx
+++ b/src/app/proposals/components/ProposalStateAdmin.tsx
@@ -77,6 +77,8 @@ export const ProposalStateAdmin = ({ proposal }: Props) => {
             proposal.proposalType === "STANDARD"
           ) {
             return "This proposal is now passed and can be queued for execution.";
+          } else if (proposal.proposalType === "OPTIMISTIC") {
+            return "This proposal has been optimistically passed.";
           }
           return "This proposal can still be cancelled by the admin.";
         }

--- a/src/app/proposals/components/ProposalStateAdmin.tsx
+++ b/src/app/proposals/components/ProposalStateAdmin.tsx
@@ -177,6 +177,8 @@ const successActions = ({ proposal, namespace }: ActionProps) => {
             <AgoraOptimismGovQueue proposal={proposal} />
           </div>
         );
+      } else if (proposal.proposalType === "OPTIMISTIC") {
+        return null;
       } else {
         return <AgoraOptimismGovCancel proposal={proposal} />;
       }

--- a/src/app/proposals/components/ProposalStateAdmin.tsx
+++ b/src/app/proposals/components/ProposalStateAdmin.tsx
@@ -80,6 +80,8 @@ export const ProposalStateAdmin = ({ proposal }: Props) => {
           }
           return "This proposal can still be cancelled by the admin.";
         }
+        // If succeeded but not Optimism, then proceed to queue
+        return "This proposal is now passed and can be queued for execution.";
 
       case PROPOSAL_STATUS.QUEUED:
         return "This proposal can be executed after the timelock passes, or cancelled by the admin.";

--- a/src/app/proposals/components/ProposalStateAdmin.tsx
+++ b/src/app/proposals/components/ProposalStateAdmin.tsx
@@ -78,7 +78,8 @@ export const ProposalStateAdmin = ({ proposal }: Props) => {
           ) {
             return "This proposal is now passed and can be queued for execution.";
           } else if (proposal.proposalType === "OPTIMISTIC") {
-            return "This proposal has been optimistically passed.";
+            // No banner for Optimistic proposals.
+            return null;
           }
           return "This proposal can still be cancelled by the admin.";
         }
@@ -124,7 +125,7 @@ export const ProposalStateAdmin = ({ proposal }: Props) => {
 
   const action = renderAction();
 
-  if (action) {
+  if (action && renderLabel()) {
     return (
       <div className="flex flex-row justify-between items-center align-middle border border-line p-2 mb-6 rounded-md bg-neutral text-sm text-primary">
         <div className="ml-4">{renderLabel()}</div>

--- a/src/app/proposals/components/ProposalStateAdmin.tsx
+++ b/src/app/proposals/components/ProposalStateAdmin.tsx
@@ -87,6 +87,8 @@ export const ProposalStateAdmin = ({ proposal }: Props) => {
 
       case PROPOSAL_STATUS.QUEUED:
         return "This proposal can be executed after the timelock passes, or cancelled by the admin.";
+      default:
+        return null;
     }
   };
 


### PR DESCRIPTION
Added case for Optimistic proposal type. This could also be null but I'd rather have the feedback to indicate the proposal status.

added an edge case that will catch non-optimistic succeeded proposals. 

defaults the render label to null. used if one of the PROPOSAL_STATUS states is passed that has not been explicitly defined. 

