### PR TITLE
feat: ENS reverse lookup in proposal

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,1 +1,19 @@
 import "@testing-library/jest-dom/vitest";
+
+// JSDOM doesn't implement IntersectionObserver. Mock it for components that lazily
+// observe visibility (e.g., ENSName) so unit tests don't throw at mount time.
+class MockIntersectionObserver {
+  constructor(
+    _callback?: IntersectionObserverCallback,
+    _options?: IntersectionObserverInit
+  ) {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+(global as any).IntersectionObserver =
+  (global as any).IntersectionObserver || MockIntersectionObserver;

--- a/src/components/shared/ENSName.tsx
+++ b/src/components/shared/ENSName.tsx
@@ -1,34 +1,71 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useEnsName } from "wagmi";
 import { truncateAddress } from "@/app/lib/utils/text";
 
 interface ENSNameProps {
   address: string;
   truncate?: boolean;
+  // When true, defer ENS reverse lookup until the component is visible
+  lazy?: boolean;
 }
 
-// This component will display the ENS name for a given address
-export default function ENSName({ address, truncate = true }: ENSNameProps) {
+// Displays ENS reverse record for an address with lazy-loading to limit lookups.
+export default function ENSName({
+  address,
+  truncate = true,
+  lazy = true,
+}: ENSNameProps) {
   const [ensName, setEnsName] = useState(
     truncate ? truncateAddress(address || "") : address || ""
   );
+  const [isInView, setIsInView] = useState(!lazy);
+  const ref = useRef<HTMLSpanElement | null>(null);
+
+  // Observe visibility to enable the ENS query lazily
+  useEffect(() => {
+    if (!lazy) return;
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry && entry.isIntersecting) {
+          setIsInView(true);
+          observer.disconnect();
+        }
+      },
+      { root: null, rootMargin: "0px", threshold: 0 }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [lazy]);
 
   const { data } = useEnsName({
     chainId: 1,
     address: address as `0x${string}`,
+    query: {
+      enabled: isInView,
+      staleTime: 1000 * 60 * 60 * 24, // cache for a day
+    },
   });
 
   useEffect(() => {
     if (data) {
-      setEnsName(data); // Set ENS name if available
+      setEnsName(data);
     } else {
-      setEnsName(truncate ? truncateAddress(address) : address); // Fallback
+      setEnsName(truncate ? truncateAddress(address) : address);
     }
   }, [data, address, truncate]);
 
-  return truncate
-    ? ensName || `${address.slice(0, 6)}...${address.slice(-4)}`
-    : ensName || address;
+  return (
+    <span ref={ref}>
+      {truncate
+        ? ensName || `${address.slice(0, 6)}...${address.slice(-4)}`
+        : ensName || address}
+    </span>
+  );
 }


### PR DESCRIPTION
## Summary
- Added IntersectionObserver-based lazy loading (enabled by default).
- Wired useEnsName with query.enabled to defer network calls until in-view.
- Keeps a truncated address as the initial value; swaps to ENS if found.
- Returns a <span> element with the resolved text.