### PR TITLE
Fix XAI SIWE login 401 by adding Arbitrum chains to getChainById

### DIFF
--- a/src/lib/viem.ts
+++ b/src/lib/viem.ts
@@ -6,6 +6,8 @@ import {
   http,
 } from "viem";
 import {
+  arbitrum,
+  arbitrumSepolia,
   base,
   bsc,
   cyber,
@@ -113,6 +115,10 @@ export const getChainById = (chainId: number): Chain | null => {
       return linea;
     case lineaSepolia.id:
       return lineaSepolia;
+    case arbitrum.id:
+      return arbitrum;
+    case arbitrumSepolia.id:
+      return arbitrumSepolia;
     case base.id:
       return base;
     case bsc.id:


### PR DESCRIPTION
getChainById was missing arbitrum and arbitrumSepolia, causing signature verification to fail for XAI tenants (which use Arbitrum) because getVerificationPublicClient returned null for chain 42161.