### PR TITLE
fix(scope): Show friendly scopes rejection message on submit

### DIFF
--- a/src/app/proposals/draft/utils/stages.ts
+++ b/src/app/proposals/draft/utils/stages.ts
@@ -125,5 +125,34 @@ export const parseError = (error: any) => {
   if (error.message.includes("one live proposal per proposer")) {
     return "You have an outstanding proposal that has not yet completed. Please wait for it to be processed before submitting or sponsoring a new one. ";
   }
+  const supportsScopes = Boolean(Tenant.current().contracts.supportScopes);
+  const msg = String(error?.message || "").toLowerCase();
+  const cause = String(error?.cause?.message || "").toLowerCase();
+
+  const combined = `${msg}\n${cause}`;
+
+  const signaturesToFlag = ["0x31f837ca"];
+
+  const indicativePhrases = [
+    "unable to decode signature",
+    "decodeerrorresult",
+    "invalid proposal type",
+    "scoped",
+  ];
+
+  const mentionsSignature = signaturesToFlag.some((sig) =>
+    combined.includes(sig)
+  );
+  const mentionsIndicative = indicativePhrases.some((p) =>
+    combined.includes(p)
+  );
+
+  if (supportsScopes && (mentionsSignature || mentionsIndicative)) {
+    return (
+      "This action is blocked by scopes. Please contact the DAO Admin or Manager " +
+      "to refine proposal types and scope definitions."
+    );
+  }
+
   return error.message;
 };

--- a/src/app/proposals/sponsor/components/ApprovalProposalAction.tsx
+++ b/src/app/proposals/sponsor/components/ApprovalProposalAction.tsx
@@ -10,6 +10,7 @@ import { onSubmitAction as sponsorDraftProposal } from "../../draft/actions/spon
 import { ApprovalProposal, ProposalScope } from "@/app/proposals/draft/types";
 import { trackEvent } from "@/lib/analytics";
 import { ANALYTICS_EVENT_NAMES } from "@/lib/types.d";
+import { parseError } from "../../draft/utils/stages";
 
 const ApprovalProposalAction = ({
   draftProposal,
@@ -86,8 +87,8 @@ const ApprovalProposalAction = ({
         Submit proposal
       </UpdatedButton>
       {onPrepareError && (
-        <div className="p-4 border border-line bg-wash rounded mt-4 text-sm text-tertiary break-words hyphens-auto">
-          {error?.message}
+        <div className="p-4 border border-negative bg-negative/10 rounded mt-4 text-sm text-negative break-words hyphens-auto">
+          {parseError(error)}
         </div>
       )}
     </>

--- a/src/app/proposals/sponsor/components/OptimisticProposalAction.tsx
+++ b/src/app/proposals/sponsor/components/OptimisticProposalAction.tsx
@@ -13,6 +13,7 @@ import { getInputData } from "../../draft/utils/getInputData";
 import { onSubmitAction as sponsorDraftProposal } from "../../draft/actions/sponsorDraftProposal";
 import { trackEvent } from "@/lib/analytics";
 import { ANALYTICS_EVENT_NAMES } from "@/lib/types.d";
+import { parseError } from "../../draft/utils/stages";
 
 const OptimisticProposalAction = ({
   draftProposal,
@@ -88,8 +89,8 @@ const OptimisticProposalAction = ({
         Submit proposal
       </UpdatedButton>
       {onPrepareError && (
-        <div className="p-4 border border-line bg-wash rounded mt-4 text-sm text-tertiary break-words hyphens-auto">
-          {error?.message}
+        <div className="p-4 border border-negative bg-negative/10 rounded mt-4 text-sm text-negative break-words hyphens-auto">
+          {parseError(error)}
         </div>
       )}
     </>


### PR DESCRIPTION
Map unknown revert signatures (e.g., 0x31f837ca) and decode errors to a human-friendly scopes message in parseError Gate by Tenant.current().contracts.supportScopes to avoid false positives Surface the message in Approval and Optimistic submit UIs (use parseError); Basic already used it No behavior change for tenants without scopes.