### PR TITLE
fix: register shape and shapeSepolia chains in viem helpers

### DIFF
--- a/src/lib/viem.ts
+++ b/src/lib/viem.ts
@@ -15,6 +15,8 @@ import {
   optimism,
   scroll,
   sepolia,
+  shape,
+  shapeSepolia,
   linea,
   lineaSepolia,
 } from "viem/chains";
@@ -90,6 +92,18 @@ export const getWalletClient = (chainId: number) => {
         transport,
       });
 
+    case shape.id:
+      return createWalletClient({
+        chain: shape,
+        transport,
+      });
+
+    case shapeSepolia.id:
+      return createWalletClient({
+        chain: shapeSepolia,
+        transport,
+      });
+
     default:
       throw new Error("Invalid chainId");
   }
@@ -115,6 +129,10 @@ export const getChainById = (chainId: number): Chain | null => {
       return linea;
     case lineaSepolia.id:
       return lineaSepolia;
+    case shape.id:
+      return shape;
+    case shapeSepolia.id:
+      return shapeSepolia;
     case arbitrum.id:
       return arbitrum;
     case arbitrumSepolia.id:


### PR DESCRIPTION
SIWE verification was failing with 401 "Invalid SIWE signature" on gov.structura.org because getChainById returned null for chainId 360 (shape), causing serverVerifyMessage to bail out before verifying.