### PR TITLE
fix(mobile): ENG-1829 / auto-scroll to “Statement Saved” banner after saving delegate statement

### DIFF
--- a/src/components/Delegates/DelegateStatement/DelegateStatementContainer.tsx
+++ b/src/components/Delegates/DelegateStatement/DelegateStatementContainer.tsx
@@ -5,7 +5,7 @@ import { useAccount } from "wagmi";
 import DelegateStatement from "./DelegateStatement";
 import { Delegate } from "@/app/api/common/delegates/delegate";
 import { useDelegateStatementStore } from "@/stores/delegateStatement";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface Props {
   delegate: Delegate;
@@ -25,6 +25,26 @@ export default function DelegateStatementContainer({ delegate }: Props) {
     delegate?.statement?.payload as { delegateStatement: string }
   )?.delegateStatement;
 
+  const successBannerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!showSuccessMessage) return;
+    const banner = successBannerRef.current;
+    if (!banner) return;
+    const isMobileViewport =
+      typeof window !== "undefined" &&
+      window.matchMedia &&
+      window.matchMedia("(max-width: 768px)").matches;
+    if (!isMobileViewport) return;
+
+    const bannerTop = banner.getBoundingClientRect().top + window.scrollY;
+    const offset = 80;
+    window.scrollTo({
+      top: Math.max(0, bannerTop - offset),
+      behavior: "smooth",
+    });
+  }, [showSuccessMessage]);
+
   useEffect(() => {
     const handleBeforeUnload = () => {
       setSaveSuccess(false);
@@ -41,6 +61,7 @@ export default function DelegateStatementContainer({ delegate }: Props) {
         <div
           className="bg-green-100 border-l-4 border-green-500 text-green-700 p-4"
           role="alert"
+          ref={successBannerRef}
         >
           <p className="font-bold">Statement Saved</p>
           <p>Nice! Thank you for telling the community what you believe in.</p>


### PR DESCRIPTION
## Description
Fixes ENG-1829, on mobile, after creating/editing a delegate statement the view now auto-scrolls to the “Statement Saved” banner. Implemented a ref-driven effect that runs only on small viewports (via matchMedia) and calls window.scrollTo with a conservative 80px offset to avoid the top navigation; desktop behavior is unchanged. 

Manually verified on iOS Safari and Android Chrome by saving a statement and confirming the banner is visible upon redirect. 

I used this approach instead of router.push cuz is better for UX.