### PR TITLE
[codex] Remove info page SIWE auto-auth from release branch

### DIFF
--- a/src/app/duna/components/DocumentsSection.tsx
+++ b/src/app/duna/components/DocumentsSection.tsx
@@ -52,20 +52,17 @@ const DocumentsSection = ({
   const { hasPermission: canCreateFilings } = useHasPermission(
     "duna_filings",
     "filings",
-    "create",
-    { autoAuthenticate: true }
+    "create"
   );
   const { hasPermission: canArchiveFilings } = useHasPermission(
     "duna_filings",
     "filings",
-    "archive",
-    { autoAuthenticate: true }
+    "archive"
   );
   const { hasPermission: canDeleteFilings } = useHasPermission(
     "duna_filings",
     "filings",
-    "delete",
-    { autoAuthenticate: true }
+    "delete"
   );
 
   const { ui } = Tenant.current();


### PR DESCRIPTION
## Summary

Cherry-picks the info page SIWE behavior fix onto `release/uniswap23rdApr`.

This removes `autoAuthenticate: true` from the DUNA filings permission checks in `DocumentsSection`, so the info page no longer auto-triggers SIWE while checking create/archive/delete filing permissions.

Original commit: `8e41abb500ee2b53d4077e6816a8ee07a6c9c832`
Cherry-picked commit on this branch: `38985537`

## Validation

- Verified the branch is exactly one commit ahead of `origin/release/uniswap23rdApr`
- Verified the diff only changes `src/app/duna/components/DocumentsSection.tsx`
- Automated tests not run; the temporary worktree does not have dependencies installed, and this is a clean cherry-pick of the requested commit.