### PR TITLE
Prevent overflow of user profile name text on mobile devices

### DIFF
--- a/src/components/Delegates/DelegateCard/DelegateProfileImage.tsx
+++ b/src/components/Delegates/DelegateCard/DelegateProfileImage.tsx
@@ -96,7 +96,12 @@ export function DelegateProfileImage({
 
       <div className="flex flex-col min-w-0">
         <div className="text-primary flex flex-row gap-1 font-medium items-center min-w-0">
-          <div className={cn("min-w-0 max-w-full flex-1", truncateText && "truncate")}>
+          <div
+            className={cn(
+              "min-w-0 max-w-full flex-1",
+              truncateText && "truncate"
+            )}
+          >
             {copyable ? (
               <CopyableHumanAddress address={address} />
             ) : (


### PR DESCRIPTION
Updated the styling to ensure user profile names do not overflow on smaller screens. This change improves the display and usability of the user interface on mobile devices.