### PR TITLE
Enable Safe SIWE flows for supported tenants

### DIFF
--- a/src/app/proposals/draft/[id]/DraftProposalPageClient.tsx
+++ b/src/app/proposals/draft/[id]/DraftProposalPageClient.tsx
@@ -9,7 +9,6 @@ import {
   DraftProposal as DraftProposalType,
   PLMConfig,
 } from "@/app/proposals/draft/types";
-import { useSIWE } from "connectkit";
 import { useAccount, useChainId, useSwitchChain } from "wagmi";
 import { useDraftStage } from "./hooks/useDraftStage";
 import { DraftPageHeader } from "./components/DraftPageHeader";
@@ -20,6 +19,7 @@ import Loading from "./loading";
 import Tenant from "@/lib/tenant/tenant";
 import ShareDraftLink from "./components/ShareDraftLink";
 import { getStoredSiweJwt } from "@/lib/siweSession";
+import { useSiweJwt } from "@/hooks/useSiweJwt";
 
 type DraftResponse = DraftProposalType;
 
@@ -61,6 +61,11 @@ export default function DraftProposalPageClient({
   const { address } = useAccount();
   const currentChainId = useChainId();
   const { switchChainAsync, isPending: isSwitching } = useSwitchChain();
+  const { ensureSession: ensureDraftSiweSession } = useSiweJwt({
+    expectedAddress: address?.toLowerCase(),
+    purpose: "proposal_draft",
+    chainId: targetChainId,
+  });
 
   useEffect(() => {
     // Do not clear SIWE session on disconnect/refresh; only reset local UI state
@@ -163,8 +168,6 @@ export default function DraftProposalPageClient({
     }
   }, [data, isLoading, queryError]);
 
-  const { signIn } = useSIWE();
-
   // On mount: if user refreshed/closed while awaiting signature and no JWT exists, reset UI state
   useEffect(() => {
     try {
@@ -193,6 +196,8 @@ export default function DraftProposalPageClient({
       } catch {}
       if (!address) {
         setError("Please connect your wallet before signing");
+        setIsSigning(false);
+        setPostSignGrace(false);
         return;
       }
       if (currentChainId !== targetChainId && switchChainAsync) {
@@ -200,14 +205,45 @@ export default function DraftProposalPageClient({
           await switchChainAsync({ chainId: targetChainId });
         } catch (e) {
           setError("Failed to switch network for this tenant");
+          setIsSigning(false);
+          setPostSignGrace(false);
           return;
         }
       }
       setSignLabel("Awaiting Confirmation");
-      await signIn();
-    } catch {
+      const jwt = await ensureDraftSiweSession();
+      if (!jwt) {
+        setSignLabel("Cancelled");
+        setError("Signature cancelled by user");
+        setIsSigning(false);
+        setPostSignGrace(false);
+        completedSignRef.current = false;
+        return;
+      }
+
+      completedSignRef.current = true;
+      setSignLabel("Signed");
+      setAdvancing(true);
+      setError(null);
+      await refetch();
+      setSignLabel(null);
+      setIsSigning(false);
+      setPostSignGrace(false);
+      setAdvancing(false);
+      try {
+        localStorage.removeItem(LOCAL_STORAGE_SIWE_STAGE_KEY);
+      } catch {}
+      if (pollIdRef.current) {
+        clearInterval(pollIdRef.current);
+        pollIdRef.current = null;
+      }
+    } catch (sessionError) {
       setSignLabel("Cancelled");
-      setError("Signature cancelled by user");
+      setError(
+        sessionError instanceof Error
+          ? sessionError.message
+          : "Signature cancelled by user"
+      );
       try {
         localStorage.setItem(LOCAL_STORAGE_SIWE_STAGE_KEY, "error");
       } catch {}
@@ -226,7 +262,8 @@ export default function DraftProposalPageClient({
     currentChainId,
     targetChainId,
     switchChainAsync,
-    signIn,
+    ensureDraftSiweSession,
+    refetch,
   ]);
 
   const onDeleteSuccess = useCallback(() => {

--- a/src/hooks/useSiweJwt.ts
+++ b/src/hooks/useSiweJwt.ts
@@ -11,6 +11,7 @@ interface UseSiweJwtOptions {
   expectedAddress?: string;
   autoAuthenticate?: boolean;
   purpose?: SafeOffchainSigningPurpose;
+  chainId?: number;
 }
 
 const siweSessionRequests = new Map<string, Promise<string | null>>();
@@ -33,7 +34,7 @@ export function useSiweJwt(options: UseSiweJwtOptions = {}) {
   const { clearSiweSession, ensureSiweSession, loadSiweJwt, walletType } =
     useEnsureSiweSession({
       address: expectedAddress ?? undefined,
-      chainId: chain?.id,
+      chainId: options.chainId ?? chain?.id,
       purpose,
     });
 

--- a/src/lib/tenant/configs/ui/b3.ts
+++ b/src/lib/tenant/configs/ui/b3.ts
@@ -267,6 +267,18 @@ If you meet the proposal threshold or are the manager of the governor, then you 
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-daonode-for-proposal-types",
       enabled: false,
     },

--- a/src/lib/tenant/configs/ui/boost.ts
+++ b/src/lib/tenant/configs/ui/boost.ts
@@ -185,6 +185,18 @@ If you need help creating transactions / calldata, please see this [video](https
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-daonode-for-proposal-types",
       enabled: false,
     },

--- a/src/lib/tenant/configs/ui/demo.ts
+++ b/src/lib/tenant/configs/ui/demo.ts
@@ -292,6 +292,18 @@ If you meet the proposal threshold or are the manager of the governor, then you 
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-daonode-for-proposal-types",
       enabled: false,
     },

--- a/src/lib/tenant/configs/ui/demo2.tsx
+++ b/src/lib/tenant/configs/ui/demo2.tsx
@@ -270,6 +270,18 @@ export const demo2TenantUIConfig = new TenantUI({
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-archive-for-proposals",
       enabled: true,
     },

--- a/src/lib/tenant/configs/ui/demo3.tsx
+++ b/src/lib/tenant/configs/ui/demo3.tsx
@@ -412,6 +412,23 @@ export const demo3TenantUIConfig = new TenantUI({
     },
 
     {
+      name: "safe-proposal-choice",
+
+      enabled: true,
+    },
+
+    {
+      name: "safe-tracking",
+
+      enabled: true,
+
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+
+    {
       name: "use-archive-for-proposals",
 
       enabled: true,

--- a/src/lib/tenant/configs/ui/demo4.tsx
+++ b/src/lib/tenant/configs/ui/demo4.tsx
@@ -401,6 +401,23 @@ export const demo4TenantUIConfig = new TenantUI({
     },
 
     {
+      name: "safe-proposal-choice",
+
+      enabled: true,
+    },
+
+    {
+      name: "safe-tracking",
+
+      enabled: true,
+
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+
+    {
       name: "use-archive-for-proposals",
 
       enabled: true,

--- a/src/lib/tenant/configs/ui/ens.ts
+++ b/src/lib/tenant/configs/ui/ens.ts
@@ -285,6 +285,18 @@ For a full walkthrough of the proposal process, check out the [ENS DAO docs](htt
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-daonode-for-proposals",
       enabled: false,
     },

--- a/src/lib/tenant/configs/ui/linea.ts
+++ b/src/lib/tenant/configs/ui/linea.ts
@@ -277,6 +277,18 @@ If you meet the proposal threshold or are the manager of the governor, then you 
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-daonode-for-proposal-types",
       enabled: true,
     },

--- a/src/lib/tenant/configs/ui/optimism.ts
+++ b/src/lib/tenant/configs/ui/optimism.ts
@@ -321,6 +321,18 @@ If you're using the OP Foundation multisig, you can queue several proposals at o
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "delegation-encouragement",
       enabled: true,
     },

--- a/src/lib/tenant/configs/ui/scroll.ts
+++ b/src/lib/tenant/configs/ui/scroll.ts
@@ -324,6 +324,18 @@ If you meet the proposal threshold or are the manager of the governor, then you 
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-daonode-for-proposals",
       enabled: false,
     },

--- a/src/lib/tenant/configs/ui/syndicate.tsx
+++ b/src/lib/tenant/configs/ui/syndicate.tsx
@@ -318,6 +318,18 @@ export const syndicateTenantUIConfig = new TenantUI({
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-archive-for-proposals",
       enabled: true,
     },

--- a/src/lib/tenant/configs/ui/towns.tsx
+++ b/src/lib/tenant/configs/ui/towns.tsx
@@ -293,6 +293,18 @@ export const townsTenantUIConfig = new TenantUI({
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "use-archive-for-proposals",
       enabled: true,
     },

--- a/src/lib/tenant/configs/ui/xai.ts
+++ b/src/lib/tenant/configs/ui/xai.ts
@@ -297,6 +297,18 @@ If you need help creating transactions / calldata, please see this [video](https
       },
     },
     {
+      name: "safe-proposal-choice",
+      enabled: true,
+    },
+    {
+      name: "safe-tracking",
+      enabled: true,
+      config: {
+        offchainMessageTracking: true,
+        onchainTransactionTracking: true,
+      },
+    },
+    {
       name: "hide-7d-change",
       enabled: true,
     },


### PR DESCRIPTION
## Summary

- Route draft proposal access through the shared Safe-aware SIWE helper so Safe wallets get the tracked Safe SIWE signing dialog instead of the bare ConnectKit SIWE flow.
- Add a tenant-chain override to `useSiweJwt` so draft access authenticates against the proposal tenant chain.
- Enable `safe-proposal-choice` and full `safe-tracking` for tenants on chains already supported by the app Safe tx-service map: ENS, Optimism, Scroll, Boost, Xai, B3, Demo, Linea, Towns, Syndicate, demo2, demo3, and demo4.

## Tenant Impact

Already enabled tenants remain unchanged: Uniswap and Protocol Guild.

Newly enabled tenants get:

- Safe proposal choice modal for proposal creation.
- Tracked Safe offchain SIWE/message signing.
- Tracked Safe onchain proposal publish status.

Intentionally not enabled:

- Cyber, Derive, and Shape: SIWE verification is supported, but tracked Safe flows are not because these chains are not in `safeChains.ts` transaction-service capabilities.
- 0g and Etherfi: left unchanged because the relevant governance/edit surfaces are disabled or not currently configured for this rollout.