### PR TITLE
ENG-1832: reveal X more proposed transaction options does not work

### DIFF
--- a/src/components/Proposals/ProposalPage/ApprovedTransactions/ApprovedTransactions.jsx
+++ b/src/components/Proposals/ProposalPage/ApprovedTransactions/ApprovedTransactions.jsx
@@ -49,12 +49,12 @@ export default function ApprovedTransactions({
           {proposalData.options.slice(0, displayedOptions).map((option, i) => {
             return (
               <div key={i}>
-                {proposalType === "APPROVAL" ||
-                  (proposalType === "HYBRID_APPROVAL" && (
-                    <p className="font-mono text-xs font-medium leading-4 text-tertiary">
-                      {"//"} {option.description}
-                    </p>
-                  ))}
+                {(proposalType === "APPROVAL" ||
+                  proposalType === "HYBRID_APPROVAL") && (
+                  <p className="font-mono text-xs font-medium leading-4 text-tertiary">
+                    {"//"} {option.description}
+                  </p>
+                )}
                 {option.values.length > 0 &&
                   option.targets.map((t, i) => {
                     const valueETH =


### PR DESCRIPTION
## Problem

- The "Reveal X more options" button on approval proposals did not display additional options when clicked.
- The toggle logic and state were working, but the UI did not update to show more options.

## Changes

- Fixed the conditional rendering in `ApprovedTransactions.jsx` by replacing an incorrect use of the `||` operator with the correct `&&` pattern for React.
- Now, option descriptions are rendered for both `APPROVAL` and `HYBRID_APPROVAL` proposal types when toggling options.

## Testing

- Manually verified that clicking "Reveal X more options" now displays all options as expected.
- Ran Prettier and ESLint to ensure code style and linting pass.