### PR TITLE
feat: add Optimism draft sharing via ?share=AuthorAddress parameter

### DIFF
--- a/src/app/proposals/draft/[id]/components/OwnerOnly.tsx
+++ b/src/app/proposals/draft/[id]/components/OwnerOnly.tsx
@@ -3,7 +3,7 @@
 import { useAccount } from "wagmi";
 import { useSearchParams } from "next/navigation";
 import Tenant from "@/lib/tenant/tenant";
-import { TENANT_NAMESPACES } from "@/lib/constants";
+import { PLMConfig } from "@/app/proposals/draft/types";
 
 const OnlyOwner = ({
   ownerAddresses,
@@ -15,7 +15,9 @@ const OnlyOwner = ({
   const { address, isConnecting, isReconnecting } = useAccount();
   const searchParams = useSearchParams();
   const shareParam = searchParams?.get("share");
-  const { namespace } = Tenant.current();
+  const { ui } = Tenant.current();
+  const proposalLifecycleToggle = ui.toggle("proposal-lifecycle");
+  const config = proposalLifecycleToggle?.config as PLMConfig;
 
   // causing jitter when loading... need to figure out a better long term solution
   //   if (isConnecting || isReconnecting) {
@@ -32,9 +34,9 @@ const OnlyOwner = ({
   //     );
   //   }
 
-  // Check if sharing via author address - only for Optimism tenant
+  // Check if sharing via author address - configurable per tenant
   if (
-    namespace === TENANT_NAMESPACES.OPTIMISM &&
+    config?.allowDraftSharing &&
     shareParam &&
     ownerAddresses.some(
       (owner) => owner.toLowerCase() === shareParam.toLowerCase()

--- a/src/app/proposals/draft/types.ts
+++ b/src/app/proposals/draft/types.ts
@@ -212,6 +212,8 @@ export type PLMConfig = {
   protocolLevelCreateProposalButtonCheck?: boolean;
   // The addresses that can create offchain proposals
   offchainProposalCreator?: string[];
+  // Temporary: allow public draft sharing via ?share=AuthorAddress
+  allowDraftSharing?: boolean;
 };
 
 export type BaseProposal = ProposalDraft & {

--- a/src/lib/tenant/configs/ui/optimism.ts
+++ b/src/lib/tenant/configs/ui/optimism.ts
@@ -239,6 +239,8 @@ export const optimismTenantUIConfig = new TenantUI({
       name: "proposal-lifecycle",
       enabled: true,
       config: {
+        // Temporary: allow public draft sharing via ?share=AuthorAddress
+        allowDraftSharing: true,
         offchainProposalCreator: [
           "0x648BFC4dB7e43e799a84d0f607aF0b4298F932DB",
           "0xa7f8Ad892F3E6f25BB042c8AD7a220e74aCebAd8",


### PR DESCRIPTION
## Configurable Draft Sharing

Adds configurable public sharing for draft proposals via `?share=AuthorAddress` query parameter. When `allowDraftSharing: true` is set in tenant config and the share parameter matches the proposal author's address, the draft becomes publicly accessible without login. Currently enabled for **Optimism only**, but easily extensible to other tenants.

**Example:** `https://vote.optimism.io/proposals/draft/123?share=0x648BFC4dB7e43e799a84d0f607aF0b4298F932DB`