### PR TITLE
Fix sponsored delegation relay completion

### DIFF
--- a/src/app/api/v1/relay/delegate/delegate.ts
+++ b/src/app/api/v1/relay/delegate/delegate.ts
@@ -11,6 +11,13 @@ import { createWalletClient, parseSignature, isHex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
 const SPONSOR_PRIVATE_KEY = process.env.GAS_SPONSOR_PK;
+const DELEGATE_BY_SIG_GAS_BUFFER_PERCENT = 30n;
+
+function getBufferedDelegateBySigGasLimit(estimatedGas: bigint) {
+  return (
+    estimatedGas + (estimatedGas * DELEGATE_BY_SIG_GAS_BUFFER_PERCENT) / 100n
+  );
+}
 
 export async function delegateBySignatureApi({
   signature,
@@ -135,14 +142,22 @@ async function prepareDelegateBySignatureApi({
   }
 
   const account = privateKeyToAccount(SPONSOR_PRIVATE_KEY);
-
-  const { request } = await publicClient.simulateContract({
+  const delegateBySigRequest = {
     address: token.address as `0x${string}`,
     abi: token.abi,
     functionName: "delegateBySig",
     args: [delegatee, BigInt(nonce), BigInt(expiry), v, r, s],
     account: account,
-  });
+  } as const;
 
-  return { request };
+  const { request } = await publicClient.simulateContract(delegateBySigRequest);
+  const estimatedGas =
+    await publicClient.estimateContractGas(delegateBySigRequest);
+
+  return {
+    request: {
+      ...request,
+      gas: getBufferedDelegateBySigGasLimit(estimatedGas),
+    },
+  };
 }

--- a/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
+++ b/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
@@ -99,6 +99,7 @@ export function DelegateDialog({
     call,
     isFetching: isProcessingSponsoredDelegation,
     isFetched: didProcessSponsoredDelegation,
+    isError: didFailSponsoredDelegation,
     txHash: sponsoredTxnHash,
   } = useSponsoredDelegation({
     address: accountAddress,
@@ -121,9 +122,7 @@ export function DelegateDialog({
     isSuccess: didProcessDelegation,
     isError: didFailDelegation,
   } = useWaitForTransactionReceipt({
-    hash: isGasRelayLive
-      ? sponsoredTxnHash
-      : (localDelegateTxHash ?? delegateTxHash),
+    hash: isGasRelayLive ? undefined : (localDelegateTxHash ?? delegateTxHash),
   });
 
   const fetchData = async () => {
@@ -136,7 +135,7 @@ export function DelegateDialog({
   };
 
   useEffect(() => {
-    if (didProcessDelegation) {
+    if (didProcessDelegation || didProcessSponsoredDelegation) {
       trackEvent({
         event_name: ANALYTICS_EVENT_NAMES.DELEGATE,
         event_data: {
@@ -159,7 +158,7 @@ export function DelegateDialog({
         });
       }
     }
-  }, [didProcessDelegation]);
+  }, [didProcessDelegation, didProcessSponsoredDelegation]);
 
   useEffect(() => {
     if (isGasRelayLive || !delegationTraceRef.current) {
@@ -341,7 +340,7 @@ export function DelegateDialog({
       );
     }
 
-    if (isError || didFailDelegation) {
+    if (isError || didFailDelegation || didFailSponsoredDelegation) {
       return (
         <Button disabled={false} onClick={executeDelegate}>
           Delegation failed - try again
@@ -377,7 +376,9 @@ export function DelegateDialog({
     ) {
       fetchData();
     }
+  }, [accountAddress, tokenBalance]);
 
+  useEffect(() => {
     if (didProcessDelegation || didProcessSponsoredDelegation) {
       // Refresh delegation
       if (tokenBalance !== undefined && tokenBalance > 0n) {
@@ -387,7 +388,7 @@ export function DelegateDialog({
         });
       }
     }
-  }, [didProcessDelegation, delegate, tokenBalance, accountAddress]);
+  }, [didProcessDelegation, didProcessSponsoredDelegation]);
 
   if (!isReady) {
     return (

--- a/src/components/Dialogs/UndelegateDialog/UndelegateDialog.tsx
+++ b/src/components/Dialogs/UndelegateDialog/UndelegateDialog.tsx
@@ -39,6 +39,7 @@ interface UndelegateActionButtonsProps {
   executeDelegate: () => void;
   isError: boolean;
   didFailDelegation: boolean;
+  didFailSponsoredUnelegation: boolean;
   isProcessingDelegation: boolean;
   isProcessingSponsoredUnelegation: boolean;
   didProcessDelegation: boolean;
@@ -55,6 +56,7 @@ const UndelegateActionButtons = ({
   executeDelegate,
   isError,
   didFailDelegation,
+  didFailSponsoredUnelegation,
   isProcessingDelegation,
   isProcessingSponsoredUnelegation,
   didProcessDelegation,
@@ -71,7 +73,7 @@ const UndelegateActionButtons = ({
     );
   }
 
-  if (isError || didFailDelegation) {
+  if (isError || didFailDelegation || didFailSponsoredUnelegation) {
     return (
       <Button disabled={false} onClick={executeDelegate}>
         Undelegation failed - try again
@@ -158,6 +160,7 @@ export function UndelegateDialog({
     call,
     isFetching: isProcessingSponsoredUnelegation,
     isFetched: didProcessSponsoredUnelegation,
+    isError: didFailSponsoredUnelegation,
     txHash: sponsoredTxnHash,
   } = useSponsoredDelegation({
     address: accountAddress,
@@ -180,7 +183,7 @@ export function UndelegateDialog({
     isSuccess: didProcessDelegation,
     isError: didFailDelegation,
   } = useWaitForTransactionReceipt({
-    hash: isGasRelayLive ? sponsoredTxnHash : delegateTxHash,
+    hash: isGasRelayLive ? undefined : delegateTxHash,
   });
 
   const fetchData = useCallback(async () => {
@@ -255,7 +258,9 @@ export function UndelegateDialog({
     if (!isReady) {
       fetchData();
     }
+  }, [isReady, fetchData]);
 
+  useEffect(() => {
     if (didProcessDelegation) {
       if (delegationTraceRef.current) {
         attachMiradorTransactionArtifacts(delegationTraceRef.current, {
@@ -274,6 +279,9 @@ export function UndelegateDialog({
         });
         delegationTraceRef.current = null;
       }
+    }
+
+    if (didProcessDelegation || didProcessSponsoredUnelegation) {
       // Refresh delegation
       if (Number(votingPower) > 0) {
         setRefetchDelegate({
@@ -283,7 +291,7 @@ export function UndelegateDialog({
       }
       revalidateData();
     }
-  }, [isReady, fetchData, didProcessDelegation, delegate, votingPower]);
+  }, [didProcessDelegation, didProcessSponsoredUnelegation]);
 
   useEffect(() => {
     if (!delegationTraceRef.current || isGasRelayLive) {
@@ -387,6 +395,7 @@ export function UndelegateDialog({
           executeDelegate={executeDelegate}
           isError={isError}
           didFailDelegation={didFailDelegation}
+          didFailSponsoredUnelegation={didFailSponsoredUnelegation}
           isProcessingDelegation={isProcessingDelegation}
           isProcessingSponsoredUnelegation={isProcessingSponsoredUnelegation}
           didProcessDelegation={didProcessDelegation}

--- a/src/hooks/__tests__/useSponsoredDelegation.test.tsx
+++ b/src/hooks/__tests__/useSponsoredDelegation.test.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSponsoredDelegation } from "@/hooks/useSponsoredDelegation";
+
+const {
+  addMiradorEventMock,
+  attachMiradorTransactionArtifactsMock,
+  closeFrontendMiradorFlowTraceMock,
+  getFrontendMiradorTraceContextMock,
+  postMock,
+  signTypedDataAsyncMock,
+  startFrontendMiradorFlowTraceMock,
+  useNonceMock,
+  useSignTypedDataMock,
+  useTokenNameMock,
+  waitForTransactionReceiptMock,
+} = vi.hoisted(() => ({
+  addMiradorEventMock: vi.fn(),
+  attachMiradorTransactionArtifactsMock: vi.fn(),
+  closeFrontendMiradorFlowTraceMock: vi.fn(),
+  getFrontendMiradorTraceContextMock: vi.fn(),
+  postMock: vi.fn(),
+  signTypedDataAsyncMock: vi.fn(),
+  startFrontendMiradorFlowTraceMock: vi.fn(),
+  useNonceMock: vi.fn(),
+  useSignTypedDataMock: vi.fn(),
+  useTokenNameMock: vi.fn(),
+  waitForTransactionReceiptMock: vi.fn(),
+}));
+
+const delegateAbi = [
+  {
+    type: "function",
+    name: "delegate",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "delegatee", type: "address" }],
+    outputs: [],
+  },
+] as const;
+
+vi.mock("@/app/Web3Provider", () => ({
+  config: {},
+}));
+
+vi.mock("wagmi", () => ({
+  useSignTypedData: useSignTypedDataMock,
+}));
+
+vi.mock("wagmi/actions", () => ({
+  waitForTransactionReceipt: waitForTransactionReceiptMock,
+}));
+
+vi.mock("@/hooks/useNonce", () => ({
+  useNonce: useNonceMock,
+}));
+
+vi.mock("@/hooks/useTokenName", () => ({
+  useTokenName: useTokenNameMock,
+}));
+
+vi.mock("@/app/lib/agoraAPI", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    post: postMock,
+  })),
+}));
+
+vi.mock("@/lib/tenant/tenant", () => ({
+  default: {
+    current: () => ({
+      ui: {
+        toggle: (name: string) => {
+          if (name === "sponsoredDelegate") {
+            return {
+              enabled: true,
+              config: {
+                signature: {
+                  version: "1",
+                },
+              },
+            };
+          }
+
+          return { enabled: false };
+        },
+      },
+      contracts: {
+        token: {
+          abi: delegateAbi,
+          address: "0x0000000000000000000000000000000000000001",
+          chain: { id: 1 },
+          provider: {
+            getBlock: vi.fn().mockResolvedValue({ timestamp: 1000 }),
+          },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock("@/lib/mirador/headers", () => ({
+  withMiradorTraceHeaders: vi.fn((headers) => headers),
+}));
+
+vi.mock("@/lib/mirador/frontendFlowTrace", () => ({
+  attachMiradorTransactionArtifacts: attachMiradorTransactionArtifactsMock,
+  closeFrontendMiradorFlowTrace: closeFrontendMiradorFlowTraceMock,
+  getFrontendMiradorTraceContext: getFrontendMiradorTraceContextMock,
+  startFrontendMiradorFlowTrace: startFrontendMiradorFlowTraceMock,
+}));
+
+vi.mock("@/lib/mirador/webTrace", () => ({
+  addMiradorEvent: addMiradorEventMock,
+}));
+
+describe("useSponsoredDelegation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useNonceMock.mockReturnValue({ data: 0n });
+    useTokenNameMock.mockReturnValue({ data: "Uniswap" });
+    signTypedDataAsyncMock.mockResolvedValue("0xsignature");
+    useSignTypedDataMock.mockReturnValue({
+      signTypedDataAsync: signTypedDataAsyncMock,
+    });
+    startFrontendMiradorFlowTraceMock.mockReturnValue({ traceId: "trace-id" });
+    getFrontendMiradorTraceContextMock.mockReturnValue({ traceId: "trace-id" });
+    postMock.mockResolvedValue({
+      json: vi
+        .fn()
+        .mockResolvedValue(
+          "0x000000000000000000000000000000000000000000000000000000000000000a"
+        ),
+    });
+    waitForTransactionReceiptMock.mockResolvedValue({ status: "success" });
+  });
+
+  it("marks a sponsored delegation as fetched only after a successful receipt", async () => {
+    const { result } = renderHook(() =>
+      useSponsoredDelegation({
+        address: "0x0000000000000000000000000000000000000002",
+        delegate: {
+          address: "0x0000000000000000000000000000000000000003",
+          votingPower: { total: "0", direct: "0", advanced: "0" },
+          statement: null,
+          participation: 0,
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.call();
+    });
+
+    expect(waitForTransactionReceiptMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        hash: "0x000000000000000000000000000000000000000000000000000000000000000a",
+        chainId: 1,
+      })
+    );
+    expect(addMiradorEventMock).toHaveBeenCalledWith(
+      { traceId: "trace-id" },
+      "governance_delegation_submitted",
+      expect.objectContaining({
+        transactionHash:
+          "0x000000000000000000000000000000000000000000000000000000000000000a",
+      })
+    );
+    expect(closeFrontendMiradorFlowTraceMock).toHaveBeenCalledWith(
+      { traceId: "trace-id" },
+      expect.objectContaining({
+        reason: "governance_delegation_succeeded",
+      })
+    );
+    expect(attachMiradorTransactionArtifactsMock).toHaveBeenCalledWith(
+      { traceId: "trace-id" },
+      expect.objectContaining({
+        txHash:
+          "0x000000000000000000000000000000000000000000000000000000000000000a",
+        txDetails: "Sponsored delegation transaction",
+      })
+    );
+    expect(result.current.isFetched).toBe(true);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("records a failed sponsored delegation when the receipt reverts", async () => {
+    waitForTransactionReceiptMock.mockResolvedValue({ status: "reverted" });
+
+    const { result } = renderHook(() =>
+      useSponsoredDelegation({
+        address: "0x0000000000000000000000000000000000000002",
+        delegate: {
+          address: "0x0000000000000000000000000000000000000003",
+          votingPower: { total: "0", direct: "0", advanced: "0" },
+          statement: null,
+          participation: 0,
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.call();
+    });
+
+    expect(closeFrontendMiradorFlowTraceMock).toHaveBeenCalledWith(
+      { traceId: "trace-id" },
+      expect.objectContaining({
+        reason: "governance_delegation_failed",
+        details: expect.objectContaining({
+          error:
+            "Sponsored delegation transaction failed with status: reverted",
+        }),
+      })
+    );
+    expect(result.current.isFetched).toBe(false);
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/src/hooks/useSponsoredDelegation.ts
+++ b/src/hooks/useSponsoredDelegation.ts
@@ -4,11 +4,14 @@ import { UIGasRelayConfig } from "@/lib/tenant/tenantUI";
 import { Address, encodeFunctionData, zeroAddress } from "viem";
 import AgoraAPI from "@/app/lib/agoraAPI";
 import { useSignTypedData } from "wagmi";
+import { waitForTransactionReceipt } from "wagmi/actions";
+import { config } from "@/app/Web3Provider";
 import { DelegateChunk } from "@/app/api/common/delegates/delegate";
 import { useEffect, useRef, useState } from "react";
 import { useTokenName } from "@/hooks/useTokenName";
 import { withMiradorTraceHeaders } from "@/lib/mirador/headers";
 import { MIRADOR_FLOW } from "@/lib/mirador/constants";
+import { addMiradorEvent } from "@/lib/mirador/webTrace";
 import {
   attachMiradorTransactionArtifacts,
   closeFrontendMiradorFlowTrace,
@@ -29,6 +32,7 @@ const types = {
     { name: "expiry", type: "uint256" },
   ],
 };
+const SPONSORED_DELEGATION_RECEIPT_TIMEOUT_MS = 10 * 60 * 1000;
 
 export const useSponsoredDelegation = ({ address, delegate }: Props) => {
   const { ui, contracts } = Tenant.current();
@@ -36,6 +40,7 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
 
   const [isFetching, setIsFetching] = useState(false);
   const [isFetched, setIsFetched] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>(undefined);
   const traceRef = useRef<FrontendMiradorTrace>(null);
 
@@ -76,9 +81,12 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
 
     setIsFetching(true);
     setIsFetched(false);
+    setError(undefined);
+    setTxHash(undefined);
 
     const isUndelegation = delegate.address === zeroAddress;
     const action = isUndelegation ? "undelegate" : "delegate";
+    let relayTxHash: `0x${string}` | undefined;
     const inputData = encodeFunctionData({
       abi: contracts.token.abi as any,
       functionName: "delegate",
@@ -161,49 +169,70 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
         )
       );
 
-      const hash = await response.json();
+      relayTxHash = (await response.json()) as `0x${string}`;
+      setTxHash(relayTxHash);
 
       attachMiradorTransactionArtifacts(trace, {
         chainId: contracts.token.chain.id,
-        inputData,
-        txHash: hash,
+        txHash: relayTxHash,
         txDetails: isUndelegation
           ? "Sponsored undelegation transaction"
           : "Sponsored delegation transaction",
       });
+
+      addMiradorEvent(trace, "governance_delegation_submitted", {
+        delegatee: delegate.address,
+        action,
+        transactionHash: relayTxHash,
+      });
+
+      const receipt = await waitForTransactionReceipt(config, {
+        hash: relayTxHash,
+        chainId: contracts.token.chain.id,
+        timeout: SPONSORED_DELEGATION_RECEIPT_TIMEOUT_MS,
+      });
+
+      if (receipt.status !== "success") {
+        throw new Error(
+          `Sponsored delegation transaction failed with status: ${receipt.status}`
+        );
+      }
+
       void closeFrontendMiradorFlowTrace(trace, {
-        reason: "governance_delegation_submitted",
-        eventName: "governance_delegation_submitted",
+        reason: "governance_delegation_succeeded",
+        eventName: "governance_delegation_succeeded",
         details: {
           delegatee: delegate.address,
           action,
-          transactionHash: hash,
+          transactionHash: relayTxHash,
         },
       });
       if (traceRef.current === trace) {
         traceRef.current = null;
       }
 
-      setTxHash(hash);
       setIsFetched(true);
     } catch (error) {
+      const nextError =
+        error instanceof Error ? error : new Error(String(error));
+      setError(nextError);
       void closeFrontendMiradorFlowTrace(trace, {
         reason: "governance_delegation_failed",
         eventName: "governance_delegation_failed",
         details: {
           delegatee: delegate.address,
           action,
-          error: error instanceof Error ? error.message : String(error),
+          transactionHash: relayTxHash,
+          error: nextError.message,
         },
       });
       if (traceRef.current === trace) {
         traceRef.current = null;
       }
-      throw error;
     } finally {
       setIsFetching(false);
     }
   };
 
-  return { call, isFetching, isFetched, txHash };
+  return { call, isFetching, isFetched, isError: !!error, error, txHash };
 };


### PR DESCRIPTION
## Summary

This PR fixes the sponsored delegation relay flow after investigating production Mirador traces where users attempted governance delegation through `delegateBySig` and the gas relay.

The core issue was that some relayed delegation transactions were being submitted with a gas limit too close to the actual gas needed by the token contract. Successful transactions were using roughly 99% of their gas limit, and several failed transactions consumed the full gas limit and reverted out-of-gas. Separately, the frontend treated the sponsored flow as complete once the backend returned a relay transaction hash, instead of waiting for the transaction receipt and verifying that it actually succeeded on-chain.

## Investigation Findings

The broken traces were sponsored governance delegation flows on Ethereum mainnet. They all used the same relay / sponsor address:

`0x9b4B7Bd2c83B4116c2F08D2B01aE56FA55e761E1`

Three relayed transactions landed on-chain and failed by consuming the entire gas limit:

- `prod-539`: https://etherscan.io/tx/0x9580101064fd826be6cb4266ad2fc3b47209f85bf36f69bffb918c476e88d158
- `prod-569`: https://etherscan.io/tx/0x0906bb7107ce51ebc8fb52e2b495365f4c0ccf1e52302e3f079233584a06f950
- `prod-606`: https://etherscan.io/tx/0x04e7abc3e0405838ed33fcd0d0347ae5050851c20eb8b5ab27b8aa946ae9a2b9

The other failed traces in the same group timed out before we found a mined transaction, but they followed the same sponsored delegation flow pattern.

Important behavior from the investigation:

- successful relayed `delegateBySig` transactions were very close to their gas limit
- failed relayed transactions consumed the entire gas limit
- the frontend marked sponsored delegation as completed after relay submission, not after receipt success
- Mirador traces could therefore look like completed app flows even when the relayed transaction later failed on-chain

## Fixes Applied

### Add a generic gas buffer for relayed `delegateBySig`

The relay backend now estimates gas for the `delegateBySig` call and submits the sponsored transaction with a generic 30% buffer over the estimate.

This is intentionally generic:

- no Ethereum-mainnet-specific gas floor
- no tenant-specific or token-specific hardcoded minimum
- no special casing for the Uniswap Foundation flow
- the gas limit is still based on the actual contract call estimate

### Wait for sponsored transaction receipts in the frontend

`useSponsoredDelegation` now waits for the relayed transaction receipt after the backend returns the tx hash.

The sponsored flow is only marked successful after:

- the relay endpoint returns a transaction hash
- the transaction is mined
- the receipt status is `success`

If the receipt reverts, times out, or relay submission fails, the hook records an error and the dialog shows the retry state.

### Avoid duplicate receipt tracking in delegation dialogs

The delegation and undelegation dialogs no longer pass sponsored relay transaction hashes into their local `useWaitForTransactionReceipt` watchers.

Direct wallet transactions are still handled by the dialog-level receipt watcher. Sponsored relay transactions are now handled inside `useSponsoredDelegation`, because that hook owns the relay request and has the right context to distinguish submitted, succeeded, and failed sponsored flows.

### Improve Mirador trace accuracy

Sponsored delegation traces now represent the actual outcome more accurately:

- relay submission event when the backend returns a transaction hash
- success close only after a successful on-chain receipt
- failure close when relay submission fails, the receipt reverts, or the receipt wait times out
- tx hints keep readable sponsored delegation / undelegation labels

This should make future Mirador traces distinguish between user exit, relay submission failure, relayed transaction failure, and true delegation success.

## Validation

Added focused coverage for `useSponsoredDelegation`:

- successful sponsored delegation is only marked fetched after a successful receipt
- reverted sponsored delegation receipt marks the hook as errored and closes the Mirador trace as failed

Ran:

```sh
pnpm exec vitest run src/hooks/__tests__/useSponsoredDelegation.test.tsx
```