### PR TITLE
feat(ab-runner): auto-generate manifest.json for local dashboard discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:ab": "rm -rf test-results/ab-diffs && playwright test tests/ab-runner/regression.spec.ts"
+    "test:ab": "rm -rf test-results/ab-diffs && playwright test tests/ab-runner/regression.spec.ts; node tests/ab-runner/generate-manifest.js"
   },
   "dependencies": {
     "@aa-sdk/core": "^4.0.0-beta.10",

--- a/tests/ab-runner/generate-manifest.js
+++ b/tests/ab-runner/generate-manifest.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Generates a manifest.json inside test-results/ab-diffs/ that lists every
+ * report.json found in the directory tree, along with the sibling image files.
+ *
+ * This manifest is consumed by the telemetry_dashboard.html Local mode to
+ * discover all scopes (including deeply nested archive proposals).
+ *
+ * Usage:  node tests/ab-runner/generate-manifest.js
+ * Called automatically by `npm run test:ab`.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const BASE_DIR = path.resolve(__dirname, "../../test-results/ab-diffs");
+
+if (!fs.existsSync(BASE_DIR)) {
+  console.log("⚠ No ab-diffs directory found — skipping manifest generation.");
+  process.exit(0);
+}
+
+const reports = [];
+
+function walk(dir, rel) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+
+    if (entry.isDirectory()) {
+      walk(fullPath, relPath);
+    } else if (entry.name === "report.json") {
+      const parentDir = path.dirname(fullPath);
+      const images = [];
+
+      // Collect sibling images
+      try {
+        for (const f of fs.readdirSync(parentDir)) {
+          if (f.endsWith(".png")) images.push(f);
+        }
+      } catch {}
+
+      // Collect focused-crops/ images
+      const cropsDir = path.join(parentDir, "focused-crops");
+      try {
+        if (fs.existsSync(cropsDir)) {
+          for (const f of fs.readdirSync(cropsDir)) {
+            if (f.endsWith(".png")) images.push(`focused-crops/${f}`);
+          }
+        }
+      } catch {}
+
+      reports.push({ path: relPath, images });
+    }
+  }
+}
+
+walk(BASE_DIR, "");
+
+const manifest = { reports, generated: new Date().toISOString() };
+const outPath = path.join(BASE_DIR, "manifest.json");
+fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2));
+
+console.log(`✅ manifest.json → ${reports.length} reports indexed`);


### PR DESCRIPTION
## Problem

Running `npm run test:ab` with archive proposals generates deeply nested report directories (`optimism/proposals/proposals-XXX/report.json`). The local dashboard only probes 5 hardcoded flat scopes as fallback, so 130+ archive reports are invisible.

## Solution

- Added `tests/ab-runner/generate-manifest.js` — walks `test-results/ab-diffs/` recursively and writes a `manifest.json` listing all `report.json` paths + sibling images.
- Updated `test:ab` npm script to chain the manifest generator using `;` (runs even when tests exit with drift failures).

## Impact

- **Local**: dashboard discovers all 134 reports on page load
- **CI**: manifest is included in GCP upload artifacts
- **Zero config**: teammates just run `npm run test:ab` and open the dashboard

## Files changed

- `tests/ab-runner/generate-manifest.js` (new)
- `package.json` (`test:ab` script)