### PR TITLE
fix: upload run_metadata.json to GCP for dashboard URL display

### DIFF
--- a/scripts/upload-ab-artifacts.sh
+++ b/scripts/upload-ab-artifacts.sh
@@ -30,8 +30,17 @@ echo "Uploading artifacts to $TARGET_DIR..."
 # We use gsutil or gcloud storage depending on environment
 if command -v gsutil &> /dev/null; then
     gsutil -m rsync -r test-results/ab-diffs $TARGET_DIR
+    # Upload run metadata (URL A/B, tenant, routes) for dashboard
+    if [ -f "test-results/run_metadata.json" ]; then
+        gsutil cp test-results/run_metadata.json "${TARGET_DIR}/run_metadata.json"
+        echo "📝 Uploaded run_metadata.json"
+    fi
 else
     gcloud storage cp -r test-results/ab-diffs/* $TARGET_DIR
+    if [ -f "test-results/run_metadata.json" ]; then
+        gcloud storage cp test-results/run_metadata.json "${TARGET_DIR}/run_metadata.json"
+        echo "📝 Uploaded run_metadata.json"
+    fi
 fi
 
 echo "Upload completed successfully! You can view the artifacts in the GCP Console."


### PR DESCRIPTION
## Summary

Fixes the 'URL inputs not recorded for this run' issue in the telemetry dashboard.

### Root Cause
The upload script (`scripts/upload-ab-artifacts.sh`) was only syncing `test-results/ab-diffs/` to GCP but not `run_metadata.json`, which the workflow generates with the URL A/B values.

### Changes
- **`scripts/upload-ab-artifacts.sh`**: Adds `gsutil cp` / `gcloud storage cp` for `run_metadata.json` after the main artifact rsync.

### Testing
- Dispatched run `24809069913` from this branch to verify metadata propagation end-to-end.