### PR TITLE
refactor(tenant): centralise CSS-var mapping and remove dead customization keys

### DIFF
--- a/src/app/custom.css/route.ts
+++ b/src/app/custom.css/route.ts
@@ -1,73 +1,13 @@
 import Tenant from "@/lib/tenant/tenant";
+import { buildTenantCssVars } from "@/lib/tenant/tenantCssVars";
 
 export async function GET() {
   const { ui } = Tenant.current();
-
-  const defaults = {
-    primary: "23 23 23",
-    secondary: "64 64 64",
-    tertiary: "115 115 115",
-    neutral: "255 255 255",
-    wash: "250 250 250",
-    line: "229 229 229",
-    positive: "0 153 43",
-    negative: "197 47 0",
-    brandPrimary: "23 23 23",
-    brandSecondary: "255 255 255",
-    font: "var(--font-inter)",
-  };
-
-  const primary = ui?.customization?.primary || defaults.primary;
-  const secondary = ui?.customization?.secondary || defaults.secondary;
-  const tertiary = ui?.customization?.tertiary || defaults.tertiary;
-  const neutral = ui?.customization?.neutral || defaults.neutral;
-  const wash = ui?.customization?.wash || defaults.wash;
-  const line = ui?.customization?.line || defaults.line;
-  const positive = ui?.customization?.positive || defaults.positive;
-  const negative = ui?.customization?.negative || defaults.negative;
-  const brandPrimary = ui?.customization?.brandPrimary || defaults.brandPrimary;
-  const brandSecondary =
-    ui?.customization?.brandSecondary || defaults.brandSecondary;
-
-  const style = {
-    "--primary": primary,
-    "--secondary": secondary,
-    "--tertiary": tertiary,
-    "--neutral": neutral,
-    "--wash": wash,
-    "--line": line,
-    "--positive": positive,
-    "--negative": negative,
-    "--brand-primary": brandPrimary,
-    "--brand-secondary": brandSecondary,
-    "--info-section-background":
-      ui?.customization?.infoSectionBackground || neutral,
-    "--header-background": ui?.customization?.headerBackground || wash,
-    "--info-tab-background": ui?.customization?.infoTabBackground || neutral,
-    "--button-background": ui?.customization?.buttonBackground || primary,
-    "--card-background": ui?.customization?.cardBackground || "255 255 255",
-    "--card-border": ui?.customization?.cardBorder || line,
-    "--card-background-light":
-      ui?.customization?.cardBackground || "255 255 255",
-    "--card-background-dark": ui?.customization?.cardBackground || "30 26 47",
-    "--hover-background-light":
-      ui?.customization?.hoverBackground || "249 250 251",
-    "--hover-background-dark": ui?.customization?.hoverBackground || "42 35 56",
-    "--modal-background-dark": ui?.customization?.cardBackground || "30 26 47",
-    "--input-background-dark": ui?.customization?.cardBackground || "42 35 56",
-    "--button-primary-dark": ui?.customization?.buttonBackground || "89 75 122",
-    "--button-secondary-dark":
-      ui?.customization?.buttonBackground || "25 16 62",
-    "--hover-background": ui?.customization?.hoverBackground || tertiary,
-    "--text-secondary": ui?.customization?.textSecondary || secondary,
-    "--footer-background": ui?.customization?.footerBackground || neutral,
-    "--inner-footer-background":
-      ui?.customization?.innerFooterBackground || wash,
-  } as React.CSSProperties;
+  const vars = buildTenantCssVars(ui?.customization);
 
   const root = `
     :root {
-      ${Object.entries(style)
+      ${Object.entries(vars)
         .map(([key, value]) => `${key}: rgb(${value});`)
         .join("\n")}
     }

--- a/src/app/info/components/InfoAbout.tsx
+++ b/src/app/info/components/InfoAbout.tsx
@@ -62,14 +62,7 @@ const InfoAbout = () => {
     return <div>Page metadata not defined</div>;
   }
 
-  const tabs = ui.customization?.customInfoTabs
-    ? ui.customization.customInfoTabs.map((tab, index) => ({
-        ...tab,
-        icon: defaultTabs[index]?.icon,
-      }))
-    : defaultTabs;
-
-  const activeTabs = page.tabs || tabs;
+  const activeTabs = page.tabs || defaultTabs;
   const sectionTitle = page.sectionTitle || "Getting started";
 
   return (
@@ -94,9 +87,7 @@ const InfoAbout = () => {
           <div
             className={`${ui.customization?.customInfoLayout ? "sm:w-auto sm:ml-2" : ui.toggle("hide-hero-image")?.enabled ? "w-full" : "sm:w-1/2"}`}
           >
-            <div
-              className={`${ui.customization?.customTextContainer ? ui.customization.customTextContainer : ""}`}
-            >
+            <div>
               <h3 className="text-lg font-bold text-primary">
                 {ui.customization?.customAboutSubtitle || "About " + brandName}
               </h3>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,10 @@ import { fetchMetrics } from "@/app/api/common/metrics/getMetrics";
 import DAOMetricsHeader from "@/components/Metrics/DAOMetricsHeader";
 import Tenant from "@/lib/tenant/tenant";
 import { fontMapper, inter } from "@/styles/fonts";
+import {
+  buildTenantCssVars,
+  CSS_VAR_DEFAULTS,
+} from "@/lib/tenant/tenantCssVars";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { ForumPermissionsProvider } from "@/contexts/ForumPermissionsContext";
@@ -22,21 +26,6 @@ BigInt.prototype.toJSON = function (): string {
   return this.toString();
 };
 
-const defaults = {
-  primary: "23 23 23",
-  secondary: "64 64 64",
-  tertiary: "115 115 115",
-  neutral: "255 255 255",
-  wash: "250 250 250",
-  line: "229 229 229",
-  positive: "0 153 43",
-  negative: "197 47 0",
-  brandPrimary: "23 23 23",
-  brandSecondary: "255 255 255",
-  font: "var(--font-inter)",
-  letterSpacing: "0",
-};
-
 const defaultFavicons = {
   "apple-touch-icon": "/favicon/apple-touch-icon.png",
   icon32x32: "/favicon/favicon-32x32.png",
@@ -52,19 +41,8 @@ export default async function RootLayout({
   const { ui } = Tenant.current();
   const miradorWebApiKey = process.env.MIRADOR_WEB_API_KEY;
 
-  const primary = ui?.customization?.primary || defaults.primary;
-  const secondary = ui?.customization?.secondary || defaults.secondary;
-  const tertiary = ui?.customization?.tertiary || defaults.tertiary;
-  const neutral = ui?.customization?.neutral || defaults.neutral;
-  const wash = ui?.customization?.wash || defaults.wash;
-  const line = ui?.customization?.line || defaults.line;
-  const positive = ui?.customization?.positive || defaults.positive;
-  const negative = ui?.customization?.negative || defaults.negative;
-  const brandPrimary = ui?.customization?.brandPrimary || defaults.brandPrimary;
-  const brandSecondary =
-    ui?.customization?.brandSecondary || defaults.brandSecondary;
   const letterSpacing =
-    ui?.customization?.letterSpacing || defaults.letterSpacing;
+    ui?.customization?.letterSpacing || CSS_VAR_DEFAULTS.letterSpacing;
   const font =
     fontMapper[ui?.customization?.font || ""]?.style.fontFamily ||
     inter.style.fontFamily;
@@ -79,39 +57,7 @@ export default async function RootLayout({
   };
 
   const style = {
-    "--primary": primary,
-    "--secondary": secondary,
-    "--tertiary": tertiary,
-    "--neutral": neutral,
-    "--wash": wash,
-    "--line": line,
-    "--positive": positive,
-    "--negative": negative,
-    "--brand-primary": brandPrimary,
-    "--brand-secondary": brandSecondary,
-    "--info-section-background":
-      ui?.customization?.infoSectionBackground || neutral,
-    "--header-background": ui?.customization?.headerBackground || wash,
-    "--info-tab-background": ui?.customization?.infoTabBackground || neutral,
-    "--button-background": ui?.customization?.buttonBackground || primary,
-    "--card-background": ui?.customization?.cardBackground || "255 255 255",
-    "--card-border": ui?.customization?.cardBorder || line,
-    "--card-background-light":
-      ui?.customization?.cardBackground || "255 255 255",
-    "--card-background-dark": ui?.customization?.cardBackground || "30 26 47",
-    "--hover-background-light":
-      ui?.customization?.hoverBackground || "249 250 251",
-    "--hover-background-dark": ui?.customization?.hoverBackground || "42 35 56",
-    "--modal-background-dark": ui?.customization?.cardBackground || "30 26 47",
-    "--input-background-dark": ui?.customization?.cardBackground || "42 35 56",
-    "--button-primary-dark": ui?.customization?.buttonBackground || "89 75 122",
-    "--button-secondary-dark":
-      ui?.customization?.buttonBackground || "25 16 62",
-    "--hover-background": ui?.customization?.hoverBackground || tertiary,
-    "--text-secondary": ui?.customization?.textSecondary || secondary,
-    "--footer-background": ui?.customization?.footerBackground || neutral,
-    "--inner-footer-background":
-      ui?.customization?.innerFooterBackground || wash,
+    ...buildTenantCssVars(ui?.customization),
     fontFamily: font,
     letterSpacing: letterSpacing,
   } as React.CSSProperties;

--- a/src/contexts/DevTenantContext.tsx
+++ b/src/contexts/DevTenantContext.tsx
@@ -6,6 +6,10 @@ import { TENANT_NAMESPACES } from "@/lib/constants";
 import TenantUIFactory from "@/lib/tenant/tenantUIFactory";
 import { TenantUI } from "@/lib/tenant/tenantUI";
 import { fontMapper, inter } from "@/styles/fonts";
+import {
+  buildTenantCssVars,
+  CSS_VAR_DEFAULTS,
+} from "@/lib/tenant/tenantCssVars";
 
 type DevTenantContextType = {
   selectedTenant: TenantNamespace | null;
@@ -18,119 +22,21 @@ const DevTenantContext = createContext<DevTenantContextType | undefined>(
   undefined
 );
 
-const defaults = {
-  primary: "23 23 23",
-  secondary: "64 64 64",
-  tertiary: "115 115 115",
-  neutral: "255 255 255",
-  wash: "250 250 250",
-  line: "229 229 229",
-  positive: "0 153 43",
-  negative: "197 47 0",
-  brandPrimary: "23 23 23",
-  brandSecondary: "255 255 255",
-  letterSpacing: "0",
-};
-
 function applyThemeColors(ui: TenantUI) {
   const root = document.documentElement;
   const customization = ui.customization;
+  const vars = buildTenantCssVars(customization);
 
-  const primary = customization?.primary || defaults.primary;
-  const secondary = customization?.secondary || defaults.secondary;
-  const tertiary = customization?.tertiary || defaults.tertiary;
-  const neutral = customization?.neutral || defaults.neutral;
-  const wash = customization?.wash || defaults.wash;
-  const line = customization?.line || defaults.line;
-  const positive = customization?.positive || defaults.positive;
-  const negative = customization?.negative || defaults.negative;
-  const brandPrimary = customization?.brandPrimary || defaults.brandPrimary;
-  const brandSecondary =
-    customization?.brandSecondary || defaults.brandSecondary;
-  const letterSpacing = customization?.letterSpacing || defaults.letterSpacing;
+  Object.entries(vars).forEach(([key, value]) => {
+    root.style.setProperty(key, value);
+  });
+
+  const letterSpacing =
+    customization?.letterSpacing || CSS_VAR_DEFAULTS.letterSpacing;
   const font =
     fontMapper[customization?.font || ""]?.style.fontFamily ||
     inter.style.fontFamily;
 
-  root.style.setProperty("--primary", primary);
-  root.style.setProperty("--secondary", secondary);
-  root.style.setProperty("--tertiary", tertiary);
-  root.style.setProperty("--neutral", neutral);
-  root.style.setProperty("--wash", wash);
-  root.style.setProperty("--line", line);
-  root.style.setProperty("--positive", positive);
-  root.style.setProperty("--negative", negative);
-  root.style.setProperty("--brand-primary", brandPrimary);
-  root.style.setProperty("--brand-secondary", brandSecondary);
-  root.style.setProperty(
-    "--info-section-background",
-    customization?.infoSectionBackground || neutral
-  );
-  root.style.setProperty(
-    "--header-background",
-    customization?.headerBackground || wash
-  );
-  root.style.setProperty(
-    "--info-tab-background",
-    customization?.infoTabBackground || neutral
-  );
-  root.style.setProperty(
-    "--button-background",
-    customization?.buttonBackground || primary
-  );
-  root.style.setProperty(
-    "--card-background",
-    customization?.cardBackground || "255 255 255"
-  );
-  root.style.setProperty("--card-border", customization?.cardBorder || line);
-  root.style.setProperty(
-    "--card-background-light",
-    customization?.cardBackground || "255 255 255"
-  );
-  root.style.setProperty(
-    "--card-background-dark",
-    customization?.cardBackground || "30 26 47"
-  );
-  root.style.setProperty(
-    "--hover-background-light",
-    customization?.hoverBackground || "249 250 251"
-  );
-  root.style.setProperty(
-    "--hover-background-dark",
-    customization?.hoverBackground || "42 35 56"
-  );
-  root.style.setProperty(
-    "--modal-background-dark",
-    customization?.cardBackground || "30 26 47"
-  );
-  root.style.setProperty(
-    "--input-background-dark",
-    customization?.cardBackground || "42 35 56"
-  );
-  root.style.setProperty(
-    "--button-primary-dark",
-    customization?.buttonBackground || "89 75 122"
-  );
-  root.style.setProperty(
-    "--button-secondary-dark",
-    customization?.buttonBackground || "25 16 62"
-  );
-  root.style.setProperty(
-    "--hover-background",
-    customization?.hoverBackground || tertiary
-  );
-  root.style.setProperty(
-    "--text-secondary",
-    customization?.textSecondary || secondary
-  );
-  root.style.setProperty(
-    "--footer-background",
-    customization?.footerBackground || neutral
-  );
-  root.style.setProperty(
-    "--inner-footer-background",
-    customization?.innerFooterBackground || wash
-  );
   root.style.fontFamily = font;
   root.style.letterSpacing = letterSpacing;
 

--- a/src/lib/tenant/configs/ui/syndicate.tsx
+++ b/src/lib/tenant/configs/ui/syndicate.tsx
@@ -72,7 +72,6 @@ export const syndicateTenantUIConfig = new TenantUI({
     customAboutSubtitle: "About Syndicate Network Collective",
     customIconColor: "#87819F",
     customInfoLayout: "flex-col sm:flex-row gap-2",
-    noReportsFound: "Quarterly Reports will be posted on October 15th, 2025.",
     customHeroImageSize: "sm:h-[160px]",
   },
 

--- a/src/lib/tenant/tenantCssVars.ts
+++ b/src/lib/tenant/tenantCssVars.ts
@@ -1,0 +1,63 @@
+import { TenantUI } from "./tenantUI";
+
+export const CSS_VAR_DEFAULTS = {
+  primary: "23 23 23",
+  secondary: "64 64 64",
+  tertiary: "115 115 115",
+  neutral: "255 255 255",
+  wash: "250 250 250",
+  line: "229 229 229",
+  positive: "0 153 43",
+  negative: "197 47 0",
+  brandPrimary: "23 23 23",
+  brandSecondary: "255 255 255",
+  letterSpacing: "0",
+};
+
+export function buildTenantCssVars(
+  customization: TenantUI["customization"]
+): Record<string, string> {
+  const c = customization;
+
+  const primary = c?.primary || CSS_VAR_DEFAULTS.primary;
+  const secondary = c?.secondary || CSS_VAR_DEFAULTS.secondary;
+  const tertiary = c?.tertiary || CSS_VAR_DEFAULTS.tertiary;
+  const neutral = c?.neutral || CSS_VAR_DEFAULTS.neutral;
+  const wash = c?.wash || CSS_VAR_DEFAULTS.wash;
+  const line = c?.line || CSS_VAR_DEFAULTS.line;
+  const positive = c?.positive || CSS_VAR_DEFAULTS.positive;
+  const negative = c?.negative || CSS_VAR_DEFAULTS.negative;
+  const brandPrimary = c?.brandPrimary || CSS_VAR_DEFAULTS.brandPrimary;
+  const brandSecondary = c?.brandSecondary || CSS_VAR_DEFAULTS.brandSecondary;
+
+  return {
+    "--primary": primary,
+    "--secondary": secondary,
+    "--tertiary": tertiary,
+    "--neutral": neutral,
+    "--wash": wash,
+    "--line": line,
+    "--positive": positive,
+    "--negative": negative,
+    "--brand-primary": brandPrimary,
+    "--brand-secondary": brandSecondary,
+    "--info-section-background": c?.infoSectionBackground || neutral,
+    "--header-background": c?.headerBackground || wash,
+    "--info-tab-background": c?.infoTabBackground || neutral,
+    "--button-background": c?.buttonBackground || primary,
+    "--card-background": c?.cardBackground || "255 255 255",
+    "--card-border": c?.cardBorder || line,
+    "--card-background-light": c?.cardBackground || "255 255 255",
+    "--card-background-dark": c?.cardBackground || "30 26 47",
+    "--hover-background-light": c?.hoverBackground || "249 250 251",
+    "--hover-background-dark": c?.hoverBackground || "42 35 56",
+    "--modal-background-dark": c?.cardBackground || "30 26 47",
+    "--input-background-dark": c?.cardBackground || "42 35 56",
+    "--button-primary-dark": c?.buttonBackground || "89 75 122",
+    "--button-secondary-dark": c?.buttonBackground || "25 16 62",
+    "--hover-background": c?.hoverBackground || tertiary,
+    "--text-secondary": c?.textSecondary || secondary,
+    "--footer-background": c?.footerBackground || neutral,
+    "--inner-footer-background": c?.innerFooterBackground || wash,
+  };
+}

--- a/src/lib/tenant/tenantUI.ts
+++ b/src/lib/tenant/tenantUI.ts
@@ -203,15 +203,12 @@ type TenantUIParams = {
     footerBackground?: string;
     innerFooterBackground?: string;
     customHeroImageSize?: string;
-    customInfoTabs?: Array<{ title: string; description: string }>;
     customIconBackground?: string;
     customInfoLayout?: string;
-    customTextContainer?: string;
     customAboutSubtitle?: string;
     customTitleSize?: string;
     customCardSize?: string;
     customIconColor?: string;
-    noReportsFound?: string;
     customHeroTitleWidth?: string;
     tagBackground?: string;
     infoBannerBackground?: string;
@@ -272,15 +269,12 @@ export class TenantUI {
     footerBackground?: string;
     innerFooterBackground?: string;
     customHeroImageSize?: string;
-    customInfoTabs?: Array<{ title: string; description: string }>;
     customIconBackground?: string;
     customInfoLayout?: string;
-    customTextContainer?: string;
     customAboutSubtitle?: string;
     customTitleSize?: string;
     customCardSize?: string;
     customIconColor?: string;
-    noReportsFound?: string;
     customHeroTitleWidth?: string;
     tagBackground?: string;
     infoBannerBackground?: string;
@@ -426,17 +420,16 @@ export class TenantUI {
         footerBackground?: string;
         innerFooterBackground?: string;
         customHeroImageSize?: string;
-        customInfoTabs?: Array<{ title: string; description: string }>;
         customIconBackground?: string;
         customInfoLayout?: string;
-        customTextContainer?: string;
         customAboutSubtitle?: string;
         customTitleSize?: string;
         customCardSize?: string;
         customIconColor?: string;
-        noReportsFound?: string;
+        customHeroTitleWidth?: string;
         tagBackground?: string;
         infoBannerBackground?: string;
+        heroCardGradient?: { from: string; to: string };
       }
     | undefined {
     return this._customization;


### PR DESCRIPTION
Three places (layout.tsx, custom.css/route.ts, DevTenantContext.tsx) each independently built the same CSS-variable map from ui.customization, so any addition or default change had to be made in three spots — the root cause of tenant styles falling through to defaults when the copies drifted.

Extract buildTenantCssVars() and CSS_VAR_DEFAULTS into tenantCssVars.ts and call from all three sites.

Also fix a TypeScript gap where customHeroTitleWidth and heroCardGradient were missing from the TenantUI.customization getter return type, causing silent undefined in .tsx consumers.

Remove dead schema fields that no tenant ever set and no component rendered:
- noReportsFound (syndicate config had a stale Oct-2025 date string)
- customTextContainer (InfoAbout.tsx fell back to empty string 100% of the time)
- customInfoTabs (InfoAbout.tsx logic was dead; page.tabs supersedes it)