### PR TITLE
Handle relayed delegation reconciliation

### DIFF
--- a/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
+++ b/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
@@ -34,12 +34,21 @@ import { useTokenBalance } from "@/hooks/useTokenBalance";
 import { trackEvent } from "@/lib/analytics";
 import { ANALYTICS_EVENT_NAMES } from "@/lib/types.d";
 import { MIRADOR_FLOW } from "@/lib/mirador/constants";
+import { addMiradorEvent } from "@/lib/mirador/webTrace";
 import {
   attachMiradorTransactionArtifacts,
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
 } from "@/lib/mirador/frontendFlowTrace";
+
+function getErrorMessage(error: unknown) {
+  if (!error) {
+    return undefined;
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
 
 export function DelegateDialog({
   delegate,
@@ -54,6 +63,7 @@ export function DelegateDialog({
 }) {
   const shouldFetchData = useRef(true);
   const delegationTraceRef = useRef<FrontendMiradorTrace>(null);
+  const directDelegationAttemptErrorRef = useRef<string | undefined>(undefined);
   const [isReady, setIsReady] = useState(false);
   const { ui, contracts, token } = Tenant.current();
   const shouldHideAgoraBranding = ui.hideAgoraBranding;
@@ -108,6 +118,7 @@ export function DelegateDialog({
 
   const {
     isError,
+    error: writeError,
     writeContract: write,
     data: delegateTxHash,
   } = useWriteContract();
@@ -121,9 +132,12 @@ export function DelegateDialog({
     isLoading: isProcessingDelegation,
     isSuccess: didProcessDelegation,
     isError: didFailDelegation,
+    error: receiptError,
   } = useWaitForTransactionReceipt({
     hash: isGasRelayLive ? undefined : (localDelegateTxHash ?? delegateTxHash),
   });
+  const writeErrorMessage = getErrorMessage(writeError);
+  const receiptErrorMessage = getErrorMessage(receiptError);
 
   const fetchData = async () => {
     if (shouldFetchData.current && accountAddress) {
@@ -180,19 +194,31 @@ export function DelegateDialog({
         },
       });
       delegationTraceRef.current = null;
+      directDelegationAttemptErrorRef.current = undefined;
       return;
     }
 
     if (didFailDelegation || isError) {
+      const directAttemptError = directDelegationAttemptErrorRef.current;
       void closeFrontendMiradorFlowTrace(delegationTraceRef.current, {
         reason: "governance_delegation_failed",
         eventName: "governance_delegation_failed",
         details: {
           delegatee: delegate.address,
-          error: "Delegation transaction failed",
+          action: "delegate",
+          transactionHash: directDelegationTxHash,
+          error:
+            receiptErrorMessage ||
+            writeErrorMessage ||
+            directAttemptError ||
+            "Delegation transaction failed",
+          directAttemptError,
+          walletError: writeErrorMessage,
+          receiptError: receiptErrorMessage,
         },
       });
       delegationTraceRef.current = null;
+      directDelegationAttemptErrorRef.current = undefined;
     }
   }, [
     contracts.token.chain.id,
@@ -202,6 +228,8 @@ export function DelegateDialog({
     directDelegationTxHash,
     isError,
     isGasRelayLive,
+    receiptErrorMessage,
+    writeErrorMessage,
   ]);
 
   useEffect(() => {
@@ -225,6 +253,7 @@ export function DelegateDialog({
     if (isGasRelayLive) {
       await call();
     } else {
+      directDelegationAttemptErrorRef.current = undefined;
       if (delegationTraceRef.current) {
         void closeFrontendMiradorFlowTrace(delegationTraceRef.current, {
           reason: "governance_delegation_restarted",
@@ -293,6 +322,15 @@ export function DelegateDialog({
         setLocalDelegateTxHash(txHash);
       } catch (error) {
         console.error("delegate via viem failed", error);
+        const directAttemptError = getErrorMessage(error);
+        directDelegationAttemptErrorRef.current = directAttemptError;
+        addMiradorEvent(trace, "governance_delegation_direct_attempt_failed", {
+          delegatee: delegate.address,
+          action: "delegate",
+          phase: "viem_simulate_or_write",
+          error: directAttemptError,
+          fallback: "wagmi_write",
+        });
         // Fallback to wagmi write (may still fail under Safe CAIP-2)
         try {
           write({
@@ -304,20 +342,22 @@ export function DelegateDialog({
           });
         } catch (innerError) {
           console.error("delegate via wagmi fallback failed", innerError);
+          const fallbackError = getErrorMessage(innerError);
           void closeFrontendMiradorFlowTrace(trace, {
             reason: "governance_delegation_failed",
             eventName: "governance_delegation_failed",
             details: {
               delegatee: delegate.address,
-              error:
-                innerError instanceof Error
-                  ? innerError.message
-                  : String(innerError),
+              action: "delegate",
+              phase: "wagmi_write",
+              error: fallbackError,
+              directAttemptError,
             },
           });
           if (delegationTraceRef.current === trace) {
             delegationTraceRef.current = null;
           }
+          directDelegationAttemptErrorRef.current = undefined;
         }
       }
     }

--- a/src/components/Dialogs/UndelegateDialog/UndelegateDialog.tsx
+++ b/src/components/Dialogs/UndelegateDialog/UndelegateDialog.tsx
@@ -25,12 +25,21 @@ import { useSponsoredDelegation } from "@/hooks/useSponsoredDelegation";
 import { useEthBalance } from "@/hooks/useEthBalance";
 import { UIGasRelayConfig } from "@/lib/tenant/tenantUI";
 import { MIRADOR_FLOW } from "@/lib/mirador/constants";
+import { addMiradorEvent } from "@/lib/mirador/webTrace";
 import {
   attachMiradorTransactionArtifacts,
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
 } from "@/lib/mirador/frontendFlowTrace";
+
+function getErrorMessage(error: unknown) {
+  if (!error) {
+    return undefined;
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
 
 interface UndelegateActionButtonsProps {
   isDisabledInTenant: boolean;
@@ -174,6 +183,7 @@ export function UndelegateDialog({
 
   const {
     isError,
+    error: writeError,
     writeContract: write,
     data: delegateTxHash,
   } = useWriteContract();
@@ -182,9 +192,12 @@ export function UndelegateDialog({
     isLoading: isProcessingDelegation,
     isSuccess: didProcessDelegation,
     isError: didFailDelegation,
+    error: receiptError,
   } = useWaitForTransactionReceipt({
     hash: isGasRelayLive ? undefined : delegateTxHash,
   });
+  const writeErrorMessage = getErrorMessage(writeError);
+  const receiptErrorMessage = getErrorMessage(receiptError);
 
   const fetchData = useCallback(async () => {
     setIsReady(false);
@@ -244,13 +257,36 @@ export function UndelegateDialog({
         chainId: contracts.token.chain.id,
         inputData,
       });
-      write({
-        address: contracts.token.address as any,
-        abi: contracts.token.abi,
-        functionName: "delegate",
-        args: [zeroAddress],
-        chainId: contracts.token.chain.id,
-      });
+      try {
+        write({
+          address: contracts.token.address as any,
+          abi: contracts.token.abi,
+          functionName: "delegate",
+          args: [zeroAddress],
+          chainId: contracts.token.chain.id,
+        });
+      } catch (error) {
+        const walletError = getErrorMessage(error);
+        addMiradorEvent(trace, "governance_delegation_direct_attempt_failed", {
+          delegatee: zeroAddress,
+          action: "undelegate",
+          phase: "wagmi_write",
+          error: walletError,
+        });
+        void closeFrontendMiradorFlowTrace(trace, {
+          reason: "governance_delegation_failed",
+          eventName: "governance_delegation_failed",
+          details: {
+            delegatee: zeroAddress,
+            action: "undelegate",
+            phase: "wagmi_write",
+            error: walletError,
+          },
+        });
+        if (delegationTraceRef.current === trace) {
+          delegationTraceRef.current = null;
+        }
+      }
     }
   };
 
@@ -305,12 +341,25 @@ export function UndelegateDialog({
         details: {
           delegatee: zeroAddress,
           action: "undelegate",
-          error: "Undelegation transaction failed",
+          transactionHash: delegateTxHash,
+          error:
+            receiptErrorMessage ||
+            writeErrorMessage ||
+            "Undelegation transaction failed",
+          walletError: writeErrorMessage,
+          receiptError: receiptErrorMessage,
         },
       });
       delegationTraceRef.current = null;
     }
-  }, [didFailDelegation, isError, isGasRelayLive]);
+  }, [
+    delegateTxHash,
+    didFailDelegation,
+    isError,
+    isGasRelayLive,
+    receiptErrorMessage,
+    writeErrorMessage,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/src/hooks/__tests__/useSponsoredDelegation.test.tsx
+++ b/src/hooks/__tests__/useSponsoredDelegation.test.tsx
@@ -325,7 +325,9 @@ describe("useSponsoredDelegation", () => {
         }),
       })
     );
-    expect(result.current.txHash).toBe(undefined);
+    expect(result.current.txHash).toBe(
+      "0x000000000000000000000000000000000000000000000000000000000000000a"
+    );
     expect(result.current.isFetched).toBe(true);
     expect(result.current.isError).toBe(false);
   });

--- a/src/hooks/__tests__/useSponsoredDelegation.test.tsx
+++ b/src/hooks/__tests__/useSponsoredDelegation.test.tsx
@@ -11,6 +11,7 @@ const {
   closeFrontendMiradorFlowTraceMock,
   getFrontendMiradorTraceContextMock,
   postMock,
+  readContractMock,
   signTypedDataAsyncMock,
   startFrontendMiradorFlowTraceMock,
   useNonceMock,
@@ -23,6 +24,7 @@ const {
   closeFrontendMiradorFlowTraceMock: vi.fn(),
   getFrontendMiradorTraceContextMock: vi.fn(),
   postMock: vi.fn(),
+  readContractMock: vi.fn(),
   signTypedDataAsyncMock: vi.fn(),
   startFrontendMiradorFlowTraceMock: vi.fn(),
   useNonceMock: vi.fn(),
@@ -64,6 +66,12 @@ vi.mock("@/hooks/useTokenName", () => ({
 vi.mock("@/app/lib/agoraAPI", () => ({
   default: vi.fn().mockImplementation(() => ({
     post: postMock,
+  })),
+}));
+
+vi.mock("@/lib/viem", () => ({
+  getPublicClient: vi.fn(() => ({
+    readContract: readContractMock,
   })),
 }));
 
@@ -134,6 +142,9 @@ describe("useSponsoredDelegation", () => {
         ),
     });
     waitForTransactionReceiptMock.mockResolvedValue({ status: "success" });
+    readContractMock.mockResolvedValue(
+      "0x0000000000000000000000000000000000000000"
+    );
   });
 
   it("marks a sponsored delegation as fetched only after a successful receipt", async () => {
@@ -217,5 +228,105 @@ describe("useSponsoredDelegation", () => {
     );
     expect(result.current.isFetched).toBe(false);
     expect(result.current.isError).toBe(true);
+  });
+
+  it("marks a sponsored delegation as fetched when the relay request fails after the chain state already changed", async () => {
+    postMock.mockRejectedValue(new Error("Internal Server Error"));
+    readContractMock.mockResolvedValue(
+      "0x0000000000000000000000000000000000000003"
+    );
+
+    const { result } = renderHook(() =>
+      useSponsoredDelegation({
+        address: "0x0000000000000000000000000000000000000002",
+        delegate: {
+          address: "0x0000000000000000000000000000000000000003",
+          votingPower: { total: "0", direct: "0", advanced: "0" },
+          statement: null,
+          participation: 0,
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.call();
+    });
+
+    expect(readContractMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "delegates",
+        args: ["0x0000000000000000000000000000000000000002"],
+      })
+    );
+    expect(addMiradorEventMock).toHaveBeenCalledWith(
+      { traceId: "trace-id" },
+      "governance_delegation_reconciliation_checked",
+      expect.objectContaining({
+        reconciled: true,
+        originalError: "Internal Server Error",
+      })
+    );
+    expect(closeFrontendMiradorFlowTraceMock).toHaveBeenCalledWith(
+      { traceId: "trace-id" },
+      expect.objectContaining({
+        reason: "governance_delegation_succeeded",
+        details: expect.objectContaining({
+          reconciled: true,
+          currentDelegatee: "0x0000000000000000000000000000000000000003",
+        }),
+      })
+    );
+    expect(waitForTransactionReceiptMock).not.toHaveBeenCalled();
+    expect(result.current.isFetched).toBe(true);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("marks a sponsored delegation as fetched when receipt waiting fails but the chain state matches", async () => {
+    waitForTransactionReceiptMock.mockRejectedValue(
+      new Error("Timed out while waiting for transaction receipt")
+    );
+    readContractMock.mockResolvedValue(
+      "0x0000000000000000000000000000000000000003"
+    );
+
+    const { result } = renderHook(() =>
+      useSponsoredDelegation({
+        address: "0x0000000000000000000000000000000000000002",
+        delegate: {
+          address: "0x0000000000000000000000000000000000000003",
+          votingPower: { total: "0", direct: "0", advanced: "0" },
+          statement: null,
+          participation: 0,
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.call();
+    });
+
+    expect(addMiradorEventMock).toHaveBeenCalledWith(
+      { traceId: "trace-id" },
+      "governance_delegation_reconciliation_checked",
+      expect.objectContaining({
+        transactionHash:
+          "0x000000000000000000000000000000000000000000000000000000000000000a",
+        reconciled: true,
+      })
+    );
+    expect(closeFrontendMiradorFlowTraceMock).toHaveBeenCalledWith(
+      { traceId: "trace-id" },
+      expect.objectContaining({
+        reason: "governance_delegation_succeeded",
+        details: expect.objectContaining({
+          reconciled: true,
+          originalTransactionHash:
+            "0x000000000000000000000000000000000000000000000000000000000000000a",
+        }),
+      })
+    );
+    expect(result.current.txHash).toBe(undefined);
+    expect(result.current.isFetched).toBe(true);
+    expect(result.current.isError).toBe(false);
   });
 });

--- a/src/hooks/useSponsoredDelegation.ts
+++ b/src/hooks/useSponsoredDelegation.ts
@@ -9,6 +9,7 @@ import { config } from "@/app/Web3Provider";
 import { DelegateChunk } from "@/app/api/common/delegates/delegate";
 import { useEffect, useRef, useState } from "react";
 import { useTokenName } from "@/hooks/useTokenName";
+import { getPublicClient } from "@/lib/viem";
 import { withMiradorTraceHeaders } from "@/lib/mirador/headers";
 import { MIRADOR_FLOW } from "@/lib/mirador/constants";
 import { addMiradorEvent } from "@/lib/mirador/webTrace";
@@ -33,6 +34,14 @@ const types = {
   ],
 };
 const SPONSORED_DELEGATION_RECEIPT_TIMEOUT_MS = 10 * 60 * 1000;
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function addressesMatch(first: string, second: string) {
+  return first.toLowerCase() === second.toLowerCase();
+}
 
 export const useSponsoredDelegation = ({ address, delegate }: Props) => {
   const { ui, contracts } = Tenant.current();
@@ -87,6 +96,7 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
     const isUndelegation = delegate.address === zeroAddress;
     const action = isUndelegation ? "undelegate" : "delegate";
     let relayTxHash: `0x${string}` | undefined;
+    let didSubmitRelayRequest = false;
     const inputData = encodeFunctionData({
       abi: contracts.token.abi as any,
       functionName: "delegate",
@@ -153,6 +163,7 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
       });
 
       const agoraAPI = new AgoraAPI();
+      didSubmitRelayRequest = true;
       const response = await agoraAPI.post(
         "/relay/delegate",
         "v1",
@@ -215,6 +226,73 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
     } catch (error) {
       const nextError =
         error instanceof Error ? error : new Error(String(error));
+
+      if (address && (didSubmitRelayRequest || relayTxHash)) {
+        try {
+          const currentDelegatee = (await getPublicClient(
+            contracts.token.chain
+          ).readContract({
+            address: contracts.token.address as Address,
+            abi: contracts.token.abi as any,
+            functionName: "delegates",
+            args: [address],
+          })) as Address;
+
+          const isDelegateStateReconciled = addressesMatch(
+            currentDelegatee,
+            delegate.address
+          );
+
+          addMiradorEvent(
+            trace,
+            "governance_delegation_reconciliation_checked",
+            {
+              delegatee: delegate.address,
+              action,
+              currentDelegatee,
+              transactionHash: relayTxHash,
+              originalError: nextError.message,
+              reconciled: isDelegateStateReconciled,
+            }
+          );
+
+          if (isDelegateStateReconciled) {
+            setError(undefined);
+            setTxHash(undefined);
+            setIsFetched(true);
+
+            void closeFrontendMiradorFlowTrace(trace, {
+              reason: "governance_delegation_succeeded",
+              eventName: "governance_delegation_succeeded",
+              details: {
+                delegatee: delegate.address,
+                action,
+                currentDelegatee,
+                originalTransactionHash: relayTxHash,
+                originalError: nextError.message,
+                reconciled: true,
+              },
+            });
+            if (traceRef.current === trace) {
+              traceRef.current = null;
+            }
+            return;
+          }
+        } catch (reconciliationError) {
+          addMiradorEvent(
+            trace,
+            "governance_delegation_reconciliation_failed",
+            {
+              delegatee: delegate.address,
+              action,
+              transactionHash: relayTxHash,
+              originalError: nextError.message,
+              reconciliationError: getErrorMessage(reconciliationError),
+            }
+          );
+        }
+      }
+
       setError(nextError);
       void closeFrontendMiradorFlowTrace(trace, {
         reason: "governance_delegation_failed",

--- a/src/hooks/useSponsoredDelegation.ts
+++ b/src/hooks/useSponsoredDelegation.ts
@@ -258,7 +258,7 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
 
           if (isDelegateStateReconciled) {
             setError(undefined);
-            setTxHash(undefined);
+            setTxHash(relayTxHash);
             setIsFetched(true);
 
             void closeFrontendMiradorFlowTrace(trace, {


### PR DESCRIPTION
## Summary

This fixes a sponsored delegation edge case we found while looking through Mirador traces: the app could show a failed delegation even when the relay eventually completed and the token contract already showed the requested delegate.

## What Changed

- After a sponsored relay error, the app now checks the final onchain `delegates(user)` value.
- If that value already matches the requested delegate, or `zeroAddress` for undelegation, we treat the flow as successful instead of leaving the user in a failed state.
- Direct delegate and undelegate failures now include the actual wallet/write/receipt error details in Mirador, instead of only a generic `transaction failed` message.
- Added tests for the relay failure cases where final onchain state is already correct.