### PR TITLE
fix: ENG-1867 / HybridStandardProposalStatus – make tally success bar full width

### DIFF
--- a/src/components/Proposals/Proposal/HybridStandardProposalStatus.tsx
+++ b/src/components/Proposals/Proposal/HybridStandardProposalStatus.tsx
@@ -20,7 +20,7 @@ export default function HybridStandardProposalStatus({
       </div>
 
       {totalForVotesPercentage > 0 && (
-        <div className="flex w-52 h-1 bg-wash rounded-full">
+        <div className="flex w-full h-1 bg-wash rounded-full">
           <div
             className=" bg-positive h-1 rounded-l-full"
             style={{ width: `${totalForVotesPercentage}%` }}
@@ -37,7 +37,7 @@ export default function HybridStandardProposalStatus({
       )}
 
       {totalForVotesPercentage === 0 && (
-        <div className="flex w-52 h-1 bg-wash rounded-full">
+        <div className="flex w-full h-1 bg-wash rounded-full">
           <div className=" bg-tertiary h-1" style={{ width: `100%` }}></div>
         </div>
       )}


### PR DESCRIPTION
## Description
Fix tally success bar for Joint House proposals to use full container width by updating HybridStandardProposalStatus from w-52 to w-full.