### PR TITLE
fix: register optimismSepolia chain in viem helpers

### DIFF
--- a/src/lib/viem.ts
+++ b/src/lib/viem.ts
@@ -13,6 +13,7 @@ import {
   cyber,
   mainnet,
   optimism,
+  optimismSepolia,
   scroll,
   sepolia,
   shape,
@@ -54,6 +55,11 @@ export const getWalletClient = (chainId: number) => {
     case optimism.id:
       return createWalletClient({
         chain: optimism,
+        transport,
+      });
+    case optimismSepolia.id:
+      return createWalletClient({
+        chain: optimismSepolia,
         transport,
       });
     case cyber.id:
@@ -117,6 +123,8 @@ export const getChainById = (chainId: number): Chain | null => {
       return sepolia;
     case optimism.id:
       return optimism;
+    case optimismSepolia.id:
+      return optimismSepolia;
     case cyber.id:
       return cyber;
     case deriveTestnet.id:


### PR DESCRIPTION
boost and optimism tenants use optimismSepolia (chainId 11155420) in non-prod, but getChainById didn't map it, which would cause SIWE verification to fail with "Invalid SIWE signature" in testnet envs. Transport was already configured in utils.ts.