### PR TITLE
Backport vote history sorting to Uniswap release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.0.7",
         "@tanstack/react-query": "^5.27.5",
+        "@tanstack/react-virtual": "^3.13.12",
         "@tiptap/core": "^3.1.0",
         "@tiptap/extension-blockquote": "^3.1.0",
         "@tiptap/extension-bold": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-query": "^5.27.5",
+    "@tanstack/react-virtual": "^3.13.12",
     "@tiptap/core": "^3.1.0",
     "@tiptap/extension-blockquote": "^3.1.0",
     "@tiptap/extension-bold": "^3.1.0",

--- a/src/app/api/archive/non-voters/[proposalId]/route.ts
+++ b/src/app/api/archive/non-voters/[proposalId]/route.ts
@@ -1,9 +1,52 @@
 import { type NextRequest, NextResponse } from "next/server";
 import Tenant from "@/lib/tenant/tenant";
 import { fetchRawProposalNonVotersFromArchive } from "@/lib/archiveUtils";
+import type {
+  VotesSort,
+  VotesSortOrder,
+  VoterTypes,
+} from "@/app/api/common/votes/vote";
+import {
+  buildArchiveNonVotersResult,
+  DEFAULT_ARCHIVE_TOKEN_DECIMALS,
+  transformArchiveNonVoterRows,
+} from "@/lib/archiveVoteHistory";
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 250;
+
+function parsePositiveInt(value: string | null, fallback: number) {
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) && parsedValue > 0
+    ? Math.trunc(parsedValue)
+    : fallback;
+}
+
+function parseOffset(value: string | null) {
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) && parsedValue > 0
+    ? Math.trunc(parsedValue)
+    : 0;
+}
+
+function emptyResponse(request: NextRequest) {
+  const hasPagination = new URL(request.url).searchParams.has("limit");
+  if (!hasPagination) {
+    return NextResponse.json({ data: [] });
+  }
+
+  return NextResponse.json({
+    meta: {
+      has_next: false,
+      total_returned: 0,
+      next_offset: 0,
+    },
+    data: [],
+  });
+}
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { proposalId: string } }
 ) {
   const { proposalId } = params;
@@ -14,19 +57,48 @@ export async function GET(
   const { namespace } = Tenant.current();
 
   try {
-    // Fetch raw non-voter data from archive - transformation happens on client side
+    // Keep the legacy raw response for callers that have not opted into paging.
     const rawNonVoters = await fetchRawProposalNonVotersFromArchive({
       namespace,
       proposalId,
     });
 
-    return NextResponse.json({ data: rawNonVoters });
+    const url = new URL(request.url);
+    const limitParam = url.searchParams.get("limit");
+    if (!limitParam) {
+      return NextResponse.json({ data: rawNonVoters });
+    }
+
+    const limit = Math.min(
+      parsePositiveInt(limitParam, DEFAULT_LIMIT),
+      MAX_LIMIT
+    );
+    const offset = parseOffset(url.searchParams.get("offset"));
+    const sort = (url.searchParams.get("sort") || "weight") as VotesSort;
+    const sortOrder = (url.searchParams.get("sortOrder") ||
+      "desc") as VotesSortOrder;
+    const voterType = (url.searchParams.get("voterType") ||
+      "ALL") as VoterTypes["type"];
+    const tokenDecimals =
+      Tenant.current().token.decimals ?? DEFAULT_ARCHIVE_TOKEN_DECIMALS;
+
+    const transformedNonVoters = transformArchiveNonVoterRows(rawNonVoters);
+    return NextResponse.json(
+      buildArchiveNonVotersResult({
+        nonVoters: transformedNonVoters,
+        pagination: { limit, offset },
+        sort,
+        sortOrder,
+        voterType,
+        tokenDecimals,
+      })
+    );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (errorMessage.includes("404") || errorMessage.includes("Not Found")) {
-      return NextResponse.json({ data: [] });
+      return emptyResponse(request);
     }
     console.error("Error fetching archive non-voters:", error);
-    return NextResponse.json({ data: [] });
+    return emptyResponse(request);
   }
 }

--- a/src/app/api/common/votes/__tests__/cplsNonVoters.test.ts
+++ b/src/app/api/common/votes/__tests__/cplsNonVoters.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCplsSnapshotNonVotersResult,
+  CPLS_SNAPSHOT_VOTING_POWER_SOURCE,
+} from "../cplsNonVoters";
+import type { ArchiveNonVoterRow } from "@/lib/archiveUtils";
+
+describe("buildCplsSnapshotNonVotersResult", () => {
+  const rows: ArchiveNonVoterRow[] = [
+    {
+      addr: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      vp: "100000000000000000000",
+    },
+    {
+      addr: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      vp: "149000000000000000000000",
+      ens: "carlg.eth",
+    },
+    {
+      addr: "0xcccccccccccccccccccccccccccccccccccccccc",
+      vp: "103900000000000000000000",
+    },
+  ];
+
+  it("sorts CPLS non-voters by snapshot VP descending", () => {
+    const result = buildCplsSnapshotNonVotersResult({
+      namespace: "demo",
+      pagination: { offset: 0, limit: 20 },
+      rows,
+      sort: "weight",
+      sortOrder: "desc",
+      type: "TH",
+    });
+
+    expect(result.data.map((row) => row.delegate)).toEqual([
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+    expect(result.data[0].voterMetadata?.name).toBe("carlg.eth");
+    expect(result.data[0].votingPowerSource).toBe(
+      CPLS_SNAPSHOT_VOTING_POWER_SOURCE
+    );
+  });
+
+  it("sorts CPLS non-voters by snapshot VP ascending and paginates", () => {
+    const result = buildCplsSnapshotNonVotersResult({
+      namespace: "demo",
+      pagination: { offset: 1, limit: 1 },
+      rows,
+      sort: "weight",
+      sortOrder: "asc",
+      type: "TH",
+    });
+
+    expect(result.data.map((row) => row.delegate)).toEqual([
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+    ]);
+    expect(result.meta).toEqual({
+      has_next: true,
+      total_returned: 1,
+      next_offset: 2,
+    });
+  });
+
+  it("filters Optimism rows by voter type and deduplicates within each voter type", () => {
+    const result = buildCplsSnapshotNonVotersResult({
+      namespace: "optimism",
+      pagination: { offset: 0, limit: 20 },
+      rows: [
+        ...rows,
+        {
+          addr: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          vp: "1",
+        },
+        {
+          addr: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          vp: "1",
+          citizen_type: "user",
+          name: "Citizen User",
+        },
+        {
+          addr: "0xdddddddddddddddddddddddddddddddddddddddd",
+          vp: "1",
+          citizen_type: "app",
+        },
+      ],
+      sort: "weight",
+      sortOrder: "desc",
+      type: "USER",
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({
+      delegate: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      citizen_type: "user",
+      voterMetadata: {
+        name: "Citizen User",
+        image: "",
+        type: "user",
+      },
+    });
+  });
+
+  it("uses deterministic delegate ordering for block_number sort", () => {
+    const result = buildCplsSnapshotNonVotersResult({
+      namespace: "demo",
+      pagination: { offset: 0, limit: 20 },
+      rows,
+      sort: "block_number",
+      sortOrder: "desc",
+      type: "TH",
+    });
+
+    expect(result.data.map((row) => row.delegate)).toEqual([
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+  });
+});

--- a/src/app/api/common/votes/cplsNonVoters.ts
+++ b/src/app/api/common/votes/cplsNonVoters.ts
@@ -1,0 +1,44 @@
+import type { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
+import { TENANT_NAMESPACES } from "@/lib/constants";
+import type { ArchiveNonVoterRow } from "@/lib/archiveUtils";
+import type { VoterTypes, VotesSort, VotesSortOrder } from "./vote";
+import {
+  buildArchiveNonVotersResult,
+  transformArchiveNonVoterRows,
+  type ArchiveNonVoter,
+} from "@/lib/archiveVoteHistory";
+
+export const CPLS_SNAPSHOT_VOTING_POWER_SOURCE = "cpls_snapshot";
+
+export type CplsSnapshotNonVoter = ArchiveNonVoter & {
+  votingPowerSource: typeof CPLS_SNAPSHOT_VOTING_POWER_SOURCE;
+};
+
+export function buildCplsSnapshotNonVotersResult({
+  namespace,
+  pagination,
+  rows,
+  sort = "weight",
+  sortOrder = "desc",
+  type = "TH",
+}: {
+  namespace: string;
+  pagination: PaginationParams;
+  rows: ArchiveNonVoterRow[];
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  type?: VoterTypes["type"];
+}): PaginatedResult<CplsSnapshotNonVoter[]> {
+  const nonVoters = transformArchiveNonVoterRows(rows, {
+    votingPowerSource: CPLS_SNAPSHOT_VOTING_POWER_SOURCE,
+  });
+  const voterType = namespace === TENANT_NAMESPACES.OPTIMISM ? type : "ALL";
+
+  return buildArchiveNonVotersResult({
+    nonVoters,
+    pagination,
+    sort,
+    sortOrder,
+    voterType,
+  });
+}

--- a/src/app/api/common/votes/getVotes.ts
+++ b/src/app/api/common/votes/getVotes.ts
@@ -6,13 +6,14 @@ import {
 import { ParsedProposalData, parseProposalData } from "@/lib/proposalUtils";
 import { parseSnapshotVote, parseVote } from "@/lib/voteUtils";
 import { cache } from "react";
-import {
+import type {
   SnapshotVote,
   SnapshotVotePayload,
   Vote,
   VotePayload,
   VoterTypes,
   VotesSort,
+  VotesSortOrder,
 } from "./vote";
 import { prismaWeb3Client } from "@/app/lib/prisma";
 import { addressOrEnsNameWrap } from "../utils/ensName";
@@ -24,7 +25,11 @@ import { Block } from "ethers";
 import { withMetrics } from "@/lib/metricWrapper";
 import { unstable_cache } from "next/cache";
 import { ProposalType } from "@/lib/types";
-import { fetchProposalFromArchive } from "@/lib/archiveUtils";
+import {
+  fetchProposalFromArchive,
+  fetchRawProposalNonVotersFromArchive,
+} from "@/lib/archiveUtils";
+import { buildCplsSnapshotNonVotersResult } from "./cplsNonVoters";
 
 const getVotesForDelegate = ({
   addressOrENSName,
@@ -385,19 +390,23 @@ function buildHasVotedQuery(
   type: VoterTypes["type"],
   offchainProposalId?: string
 ): string {
-  const isTokenHouse = type === "TH";
+  const isTokenHouse =
+    type === "TH" || namespace !== TENANT_NAMESPACES.OPTIMISM;
+  const isAll = type === "ALL" && namespace === TENANT_NAMESPACES.OPTIMISM;
 
-  if (isTokenHouse) {
-    // Token House: Check onchain votes and snapshot votes
-    return `
+  const thQuery = `
       SELECT voter FROM ${namespace}.vote_cast_events WHERE proposal_id = $1 and contract = $3
       UNION ALL
       SELECT voter FROM ${namespace}.${eventsViewName} WHERE proposal_id = $1 and contract = $3
       UNION ALL
       SELECT voter FROM "snapshot".votes WHERE proposal_id = $1 and dao_slug = '${slug}'`;
-  }
 
-  return `SELECT LOWER("voter") as voter FROM atlas."votes_with_meta_mat" WHERE "proposal_id" = ${offchainProposalId ? "$6" : "$1"}`;
+  const chQuery = `SELECT LOWER("voter") as voter FROM atlas."votes_with_meta_mat" WHERE "proposal_id" = ${offchainProposalId ? "$6" : "$1"}`;
+
+  if (isTokenHouse) return thQuery;
+  if (isAll) return `${thQuery} UNION ALL ${chQuery}`;
+
+  return chQuery;
 }
 
 /**
@@ -423,14 +432,14 @@ function buildRelevantDelegatesQuery(
   namespace: string,
   type: VoterTypes["type"]
 ): string {
-  const isTokenHouse = type === "TH";
+  const isTokenHouse =
+    type === "TH" || namespace !== TENANT_NAMESPACES.OPTIMISM;
+  const isAll = type === "ALL" && namespace === TENANT_NAMESPACES.OPTIMISM;
 
-  if (isTokenHouse) {
-    return `SELECT delegate, voting_power, NULL::text as citizen_type, NULL::text as voter_metadata_text FROM ${namespace}.delegates where contract = $2`;
-  }
+  const thQuery = `SELECT delegate, voting_power, NULL::text as citizen_type, NULL::text as voter_metadata_text FROM ${namespace}.delegates where contract = $2`;
 
   const citizenTypeFilter = getCitizenTypeFilter(type);
-  return `
+  const chQuery = `
       SELECT 
         c."address" as delegate, 
         1 as voting_power, 
@@ -438,6 +447,11 @@ function buildRelevantDelegatesQuery(
         voter_metadata_text
       FROM atlas.citizens_mat c
       WHERE ${citizenTypeFilter}`;
+
+  if (isTokenHouse) return thQuery;
+  if (isAll) return `${thQuery} UNION ALL ${chQuery}`;
+
+  return chQuery;
 }
 
 async function getVotersWhoHaveNotVotedForProposal({
@@ -445,14 +459,41 @@ async function getVotersWhoHaveNotVotedForProposal({
   pagination = { offset: 0, limit: 20 },
   offchainProposalId,
   type = "TH",
+  sort = "weight",
+  sortOrder = "desc",
 }: {
   proposalId: string;
   pagination?: PaginationParams;
   offchainProposalId?: string;
   type?: VoterTypes["type"];
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
 }) {
   return withMetrics("getVotersWhoHaveNotVotedForProposal", async () => {
     const { namespace, contracts, slug } = Tenant.current();
+
+    try {
+      const cplsNonVoterRows = await fetchRawProposalNonVotersFromArchive({
+        namespace,
+        proposalId,
+      });
+
+      if (cplsNonVoterRows.length > 0) {
+        return buildCplsSnapshotNonVotersResult({
+          namespace,
+          pagination,
+          rows: cplsNonVoterRows,
+          sort,
+          sortOrder,
+          type,
+        });
+      }
+    } catch (error) {
+      console.warn(
+        "Falling back to indexed non-voter voting power after CPLS fetch failed",
+        error
+      );
+    }
 
     const eventsViewName =
       namespace === TENANT_NAMESPACES.OPTIMISM
@@ -498,7 +539,7 @@ async function getVotersWhoHaveNotVotedForProposal({
           LEFT JOIN agora.delegate_statements ds ON 
             del.delegate = ds.address
             AND ds.dao_slug = 'OP'
-          ORDER BY del.delegate, del.voting_power DESC
+          ORDER BY del.delegate, ${sort === "block_number" ? "del.delegate" : "del.voting_power"} ${sortOrder === "asc" ? "ASC" : "DESC"}
         )
         SELECT 
           delegate, 
@@ -509,7 +550,7 @@ async function getVotersWhoHaveNotVotedForProposal({
           discord,
           warpcast
         FROM unique_delegates
-        ORDER BY voting_power DESC
+        ORDER BY ${sort === "block_number" ? "delegate" : "voting_power"} ${sortOrder === "asc" ? "ASC" : "DESC"}, delegate ASC
         OFFSET $4 LIMIT $5`;
 
       const params = [
@@ -587,11 +628,15 @@ async function getVotesForProposal({
   pagination = { offset: 0, limit: 20 },
   sort = "weight",
   offchainProposalId,
+  sortOrder = "desc",
+  voterType = "ALL",
 }: {
   proposalId: string;
   pagination?: PaginationParams;
   sort?: VotesSort;
   offchainProposalId?: string;
+  sortOrder?: VotesSortOrder;
+  voterType?: VoterTypes["type"];
 }): Promise<PaginatedResult<Vote[]>> {
   return withMetrics(
     "getVotesForProposal",
@@ -687,6 +732,7 @@ async function getVotesForProposal({
               WHERE proposal_id = $1 AND contract = $2
               ${includeCitizens ? citizenQuery : ""}
             ) t
+            ${voterType !== "ALL" && voterType ? `WHERE ${voterType === "TH" ? "citizen_type IS NULL" : getCitizenTypeFilter(voterType)}` : ""}
             GROUP BY 2,3,4,8,9
             ) av
             LEFT JOIN LATERAL (
@@ -697,7 +743,7 @@ async function getVotesForProposal({
               FROM ${namespace}.proposals_v2 proposals
               WHERE proposals.proposal_id = $1 AND proposals.contract = $2) p ON TRUE
           ) q
-          ORDER BY citizen_type IS NOT NULL DESC, ${sort} DESC
+          ORDER BY ${sort === "block_number" ? "block_number" : "weight"} ${sortOrder === "asc" ? "ASC" : "DESC"}, voter ASC
           OFFSET $3
           LIMIT $4;`;
 

--- a/src/app/api/common/votes/vote.d.ts
+++ b/src/app/api/common/votes/vote.d.ts
@@ -57,6 +57,11 @@ export type SnapshotVote = {
   title: string;
   reason: string;
   choiceLabels: Record<string, any>;
+  voterMetadata?: {
+    name: string | null;
+    image: string | null;
+    type: string | null;
+  } | null;
 };
 
 export type DelegatesSort =

--- a/src/app/api/proposals/getVotesChart.ts
+++ b/src/app/api/proposals/getVotesChart.ts
@@ -1,6 +1,9 @@
 import Tenant from "@/lib/tenant/tenant";
 import { TENANT_NAMESPACES } from "@/lib/constants";
-import { SnapshotVotePayload, VotePayload } from "@/app/api/common/votes/vote";
+import type {
+  SnapshotVotePayload,
+  VotePayload,
+} from "@/app/api/common/votes/vote";
 import { prismaWeb3Client } from "@/app/lib/prisma";
 import { fetchRawProposalVotesFromArchive } from "@/lib/archiveUtils";
 

--- a/src/app/proposals/[proposal_id]/page.tsx
+++ b/src/app/proposals/[proposal_id]/page.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/app/api/common/proposals/getProposals";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import { fetchVotableSupplyUnstableCache } from "@/app/api/common/votableSupply/getVotableSupply";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { cleanString, truncateString } from "@/app/lib/utils/text";
 import CopelandProposalPage from "@/components/Proposals/ProposalPage/CopelandProposalPage/CopelandProposalPage";
 import OPProposalApprovalPage from "@/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage";

--- a/src/app/proposals/actions.tsx
+++ b/src/app/proposals/actions.tsx
@@ -8,7 +8,11 @@ import {
 } from "@/app/api/common/votes/getVotes";
 import { getProposalsCount } from "@/lib/prismaUtils";
 import { PaginationParams } from "../lib/pagination";
-import { VoterTypes, VotesSort } from "../api/common/votes/vote";
+import {
+  VoterTypes,
+  VotesSort,
+  VotesSortOrder,
+} from "../api/common/votes/vote";
 import Tenant from "@/lib/tenant/tenant";
 
 export async function fetchProposalsCount() {
@@ -23,26 +27,34 @@ export const fetchVotersWhoHaveNotVotedForProposal = (
   proposalId: string,
   pagination?: PaginationParams,
   offchainProposalId?: string,
-  type?: VoterTypes["type"]
+  type?: VoterTypes["type"],
+  sort?: VotesSort,
+  sortOrder?: VotesSortOrder
 ) =>
   apiFetchVotersWhoHaveNotVotedForProposal({
     proposalId,
     pagination,
     offchainProposalId,
     type,
+    sort,
+    sortOrder,
   });
 
 export const fetchProposalVotes = (
   proposalId: string,
   pagination?: PaginationParams,
   sort?: VotesSort,
-  offchainProposalId?: string
+  offchainProposalId?: string,
+  sortOrder?: VotesSortOrder,
+  voterType?: VoterTypes["type"]
 ) =>
   apiFetchVotesForProposal({
     proposalId,
     pagination,
     sort,
     offchainProposalId,
+    sortOrder,
+    voterType,
   });
 
 export const fetchSnapshotProposalVotes = (

--- a/src/components/Delegates/DelegateVotes/ApprovalVoteReason.tsx
+++ b/src/components/Delegates/DelegateVotes/ApprovalVoteReason.tsx
@@ -1,4 +1,4 @@
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import React, { Fragment } from "react";
 import Markdown from "@/components/shared/Markdown/Markdown";
 

--- a/src/components/Delegates/DelegateVotes/DelegateVoteIcon.tsx
+++ b/src/components/Delegates/DelegateVotes/DelegateVoteIcon.tsx
@@ -1,4 +1,4 @@
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import {
   CheckIcon,
   XMarkIcon,

--- a/src/components/Delegates/DelegateVotes/DelegateVotes.tsx
+++ b/src/components/Delegates/DelegateVotes/DelegateVotes.tsx
@@ -11,7 +11,7 @@ import ApprovalVoteReason from "./ApprovalVoteReason";
 import { pluralizeVote } from "@/lib/tokenUtils";
 import DelegateVoteIcon from "./DelegateVoteIcon";
 import { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import LazyVotingPower from "./LazyVotingPower";
 
 function shortPropTitle(title: string, proosalId: string) {

--- a/src/components/Delegates/DelegateVotes/SnapshotVotes.tsx
+++ b/src/components/Delegates/DelegateVotes/SnapshotVotes.tsx
@@ -6,7 +6,7 @@ import { formatDistanceToNow } from "date-fns";
 import InfiniteScroll from "react-infinite-scroller";
 import { pluralizeSnapshotVote } from "@/lib/tokenUtils";
 import { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
-import { SnapshotVote } from "@/app/api/common/votes/vote";
+import type { SnapshotVote } from "@/app/api/common/votes/vote";
 
 const propHeader = (vote: SnapshotVote) => {
   return `Snapshot vote - ${formatDistanceToNow(vote.createdAt)} ago`;

--- a/src/components/Dialogs/DialogProvider/dialogs.tsx
+++ b/src/components/Dialogs/DialogProvider/dialogs.tsx
@@ -31,7 +31,7 @@ import { fetchAllForAdvancedDelegation } from "@/app/delegates/actions";
 import { PartialDelegationDialog } from "@/components/Dialogs/PartialDelegateDialog/PartialDelegationDialog";
 import SubscribeDialog from "@/components/Notifications/SubscribeDialog";
 import { ShareDialog as ShareVoteDialog } from "@/components/Proposals/ProposalPage/ShareVoteDialog/ShareVoteDialog";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { SimulationReportDialog } from "../SimulationReportDialog/SimulationReportDialog";
 import { StructuredSimulationReport } from "@/lib/seatbelt/types";
 import { EncourageConnectWalletDialog } from "@/components/Delegates/Delegations/EncourageConnectWalletDialog";

--- a/src/components/Proposals/ProposalPage/ApprovalCastVoteDialog/ApprovalCastVoteDialog.tsx
+++ b/src/components/Proposals/ProposalPage/ApprovalCastVoteDialog/ApprovalCastVoteDialog.tsx
@@ -13,7 +13,7 @@ import { calculateVoteMetadata, getVpToDisplay } from "@/lib/voteUtils";
 import { useEnsName, useAccount } from "wagmi";
 import { truncateAddress } from "@/app/lib/utils/text";
 import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { cn } from "@/lib/utils";
 import Markdown from "@/components/shared/Markdown/Markdown";
 import Tenant from "@/lib/tenant/tenant";

--- a/src/components/Proposals/ProposalPage/CopelandProposalPage/CopelandProposalPage.tsx
+++ b/src/components/Proposals/ProposalPage/CopelandProposalPage/CopelandProposalPage.tsx
@@ -46,7 +46,7 @@ export default async function CopelandProposalPage({
       <div className="flex-1 proposal-description pb-6 md:pb-0">
         <ProposalDescription proposal={proposal} />
       </div>
-      <div className="w-full md:max-w-[24rem] sticky flex-none top-20 bg-neutral border-line border rounded-xl shadow-newDefault mb-8 items-stretch sm:items-start justify-end sm:justify-between max-h-none h-auto">
+      <div className="w-full md:max-w-[24rem] sticky flex flex-col flex-none top-20 bg-neutral border-line border rounded-xl shadow-newDefault mb-8 items-stretch sm:items-start justify-end sm:justify-between max-h-none md:max-h-[calc(100vh-220px)] h-auto min-h-0">
         <CopelandVotesPanel
           proposal={proposal}
           fetchVotesForProposal={fetchProposalVotes}

--- a/src/components/Proposals/ProposalPage/CopelandProposalPage/CopelandVotesPanel/CopelandVotesPanel.tsx
+++ b/src/components/Proposals/ProposalPage/CopelandProposalPage/CopelandVotesPanel/CopelandVotesPanel.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { motion } from "framer-motion";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { SnapshotVote, VotesSort } from "@/app/api/common/votes/vote";
+import type { SnapshotVote, VotesSort } from "@/app/api/common/votes/vote";
 import { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
 import ProposalVotesFilter from "@/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesFilter";
 import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalNonVoterList";
@@ -84,12 +84,12 @@ export default function CopelandVotesPanel({
 
   return (
     <motion.div
-      className="flex flex-col flex-1"
+      className="flex flex-col flex-1 min-h-0"
       initial={{ opacity: 1 }}
       animate={{ opacity: isPending ? 0.3 : 1 }}
       transition={{ duration: 0.3, delay: isPending ? 0.3 : 0 }}
     >
-      <div className="flex flex-col gap-1 relative min-h-0 h-full">
+      <div className="flex flex-col gap-1 relative min-h-0 flex-1">
         {/* Tabs */}
         <div className="flex h-12 pt-4 px-4 mb-1">
           {["Results", "Votes"].map((tab, index) => (
@@ -155,7 +155,10 @@ export default function CopelandVotesPanel({
               showVoters ? (
                 <ArchiveCopelandProposalVotesList proposal={proposal} />
               ) : (
-                <ArchiveProposalNonVoterList proposal={proposal} />
+                <ArchiveProposalNonVoterList
+                  proposal={proposal}
+                  selectedVoterType={{ type: "ALL", value: "All" }}
+                />
               )
             ) : showVoters ? (
               <CopelandProposalVotesList
@@ -164,7 +167,10 @@ export default function CopelandVotesPanel({
                 proposalId={proposal.id}
               />
             ) : (
-              <ProposalNonVoterList proposal={proposal} />
+              <ProposalNonVoterList
+                proposal={proposal}
+                selectedVoterType={{ type: "ALL", value: "All" }}
+              />
             )}
           </>
         )}

--- a/src/components/Proposals/ProposalPage/CopelandProposalPage/OptionsResultsPanel/OptionsResultsPanel.tsx
+++ b/src/components/Proposals/ProposalPage/CopelandProposalPage/OptionsResultsPanel/OptionsResultsPanel.tsx
@@ -112,7 +112,7 @@ export default function OptionsResultsPanel({
   return (
     <div
       ref={containerRef}
-      className="flex flex-col flex-1 max-h-[calc(100vh-532px)] overflow-y-scroll flex-shrink px-4 mt-1 [&::-webkit-scrollbar]:hidden"
+      className="flex flex-col flex-1 overflow-y-auto flex-shrink px-4 mt-1 min-h-0 [&::-webkit-scrollbar]:hidden"
     >
       <Accordion
         type="single"

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/ApprovalVotesPanel.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/ApprovalVotesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect } from "react";
 import { motion } from "framer-motion";
 import { VStack, HStack } from "@/components/Layout/Stack";
 import OptionsResultsPanel from "../OptionResultsPanel/OptionResultsPanel";
@@ -14,15 +14,28 @@ import ArchiveProposalNonVoterList from "@/components/Votes/ProposalVotesList/Ar
 import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalNonVoterList";
 import { ParsedProposalData } from "@/lib/proposalUtils";
 import { PaginationParams } from "@/app/lib/pagination";
-import { Vote } from "@/app/api/common/votes/vote";
+import type {
+  Vote,
+  VoterTypes,
+  VotesSort,
+  VotesSortOrder,
+} from "@/app/api/common/votes/vote";
 import { PaginatedResult } from "@/app/lib/pagination";
 import Tenant from "@/lib/tenant/tenant";
+import ProposalVoterListFilter from "@/components/Votes/ProposalVotesList/ProsalVoterListFilter";
+import ProposalVotesSort, {
+  SortParams,
+} from "@/components/Votes/ProposalVotesList/ProposalVotesSort";
 
 type Props = {
   proposal: Proposal;
   fetchVotesForProposal: (
     proposalId: string,
-    pagination?: PaginationParams
+    pagination?: PaginationParams,
+    sort?: VotesSort,
+    offchainProposalId?: string,
+    sortOrder?: VotesSortOrder,
+    voterType?: string
   ) => Promise<PaginatedResult<Vote[]>>;
   fetchUserVotes: (
     proposalId: string,
@@ -43,6 +56,29 @@ export default function ApprovalVotesPanel({
     "use-archive-for-vote-history"
   )?.enabled;
 
+  const [sortOption, setSortOption] = useState<SortParams>({
+    sortKey: "block_number",
+    sortOrder: "desc",
+    label: "Most Recent",
+  });
+  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>({
+    type: "ALL",
+    value: "All",
+  });
+
+  const hideTimeSortOptions = false;
+
+  useEffect(() => {
+    const isTimeSortHidden = hideTimeSortOptions || !showVoters;
+    if (isTimeSortHidden && sortOption.sortKey === "block_number") {
+      setSortOption({
+        sortKey: "weight",
+        sortOrder: "desc",
+        label: "Most Voting Power",
+      });
+    }
+  }, [hideTimeSortOptions, showVoters, sortOption.sortKey]);
+
   function handleTabsChange(index: number) {
     startTransition(() => {
       setActiveTab(index);
@@ -56,9 +92,20 @@ export default function ApprovalVotesPanel({
   // Wrapper functions to match ApprovalProposalVotesList's expected signatures
   const handleFetchVotesForProposal = async (
     proposalId: string,
-    pagination: PaginationParams
+    pagination: PaginationParams,
+    sort?: VotesSort,
+    offchainProposalId?: string,
+    sortOrder?: VotesSortOrder,
+    voterType?: string
   ) => {
-    return fetchVotesForProposal(proposalId, pagination);
+    return fetchVotesForProposal(
+      proposalId,
+      pagination,
+      sort,
+      offchainProposalId,
+      sortOrder,
+      voterType
+    );
   };
 
   const handleFetchUserVotes = async (proposalId: string, address: string) => {
@@ -67,12 +114,12 @@ export default function ApprovalVotesPanel({
 
   return (
     <motion.div
-      className="flex flex-col"
+      className="flex flex-col flex-1 min-h-0"
       initial={{ opacity: 1 }}
       animate={{ opacity: isPending ? 0.3 : 1 }}
       transition={{ duration: 0.3, delay: isPending ? 0.3 : 0 }}
     >
-      <VStack gap={1} className="relative min-h-0 h-full">
+      <VStack gap={1} className="relative min-h-0 flex-1">
         {/* Tabs */}
         <HStack className="h-12 pt-4 px-4 mb-1">
           {["Results", "Votes"].map((tab, index) => (
@@ -95,22 +142,52 @@ export default function ApprovalVotesPanel({
           <OptionsResultsPanel proposal={proposal} />
         ) : (
           <>
-            <div className="px-4">
+            <div className="px-4 py-3 pb-2 flex flex-col gap-4">
               <ProposalVotesFilter
                 initialSelection={showVoters ? "Voters" : "Hasn't voted"}
                 onSelectionChange={(value) => {
                   setShowVoters(value === "Voters");
                 }}
               />
+              <div className="flex justify-between items-center border-t border-line pt-2">
+                <ProposalVoterListFilter
+                  selectedVoterType={selectedVoterType}
+                  onVoterTypeChange={setSelectedVoterType}
+                  showCitizenHouseFilters={
+                    proposal.proposalType?.includes("HYBRID") || false
+                  }
+                />
+                {showVoters ? (
+                  <ProposalVotesSort
+                    sortOption={sortOption}
+                    onSortChange={setSortOption}
+                    hideTimeSortOptions={hideTimeSortOptions}
+                  />
+                ) : (
+                  <ProposalVotesSort
+                    sortOption={sortOption}
+                    onSortChange={setSortOption}
+                    hideTimeSortOptions={true}
+                  />
+                )}
+              </div>
             </div>
             {useArchiveVoteHistory ? (
               showVoters ? (
                 <ArchiveApprovalProposalVotesList
                   proposal={proposal}
                   isThresholdCriteria={isThresholdCriteria}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  voterType={selectedVoterType.type}
                 />
               ) : (
-                <ArchiveProposalNonVoterList proposal={proposal} />
+                <ArchiveProposalNonVoterList
+                  proposal={proposal}
+                  selectedVoterType={selectedVoterType}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                />
               )
             ) : showVoters ? (
               <ApprovalProposalVotesList
@@ -118,9 +195,17 @@ export default function ApprovalVotesPanel({
                 fetchUserVotes={handleFetchUserVotes}
                 proposalId={proposal.id}
                 isThresholdCriteria={isThresholdCriteria}
+                sort={sortOption.sortKey}
+                sortOrder={sortOption.sortOrder}
+                voterType={selectedVoterType.type}
               />
             ) : (
-              <ProposalNonVoterList proposal={proposal} />
+              <ProposalNonVoterList
+                proposal={proposal}
+                sort={sortOption.sortKey}
+                sortOrder={sortOption.sortOrder}
+                selectedVoterType={selectedVoterType}
+              />
             )}
           </>
         )}

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/ArchiveApprovalVotesPanel.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/ArchiveApprovalVotesPanel.tsx
@@ -35,12 +35,12 @@ export default function ArchiveApprovalVotesPanel({ proposal }: Props) {
 
   return (
     <motion.div
-      className="flex flex-col"
+      className="flex flex-col flex-1 min-h-0"
       initial={{ opacity: 1 }}
       animate={{ opacity: isPending ? 0.3 : 1 }}
       transition={{ duration: 0.3, delay: isPending ? 0.3 : 0 }}
     >
-      <VStack gap={1} className="relative min-h-0 h-full">
+      <VStack gap={1} className="relative min-h-0 flex-1">
         {/* Tabs */}
         <HStack className="h-12 pt-4 px-4 mb-1">
           {["Results", "Votes"].map((tab, index) => (
@@ -77,7 +77,10 @@ export default function ArchiveApprovalVotesPanel({ proposal }: Props) {
                 isThresholdCriteria={isThresholdCriteria}
               />
             ) : (
-              <ArchiveProposalNonVoterList proposal={proposal} />
+              <ArchiveProposalNonVoterList
+                proposal={proposal}
+                selectedVoterType={{ type: "ALL", value: "All" }}
+              />
             )}
           </>
         )}

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/HybridApprovalVotesPanel.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ApprovalVotesPanel/HybridApprovalVotesPanel.tsx
@@ -20,6 +20,12 @@ import { HStack } from "@/components/Layout/Stack";
 import { icons } from "@/assets/icons/icons";
 import Tenant from "@/lib/tenant/tenant";
 import ProposalVotesList from "@/components/Votes/ProposalVotesList/ProposalVotesList";
+import { useEffect } from "react";
+import ProposalVotesSort, {
+  SortParams,
+} from "@/components/Votes/ProposalVotesList/ProposalVotesSort";
+import ProposalVoterListFilter from "@/components/Votes/ProposalVotesList/ProsalVoterListFilter";
+import type { VoterTypes } from "@/app/api/common/votes/vote";
 
 type Props = {
   proposal: Proposal;
@@ -33,6 +39,29 @@ export default function HybridApprovalVotesPanel({ proposal }: Props) {
   const useArchiveVoteHistory = ui.toggle(
     "use-archive-for-vote-history"
   )?.enabled;
+  const [sortOption, setSortOption] = useState<SortParams>({
+    sortKey: "block_number",
+    sortOrder: "desc",
+    label: "Most Recent",
+  });
+  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>({
+    type: "ALL",
+    value: "All",
+  });
+
+  const hideTimeSortOptions = false;
+
+  useEffect(() => {
+    const isTimeSortHidden = hideTimeSortOptions || !showVoters;
+    if (isTimeSortHidden && sortOption.sortKey === "block_number") {
+      setSortOption({
+        sortKey: "weight",
+        sortOrder: "desc",
+        label: "Most Voting Power",
+      });
+    }
+  }, [hideTimeSortOptions, showVoters, sortOption.sortKey]);
+
   const hybridApprovalData =
     proposal.proposalData as ParsedProposalData["HYBRID_APPROVAL"]["kind"];
 
@@ -51,7 +80,7 @@ export default function HybridApprovalVotesPanel({ proposal }: Props) {
   return (
     <>
       <div
-        className={`fixed flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-inherit max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"}`}
+        className={`fixed flex flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"}`}
         style={{
           transition: "bottom 600ms cubic-bezier(0, 0.975, 0.015, 0.995)",
         }}
@@ -64,7 +93,7 @@ export default function HybridApprovalVotesPanel({ proposal }: Props) {
             <img className="opacity-60" src={icons.expand.src} alt="expand" />
           </HStack>
         </button>
-        <div className="border border-line rounded-xl mb-2 bg-neutral">
+        <div className="flex flex-col flex-1 min-h-0 border border-line rounded-xl mb-2 bg-neutral">
           <ProposalVotesTab setTab={setActiveTab} activeTab={activeTab} />
 
           {activeTab === "results" ? (
@@ -102,25 +131,61 @@ export default function HybridApprovalVotesPanel({ proposal }: Props) {
                     setShowVoters(value === "Voters");
                   }}
                 />
+                <div className="flex justify-between items-center border-t border-line pt-2 mt-2">
+                  <ProposalVoterListFilter
+                    selectedVoterType={selectedVoterType}
+                    onVoterTypeChange={setSelectedVoterType}
+                    showCitizenHouseFilters={
+                      proposal.proposalType?.includes("HYBRID") || false
+                    }
+                  />
+                  {showVoters ? (
+                    <ProposalVotesSort
+                      sortOption={sortOption}
+                      onSortChange={setSortOption}
+                      hideTimeSortOptions={hideTimeSortOptions}
+                    />
+                  ) : (
+                    <ProposalVotesSort
+                      sortOption={sortOption}
+                      onSortChange={setSortOption}
+                      hideTimeSortOptions={true}
+                    />
+                  )}
+                </div>
               </div>
               {useArchiveVoteHistory ? (
                 showVoters ? (
                   <ArchiveApprovalProposalVotesList
                     proposal={proposal}
                     isThresholdCriteria={isThresholdCriteria}
+                    sort={sortOption.sortKey}
+                    sortOrder={sortOption.sortOrder}
+                    voterType={selectedVoterType.type}
                   />
                 ) : (
-                  <ArchiveProposalNonVoterList proposal={proposal} />
+                  <ArchiveProposalNonVoterList
+                    proposal={proposal}
+                    selectedVoterType={selectedVoterType}
+                    sort={sortOption.sortKey}
+                    sortOrder={sortOption.sortOrder}
+                  />
                 )
               ) : showVoters ? (
                 <ProposalVotesList
                   proposalId={proposal.id}
                   offchainProposalId={proposal.offchainProposalId}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  voterType={selectedVoterType.type}
                 />
               ) : (
                 <ProposalNonVoterList
                   proposal={proposal}
                   offchainProposalId={proposal.offchainProposalId}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  selectedVoterType={selectedVoterType}
                 />
               )}
             </>

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ArchiveApprovalProposalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/ArchiveApprovalProposalPage.tsx
@@ -16,8 +16,8 @@ export default function ArchiveApprovalProposalPage({
         </div>
         <div className="w-full md:max-w-[24rem]">
           <ArchiveProposalTypeApproval proposal={proposal} />
-          <div className="flex flex-col gap-4 sticky top-20 flex-shrink bg-neutral border-line border rounded-xl shadow-newDefault mb-8 items-stretch sm:items-start justify-end sm:justify-between w-full max-h-none h-auto">
-            <div className="flex flex-col gap-4 w-full">
+          <div className="flex flex-col gap-4 sticky top-20 flex-shrink bg-neutral border-line border rounded-xl shadow-newDefault mb-8 items-stretch sm:items-start justify-end sm:justify-between w-full max-h-none md:max-h-[calc(100vh-220px)] h-auto min-h-0">
+            <div className="flex flex-col flex-1 min-h-0 gap-4 w-full">
               <ArchiveApprovalVotesPanel proposal={proposal} />
             </div>
           </div>

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OPProposalApprovalPage.tsx
@@ -8,16 +8,24 @@ import {
 } from "@/app/api/common/votes/getVotes";
 import { PaginationParams } from "@/app/lib/pagination";
 import { TaxFormBanner } from "../TaxFormBanner";
+import type { VotesSort, VotesSortOrder } from "@/app/api/common/votes/vote";
 
 async function fetchProposalVotes(
   proposalId: string,
-  pagination?: PaginationParams
+  pagination?: PaginationParams,
+  sort?: VotesSort,
+  offchainProposalId?: string,
+  sortOrder?: VotesSortOrder,
+  voterType?: string
 ) {
   "use server";
 
   return fetchVotesForProposal({
     proposalId,
     pagination,
+    sort,
+    sortOrder,
+    voterType,
   });
 }
 
@@ -45,12 +53,12 @@ export default async function OPProposalApprovalPage({
       <ProposalStateAdmin proposal={proposal} />
 
       <div className="flex gap-0 md:gap-16 justify-between items-start max-w-[76rem] flex-col sm:flex-row sm:items-start sm:justify-between">
-        <div className="w-full proposal-description pb-6 md:pb-0">
+        <div className="w-full md:w-[calc(100%-25rem)] proposal-description pb-6 md:pb-0">
           <ProposalDescription proposal={proposal} />
         </div>
-        <div className="w-full md:max-w-[24rem]">
-          <div className="flex flex-col gap-4 sticky top-20 flex-shrink bg-neutral border-line border rounded-xl shadow-newDefault mb-8 items-stretch sm:items-start justify-end sm:justify-between w-full max-h-none h-auto">
-            <div className="flex flex-col gap-4 w-full">
+        <div className="w-full md:w-[24rem]">
+          <div className="flex flex-col gap-4 sticky top-20 flex-shrink bg-neutral border-line border rounded-xl shadow-newDefault mb-8 items-stretch sm:items-start justify-end sm:justify-between w-full max-h-none md:max-h-[calc(100vh-220px)] h-auto min-h-0">
+            <div className="flex flex-col flex-1 min-h-0 gap-4 w-full">
               {/* Show the results of the approval vote w/ a tab for votes */}
               <ApprovalVotesPanel
                 proposal={proposal}

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OptionResultsPanel/HybridOptionsResultsPanel.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OptionResultsPanel/HybridOptionsResultsPanel.tsx
@@ -68,7 +68,7 @@ export default function HybridOptionsResultsPanel({
   return (
     <div
       className={cn(
-        "flex flex-col max-h-[calc(100vh-544px)] overflow-y-auto flex-shrink p-4 min-h-[36px]",
+        "flex flex-col flex-1 overflow-y-auto flex-shrink p-4 min-h-0",
         className
       )}
     >

--- a/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OptionResultsPanel/OptionResultsPanel.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalApprovalPage/OptionResultsPanel/OptionResultsPanel.tsx
@@ -85,7 +85,7 @@ export default function OptionsResultsPanel({
   return (
     <div
       className={cn(
-        "flex flex-col max-h-[calc(100vh-482px)] overflow-y-scroll flex-shrink px-4 min-h-[36px]",
+        "flex flex-col flex-1 overflow-y-auto flex-shrink px-4 min-h-0",
         className
       )}
     >

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ArchiveProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ArchiveProposalVotesCard.tsx
@@ -29,7 +29,7 @@ export default function ArchiveProposalVotesCard({
   return (
     <>
       <div
-        className={`fixed flex justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] bg-neutral border border-line rounded-xl shadow-newDefault mb-8 transition-all ${
+        className={`fixed flex flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] bg-neutral border border-line rounded-xl shadow-newDefault mb-8 transition-all ${
           isClicked
             ? "bottom-[20px]"
             : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"
@@ -38,7 +38,7 @@ export default function ArchiveProposalVotesCard({
           transition: "bottom 600ms cubic-bezier(0, 0.975, 0.015, 0.995)",
         }}
       >
-        <div className="flex flex-col gap-4 min-h-0 shrink pt-4 w-full">
+        <div className="flex flex-col flex-1 gap-4 min-h-0 pt-4 w-full">
           <button
             onClick={handleClick}
             className="border w-10 h-10 rounded-full bg-neutral absolute top-[-20px] left-[calc(50%-20px)] shadow-newDefault block md:hidden"
@@ -65,7 +65,10 @@ export default function ArchiveProposalVotesCard({
           {showVoters ? (
             <ArchiveProposalVotesList proposal={proposal} />
           ) : (
-            <ArchiveProposalNonVoterList proposal={proposal} />
+            <ArchiveProposalNonVoterList
+              proposal={proposal}
+              selectedVoterType={{ type: "ALL", value: "All" }}
+            />
           )}
 
           {isProposalActive && (

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/HybridStandardProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/HybridStandardProposalVotesCard.tsx
@@ -8,17 +8,32 @@ import ArchiveProposalNonVoterList from "@/components/Votes/ProposalVotesList/Ar
 import ProposalVotesList from "@/components/Votes/ProposalVotesList/ProposalVotesList";
 import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalNonVoterList";
 import ProposalVotesFilter from "./ProposalVotesFilter";
+import ProposalVotesSort, {
+  SortParams,
+} from "@/components/Votes/ProposalVotesList/ProposalVotesSort";
+import type { VoterTypes } from "@/app/api/common/votes/vote";
+import ProposalVoterListFilter from "@/components/Votes/ProposalVotesList/ProsalVoterListFilter";
 import { ProposalVotesTab } from "@/components/common/ProposalVotesTab";
 import { VoteOnAtlas } from "@/components/common/VoteOnAtlas";
 import { HStack } from "@/components/Layout/Stack";
 import { icons } from "@/assets/icons/icons";
 import Tenant from "@/lib/tenant/tenant";
+import { useEffect } from "react";
 
 const HybridStandardProposalVotesCard = ({
   proposal,
 }: {
   proposal: Proposal;
 }) => {
+  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>({
+    type: "ALL",
+    value: "All",
+  });
+  const [sortOption, setSortOption] = useState<SortParams>({
+    sortKey: "block_number",
+    sortOrder: "desc",
+    label: "Most Recent",
+  });
   const [activeTab, setTab] = useState("results");
   const [showVoters, setShowVoters] = useState(true);
   const [isClicked, setIsClicked] = useState<boolean>(false);
@@ -27,6 +42,19 @@ const HybridStandardProposalVotesCard = ({
     "use-archive-for-vote-history"
   )?.enabled;
 
+  const hideTimeSortOptions = false;
+
+  useEffect(() => {
+    const isTimeSortHidden = hideTimeSortOptions || !showVoters;
+    if (isTimeSortHidden && sortOption.sortKey === "block_number") {
+      setSortOption({
+        sortKey: "weight",
+        sortOrder: "desc",
+        label: "Most Voting Power",
+      });
+    }
+  }, [hideTimeSortOptions, showVoters, sortOption.sortKey]);
+
   const handleClick = () => {
     setIsClicked(!isClicked);
   };
@@ -34,7 +62,7 @@ const HybridStandardProposalVotesCard = ({
   return (
     <>
       <div
-        className={`fixed flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"} sm:overflow-y-auto`}
+        className={`fixed flex flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"} sm:overflow-y-auto`}
         style={{
           transition: "bottom 600ms cubic-bezier(0, 0.975, 0.015, 0.995)",
         }}
@@ -47,7 +75,7 @@ const HybridStandardProposalVotesCard = ({
             <img className="opacity-60" src={icons.expand.src} alt="expand" />
           </HStack>
         </button>
-        <div className="border border-line rounded-xl mb-2 bg-neutral">
+        <div className="flex flex-col flex-1 min-h-0 border border-line rounded-xl mb-2 bg-neutral">
           <ProposalVotesTab setTab={setTab} activeTab={activeTab} />
 
           {activeTab === "results" ? (
@@ -67,29 +95,67 @@ const HybridStandardProposalVotesCard = ({
             </>
           ) : (
             <>
-              <div className="px-3 py-[10px]">
+              <div className="flex flex-col gap-4 px-4 py-3">
                 <ProposalVotesFilter
                   initialSelection={showVoters ? "Voters" : "Hasn't voted"}
                   onSelectionChange={(value) => {
                     setShowVoters(value === "Voters");
                   }}
                 />
+                <div className="flex justify-between items-center border-b border-line pb-2">
+                  <ProposalVoterListFilter
+                    selectedVoterType={selectedVoterType}
+                    onVoterTypeChange={setSelectedVoterType}
+                    showCitizenHouseFilters={
+                      proposal.proposalType?.includes("HYBRID") || false
+                    }
+                  />
+                  {showVoters ? (
+                    <ProposalVotesSort
+                      sortOption={sortOption}
+                      onSortChange={setSortOption}
+                      hideTimeSortOptions={hideTimeSortOptions}
+                    />
+                  ) : (
+                    <ProposalVotesSort
+                      sortOption={sortOption}
+                      onSortChange={setSortOption}
+                      hideTimeSortOptions={true}
+                    />
+                  )}
+                </div>
               </div>
               {useArchiveVoteHistory ? (
                 showVoters ? (
-                  <ArchiveProposalVotesList proposal={proposal} />
+                  <ArchiveProposalVotesList
+                    proposal={proposal}
+                    sort={sortOption.sortKey}
+                    sortOrder={sortOption.sortOrder}
+                    voterType={selectedVoterType.type}
+                  />
                 ) : (
-                  <ArchiveProposalNonVoterList proposal={proposal} />
+                  <ArchiveProposalNonVoterList
+                    proposal={proposal}
+                    selectedVoterType={selectedVoterType}
+                    sort={sortOption.sortKey}
+                    sortOrder={sortOption.sortOrder}
+                  />
                 )
               ) : showVoters ? (
                 <ProposalVotesList
                   proposalId={proposal.id}
                   offchainProposalId={proposal.offchainProposalId}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  voterType={selectedVoterType.type}
                 />
               ) : (
                 <ProposalNonVoterList
                   proposal={proposal}
                   offchainProposalId={proposal.offchainProposalId}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  selectedVoterType={selectedVoterType}
                 />
               )}
             </>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OffChainOptimisticProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OffChainOptimisticProposalVotesCard.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import ProposalVotesSort, {
+  SortParams,
+} from "@/components/Votes/ProposalVotesList/ProposalVotesSort";
+import type { VoterTypes } from "@/app/api/common/votes/vote";
+import ProposalVoterListFilter from "@/components/Votes/ProposalVotesList/ProsalVoterListFilter";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import ProposalStatusDetail from "@/components/Proposals/ProposalStatus/ProposalStatusDetail";
 import ProposalVotesFilter from "./ProposalVotesFilter";
@@ -27,6 +32,7 @@ import ArchiveProposalNonVoterList from "@/components/Votes/ProposalVotesList/Ar
 import ProposalVotesList from "@/components/Votes/ProposalVotesList/ProposalVotesList";
 import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalNonVoterList";
 import Tenant from "@/lib/tenant/tenant";
+import { useEffect } from "react";
 
 interface Props {
   proposal: Proposal;
@@ -97,6 +103,15 @@ const OffChainOptimisticVotesGroup = ({ proposal }: { proposal: Proposal }) => {
 };
 
 const OffChainOptimisticProposalVotesCard = ({ proposal }: Props) => {
+  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>({
+    type: "ALL",
+    value: "All",
+  });
+  const [sortOption, setSortOption] = useState<SortParams>({
+    sortKey: "block_number",
+    sortOrder: "desc",
+    label: "Most Recent",
+  });
   const [showVoters, setShowVoters] = useState(true);
   const [activeTab, setActiveTab] = useState("results");
   const [isClicked, setIsClicked] = useState<boolean>(false);
@@ -104,6 +119,19 @@ const OffChainOptimisticProposalVotesCard = ({ proposal }: Props) => {
   const useArchiveVoteHistory = ui.toggle(
     "use-archive-for-vote-history"
   )?.enabled;
+
+  const hideTimeSortOptions = false;
+
+  useEffect(() => {
+    const isTimeSortHidden = hideTimeSortOptions || !showVoters;
+    if (isTimeSortHidden && sortOption.sortKey === "block_number") {
+      setSortOption({
+        sortKey: "weight",
+        sortOrder: "desc",
+        label: "Most Voting Power",
+      });
+    }
+  }, [hideTimeSortOptions, showVoters, sortOption.sortKey]);
 
   const { totalAgainstVotes } = useMemo(
     () => calculateHybridOptimisticProposalMetrics(proposal),
@@ -141,7 +169,7 @@ const OffChainOptimisticProposalVotesCard = ({ proposal }: Props) => {
   return (
     <>
       <div
-        className={`fixed flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"}`}
+        className={`fixed flex flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"}`}
         style={{
           transition: "bottom 600ms cubic-bezier(0, 0.975, 0.015, 0.995)",
         }}
@@ -154,7 +182,7 @@ const OffChainOptimisticProposalVotesCard = ({ proposal }: Props) => {
             <img className="opacity-60" src={icons.expand.src} alt="expand" />
           </HStack>
         </button>
-        <div className="border border-line rounded-xl mb-2 bg-neutral">
+        <div className="flex flex-col flex-1 min-h-0 border border-line rounded-xl mb-2 bg-neutral">
           <ProposalVotesTab setTab={setActiveTab} activeTab={activeTab} />
           {activeTab === "results" ? (
             <>
@@ -189,29 +217,67 @@ const OffChainOptimisticProposalVotesCard = ({ proposal }: Props) => {
             </>
           ) : (
             <>
-              <div className="px-3 py-[10px]">
+              <div className="flex flex-col gap-4 px-4 py-3">
                 <ProposalVotesFilter
                   initialSelection={showVoters ? "Voters" : "Hasn't voted"}
                   onSelectionChange={(value) => {
                     setShowVoters(value === "Voters");
                   }}
                 />
+                <div className="flex justify-between items-center border-b border-line pb-2">
+                  <ProposalVoterListFilter
+                    selectedVoterType={selectedVoterType}
+                    onVoterTypeChange={setSelectedVoterType}
+                    showCitizenHouseFilters={
+                      proposal.proposalType?.includes("HYBRID") || false
+                    }
+                  />
+                  {showVoters ? (
+                    <ProposalVotesSort
+                      sortOption={sortOption}
+                      onSortChange={setSortOption}
+                      hideTimeSortOptions={hideTimeSortOptions}
+                    />
+                  ) : (
+                    <ProposalVotesSort
+                      sortOption={sortOption}
+                      onSortChange={setSortOption}
+                      hideTimeSortOptions={true}
+                    />
+                  )}
+                </div>
               </div>
               {useArchiveVoteHistory ? (
                 showVoters ? (
-                  <ArchiveProposalVotesList proposal={proposal} />
+                  <ArchiveProposalVotesList
+                    proposal={proposal}
+                    sort={sortOption.sortKey}
+                    sortOrder={sortOption.sortOrder}
+                    voterType={selectedVoterType.type}
+                  />
                 ) : (
-                  <ArchiveProposalNonVoterList proposal={proposal} />
+                  <ArchiveProposalNonVoterList
+                    proposal={proposal}
+                    selectedVoterType={selectedVoterType}
+                    sort={sortOption.sortKey}
+                    sortOrder={sortOption.sortOrder}
+                  />
                 )
               ) : showVoters ? (
                 <ProposalVotesList
                   proposalId={proposal.id}
                   offchainProposalId={proposal.offchainProposalId}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  voterType={selectedVoterType.type}
                 />
               ) : (
                 <ProposalNonVoterList
                   proposal={proposal}
                   offchainProposalId={proposal.offchainProposalId}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  selectedVoterType={selectedVoterType}
                 />
               )}
             </>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticProposalVotesCard.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import ProposalVotesSort, {
+  SortParams,
+} from "@/components/Votes/ProposalVotesList/ProposalVotesSort";
+import type { VoterTypes } from "@/app/api/common/votes/vote";
+import ProposalVoterListFilter from "@/components/Votes/ProposalVotesList/ProsalVoterListFilter";
 import { HStack, VStack } from "@/components/Layout/Stack";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import ProposalStatusDetail from "@/components/Proposals/ProposalStatus/ProposalStatusDetail";
@@ -18,6 +23,7 @@ import useFetchAllForVoting from "@/hooks/useFetchAllForVoting";
 import { checkMissingVoteForDelegate } from "@/lib/voteUtils";
 import { TENANT_NAMESPACES } from "@/lib/constants";
 import CastEasOptimisticVoteInput from "@/components/Votes/CastVoteInput/CastEasOptimisticVoteInput";
+import { useEffect } from "react";
 
 interface Props {
   proposal: Proposal;
@@ -34,6 +40,15 @@ const OptimisticProposalVotesCard = ({
   againstLengthString,
   status,
 }: Props) => {
+  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>({
+    type: "ALL",
+    value: "All",
+  });
+  const [sortOption, setSortOption] = useState<SortParams>({
+    sortKey: "block_number",
+    sortOrder: "desc",
+    label: "Most Recent",
+  });
   const { token, ui } = Tenant.current();
   const [isClicked, setIsClicked] = useState<boolean>(false);
   const [showVoters, setShowVoters] = useState(true);
@@ -44,6 +59,20 @@ const OptimisticProposalVotesCard = ({
   // Get voting data to check if user has already voted
   const isOptimismTenant =
     Tenant.current().namespace === TENANT_NAMESPACES.OPTIMISM;
+
+  const hideTimeSortOptions = false;
+
+  useEffect(() => {
+    const isTimeSortHidden = hideTimeSortOptions || !showVoters;
+    if (isTimeSortHidden && sortOption.sortKey === "block_number") {
+      setSortOption({
+        sortKey: "weight",
+        sortOrder: "desc",
+        label: "Most Voting Power",
+      });
+    }
+  }, [hideTimeSortOptions, showVoters, sortOption.sortKey]);
+
   const { data: votingData, isSuccess: isVotingDataLoaded } =
     useFetchAllForVoting({
       proposal,
@@ -85,12 +114,12 @@ const OptimisticProposalVotesCard = ({
 
   return (
     <div
-      className={`fixed flex justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] bg-neutral border border-line rounded-xl shadow-newDefault mb-8 transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"} sm:overflow-y-auto`}
+      className={`fixed flex flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] bg-neutral border border-line rounded-xl shadow-newDefault mb-8 transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"} sm:overflow-y-auto`}
       style={{
         transition: "bottom 600ms cubic-bezier(0, 0.975, 0.015, 0.995)",
       }}
     >
-      <VStack gap={4} className="min-h-0 shrink py-4">
+      <VStack gap={4} className="min-h-0 flex-1 shrink py-4">
         <button
           onClick={handleClick}
           className="border w-10 h-10 rounded-full bg-neutral absolute top-[-20px] left-[calc(50%-20px)] shadow-newDefault block md:hidden"
@@ -136,30 +165,68 @@ const OptimisticProposalVotesCard = ({
             />
           </div>
         </div>
-        <div className="px-4">
+        <div className="px-4 flex flex-col gap-4">
           <ProposalVotesFilter
             initialSelection={showVoters ? "Voters" : "Hasn't voted"}
             onSelectionChange={(value) => {
               setShowVoters(value === "Voters");
             }}
           />
+          <div className="flex justify-between items-center border-b border-line pb-2">
+            <ProposalVoterListFilter
+              selectedVoterType={selectedVoterType}
+              onVoterTypeChange={setSelectedVoterType}
+              showCitizenHouseFilters={
+                proposal.proposalType?.includes("HYBRID") || false
+              }
+            />
+            {showVoters ? (
+              <ProposalVotesSort
+                sortOption={sortOption}
+                onSortChange={setSortOption}
+                hideTimeSortOptions={hideTimeSortOptions}
+              />
+            ) : (
+              <ProposalVotesSort
+                sortOption={sortOption}
+                onSortChange={setSortOption}
+                hideTimeSortOptions={true}
+              />
+            )}
+          </div>
         </div>
         {/* Show the scrolling list of votes for the proposal */}
         {useArchiveVoteHistory ? (
           showVoters ? (
-            <ArchiveProposalVotesList proposal={proposal} />
+            <ArchiveProposalVotesList
+              proposal={proposal}
+              sort={sortOption.sortKey}
+              sortOrder={sortOption.sortOrder}
+              voterType={selectedVoterType.type}
+            />
           ) : (
-            <ArchiveProposalNonVoterList proposal={proposal} />
+            <ArchiveProposalNonVoterList
+              proposal={proposal}
+              selectedVoterType={selectedVoterType}
+              sort={sortOption.sortKey}
+              sortOrder={sortOption.sortOrder}
+            />
           )
         ) : showVoters ? (
           <ProposalVotesList
             proposalId={proposal.id}
             offchainProposalId={proposal.offchainProposalId}
+            sort={sortOption.sortKey}
+            sortOrder={sortOption.sortOrder}
+            voterType={selectedVoterType.type}
           />
         ) : (
           <ProposalNonVoterList
             proposal={proposal}
             offchainProposalId={proposal.offchainProposalId}
+            sort={sortOption.sortKey}
+            sortOrder={sortOption.sortOrder}
+            selectedVoterType={selectedVoterType}
           />
         )}
         {/* Show the input for the user to vote on a proposal if allowed */}

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticTieredProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/OptimisticTieredProposalVotesCard.tsx
@@ -4,7 +4,17 @@ import { useState, useMemo } from "react";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import ProposalStatusDetail from "@/components/Proposals/ProposalStatus/ProposalStatusDetail";
 import ProposalVotesFilter from "./ProposalVotesFilter";
-import { calculateHybridOptimisticProposalMetrics } from "@/lib/proposalUtils";
+import ProposalVotesSort, {
+  SortParams,
+} from "@/components/Votes/ProposalVotesList/ProposalVotesSort";
+import type { VoterTypes } from "@/app/api/common/votes/vote";
+import ProposalVoterListFilter from "@/components/Votes/ProposalVotesList/ProsalVoterListFilter";
+import VotesGroupTable from "@/components/common/VotesGroupTable";
+import {
+  ParsedProposalData,
+  ParsedProposalResults,
+  calculateHybridOptimisticProposalMetrics,
+} from "@/lib/proposalUtils";
 import { ProposalVotesTab } from "@/components/common/ProposalVotesTab";
 import { VoteOnAtlas } from "@/components/common/VoteOnAtlas";
 import CastVoteInput from "@/components/Votes/CastVoteInput/CastVoteInput";
@@ -22,6 +32,7 @@ import ArchiveProposalVotesList from "@/components/Votes/ProposalVotesList/Archi
 import ArchiveProposalNonVoterList from "@/components/Votes/ProposalVotesList/ArchiveProposalNonVoterList";
 import ProposalVotesList from "@/components/Votes/ProposalVotesList/ProposalVotesList";
 import ProposalNonVoterList from "@/components/Votes/ProposalVotesList/ProposalNonVoterList";
+import { useEffect } from "react";
 
 interface Props {
   proposal: Proposal;
@@ -346,12 +357,46 @@ function OptimisticTieredResultsView({ proposal }: { proposal: Proposal }) {
 
 const OptimisticTieredProposalVotesCard = ({ proposal }: Props) => {
   const [showVoters, setShowVoters] = useState(true);
+  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>({
+    type: "ALL",
+    value: "All",
+  });
+  const [sortOption, setSortOption] = useState<SortParams>({
+    sortKey: "block_number",
+    sortOrder: "desc",
+    label: "Most Recent",
+  });
   const [activeTab, setActiveTab] = useState("results");
   const [isClicked, setIsClicked] = useState<boolean>(false);
   const { ui } = Tenant.current();
   const useArchiveVoteHistory = ui.toggle(
     "use-archive-for-vote-history"
   )?.enabled;
+  const proposalData =
+    proposal.proposalData as ParsedProposalData["HYBRID_OPTIMISTIC_TIERED"]["kind"];
+
+  const hideTimeSortOptions = false;
+
+  useEffect(() => {
+    const isTimeSortHidden = hideTimeSortOptions || !showVoters;
+    if (isTimeSortHidden && sortOption.sortKey === "block_number") {
+      setSortOption({
+        sortKey: "weight",
+        sortOrder: "desc",
+        label: "Most Voting Power",
+      });
+    }
+  }, [hideTimeSortOptions, showVoters, sortOption.sortKey]);
+
+  const { vetoThresholdMet, groupTallies } = useMemo(
+    () => calculateHybridOptimisticProposalMetrics(proposal),
+    [proposal]
+  );
+
+  const vetoingGroupsCount = useMemo(
+    () => groupTallies.filter((g) => g.exceedsThreshold).length,
+    [groupTallies]
+  );
 
   const handleClick = () => {
     setIsClicked(!isClicked);
@@ -360,7 +405,7 @@ const OptimisticTieredProposalVotesCard = ({ proposal }: Props) => {
   return (
     <>
       <div
-        className={`fixed flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-320px)] md:h-auto"}`}
+        className={`fixed flex flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-320px)] md:h-auto"}`}
         style={{
           transition: "bottom 600ms cubic-bezier(0, 0.975, 0.015, 0.995)",
         }}
@@ -373,7 +418,7 @@ const OptimisticTieredProposalVotesCard = ({ proposal }: Props) => {
             <img className="opacity-60" src={icons.expand.src} alt="expand" />
           </HStack>
         </button>
-        <div className="border border-line rounded-xl mb-2 bg-neutral">
+        <div className="flex flex-col flex-1 min-h-0 border border-line rounded-xl mb-2 bg-neutral">
           <ProposalVotesTab setTab={setActiveTab} activeTab={activeTab} />
 
           {activeTab === "results" ? (
@@ -398,29 +443,67 @@ const OptimisticTieredProposalVotesCard = ({ proposal }: Props) => {
             </>
           ) : (
             <>
-              <div className="px-3 py-[10px]">
+              <div className="flex flex-col gap-4 px-4 py-3">
                 <ProposalVotesFilter
                   initialSelection={showVoters ? "Voters" : "Hasn't voted"}
                   onSelectionChange={(value) => {
                     setShowVoters(value === "Voters");
                   }}
                 />
+                <div className="flex justify-between items-center border-b border-line pb-2">
+                  <ProposalVoterListFilter
+                    selectedVoterType={selectedVoterType}
+                    onVoterTypeChange={setSelectedVoterType}
+                    showCitizenHouseFilters={
+                      proposal.proposalType?.includes("HYBRID") || false
+                    }
+                  />
+                  {showVoters ? (
+                    <ProposalVotesSort
+                      sortOption={sortOption}
+                      onSortChange={setSortOption}
+                      hideTimeSortOptions={hideTimeSortOptions}
+                    />
+                  ) : (
+                    <ProposalVotesSort
+                      sortOption={sortOption}
+                      onSortChange={setSortOption}
+                      hideTimeSortOptions={true}
+                    />
+                  )}
+                </div>
               </div>
               {useArchiveVoteHistory ? (
                 showVoters ? (
-                  <ArchiveProposalVotesList proposal={proposal} />
+                  <ArchiveProposalVotesList
+                    proposal={proposal}
+                    sort={sortOption.sortKey}
+                    sortOrder={sortOption.sortOrder}
+                    voterType={selectedVoterType.type}
+                  />
                 ) : (
-                  <ArchiveProposalNonVoterList proposal={proposal} />
+                  <ArchiveProposalNonVoterList
+                    proposal={proposal}
+                    selectedVoterType={selectedVoterType}
+                    sort={sortOption.sortKey}
+                    sortOrder={sortOption.sortOrder}
+                  />
                 )
               ) : showVoters ? (
                 <ProposalVotesList
                   proposalId={proposal.id}
                   offchainProposalId={proposal.offchainProposalId}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  voterType={selectedVoterType.type}
                 />
               ) : (
                 <ProposalNonVoterList
                   proposal={proposal}
                   offchainProposalId={proposal.offchainProposalId}
+                  sort={sortOption.sortKey}
+                  sortOrder={sortOption.sortOrder}
+                  selectedVoterType={selectedVoterType}
                 />
               )}
             </>

--- a/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesCard.tsx
+++ b/src/components/Proposals/ProposalPage/OPProposalPage/ProposalVotesCard/ProposalVotesCard.tsx
@@ -12,16 +12,45 @@ import CastVoteInput, {
 import { icons } from "@/assets/icons/icons";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import ProposalVotesFilter from "./ProposalVotesFilter";
+import ProposalVotesSort, {
+  SortParams,
+} from "@/components/Votes/ProposalVotesList/ProposalVotesSort";
+import type { VoterTypes } from "@/app/api/common/votes/vote";
+import { VOTER_TYPES } from "@/lib/constants";
+import ProposalVoterListFilter from "@/components/Votes/ProposalVotesList/ProsalVoterListFilter";
 import Tenant from "@/lib/tenant/tenant";
+import { useEffect } from "react";
 
 const ProposalVotesCard = ({ proposal }: { proposal: Proposal }) => {
   const [isClicked, setIsClicked] = useState(false);
   const [showVoters, setShowVoters] = useState(true);
   const isOffchain = proposal.proposalType?.startsWith("OFFCHAIN");
+  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>({
+    type: "ALL",
+    value: "All",
+  });
+  const [sortOption, setSortOption] = useState<SortParams>({
+    sortKey: "block_number",
+    sortOrder: "desc",
+    label: "Most Recent",
+  });
   const { ui } = Tenant.current();
   const useArchiveVoteHistory = ui.toggle(
     "use-archive-for-vote-history"
   )?.enabled;
+
+  const hideTimeSortOptions = false;
+
+  useEffect(() => {
+    const isTimeSortHidden = hideTimeSortOptions || !showVoters;
+    if (isTimeSortHidden && sortOption.sortKey === "block_number") {
+      setSortOption({
+        sortKey: "weight",
+        sortOrder: "desc",
+        label: "Most Voting Power",
+      });
+    }
+  }, [hideTimeSortOptions, showVoters, sortOption.sortKey]);
 
   const handleClick = () => {
     setIsClicked(!isClicked);
@@ -29,12 +58,12 @@ const ProposalVotesCard = ({ proposal }: { proposal: Proposal }) => {
 
   return (
     <div
-      className={`fixed flex justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] bg-neutral border border-line rounded-xl shadow-newDefault mb-8 transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"} sm:overflow-y-auto`}
+      className={`fixed flex flex-col justify-between gap-4 md:sticky top-[auto] md:top-20 md:max-h-[calc(100vh-220px)] max-h-[calc(100%-160px)] items-stretch flex-shrink w-[calc(100vw-2rem)] sm:w-[calc(100vw-4rem)] md:w-[20rem] lg:w-[24rem] bg-neutral border border-line rounded-xl shadow-newDefault mb-8 transition-all ${isClicked ? "bottom-[20px]" : "bottom-[calc(-100%+350px)] h-[calc(100%-160px)] md:h-auto"} sm:overflow-y-auto`}
       style={{
         transition: "bottom 600ms cubic-bezier(0, 0.975, 0.015, 0.995)",
       }}
     >
-      <div className="flex flex-col gap-4 min-h-0 shrink pt-4 w-full">
+      <div className="flex flex-col gap-4 min-h-0 flex-1 shrink pt-4 w-full">
         <button
           onClick={handleClick}
           className="border w-10 h-10 rounded-full bg-neutral absolute top-[-20px] left-[calc(50%-20px)] shadow-newDefault block md:hidden"
@@ -44,33 +73,70 @@ const ProposalVotesCard = ({ proposal }: { proposal: Proposal }) => {
           </div>
         </button>
         <div className="flex flex-col gap-4">
-          <div className="font-semibold px-4 text-primary">Voting activity</div>
           <ProposalVotesSummary proposal={proposal} />
-          <div className="px-4">
+          <div className="px-4 flex flex-col gap-4">
             <ProposalVotesFilter
               initialSelection={showVoters ? "Voters" : "Hasn't voted"}
               onSelectionChange={(value) => {
                 setShowVoters(value === "Voters");
               }}
             />
+            <div className="flex justify-between items-center border-b border-line pb-2">
+              <ProposalVoterListFilter
+                selectedVoterType={selectedVoterType}
+                onVoterTypeChange={setSelectedVoterType}
+                showCitizenHouseFilters={
+                  proposal.proposalType?.includes("HYBRID") || false
+                }
+              />
+              {showVoters ? (
+                <ProposalVotesSort
+                  sortOption={sortOption}
+                  onSortChange={setSortOption}
+                  hideTimeSortOptions={hideTimeSortOptions}
+                />
+              ) : (
+                <ProposalVotesSort
+                  sortOption={sortOption}
+                  onSortChange={setSortOption}
+                  hideTimeSortOptions={true}
+                />
+              )}
+            </div>
           </div>
         </div>
 
         {useArchiveVoteHistory ? (
           showVoters ? (
-            <ArchiveProposalVotesList proposal={proposal} />
+            <ArchiveProposalVotesList
+              proposal={proposal}
+              sort={sortOption.sortKey}
+              sortOrder={sortOption.sortOrder}
+              voterType={selectedVoterType.type}
+            />
           ) : (
-            <ArchiveProposalNonVoterList proposal={proposal} />
+            <ArchiveProposalNonVoterList
+              proposal={proposal}
+              selectedVoterType={selectedVoterType}
+              sort={sortOption.sortKey}
+              sortOrder={sortOption.sortOrder}
+            />
           )
         ) : showVoters ? (
           <ProposalVotesList
             proposalId={proposal.id}
             offchainProposalId={proposal.offchainProposalId}
+            sort={sortOption.sortKey}
+            sortOrder={sortOption.sortOrder}
+            voterType={selectedVoterType.type}
           />
         ) : (
           <ProposalNonVoterList
             proposal={proposal}
             offchainProposalId={proposal.offchainProposalId}
+            sort={sortOption.sortKey}
+            sortOrder={sortOption.sortOrder}
+            selectedVoterType={selectedVoterType}
           />
         )}
         {/* Show the input for the user to vote on a proposal if allowed */}

--- a/src/components/Proposals/ProposalPage/ShareVoteDialog/ShareVoteDialog.tsx
+++ b/src/components/Proposals/ProposalPage/ShareVoteDialog/ShareVoteDialog.tsx
@@ -10,7 +10,7 @@ import { Proposal } from "@/app/api/common/proposals/proposal";
 import agoraLogo from "@/icons/agoraIconWithText.svg";
 import blockIcon from "@/icons/block.svg";
 import { ogLogoForShareVote } from "./TenantLogo";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { format } from "date-fns";
 import { useLatestBlock } from "@/hooks/useLatestBlock";
 import { useState, useEffect } from "react";

--- a/src/components/Votes/ApprovalCastVoteButton/ApprovalCastVoteButton.tsx
+++ b/src/components/Votes/ApprovalCastVoteButton/ApprovalCastVoteButton.tsx
@@ -6,7 +6,7 @@ import { useModal } from "connectkit";
 import { useOpenDialog } from "@/components/Dialogs/DialogProvider/DialogProvider";
 import { useAgoraContext } from "@/contexts/AgoraContext";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { VotingPowerData } from "@/app/api/common/voting-power/votingPower";
 import { MissingVote, checkMissingVoteForDelegate } from "@/lib/voteUtils";
 import {

--- a/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalSingleVote.tsx
+++ b/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalSingleVote.tsx
@@ -1,7 +1,7 @@
 import { HStack, VStack } from "@/components/Layout/Stack";
 import TokenAmountDecorated from "@/components/shared/TokenAmountDecorated";
 import { useAccount, useEnsName } from "wagmi";
-import { type Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { useState } from "react";
 import {
   capitalizeFirstLetter,
@@ -21,10 +21,34 @@ import { fontMapper } from "@/styles/fonts";
 import Link from "next/link";
 import { HoverCard, HoverCardTrigger } from "@/components/ui/hover-card";
 import Markdown from "@/components/shared/Markdown/Markdown";
+import AvatarImage from "@/components/shared/AvatarImage";
+import { truncateAddress } from "@/app/lib/utils/text";
 
 const { token, ui } = Tenant.current();
 
-export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
+const ZERO_VP_VOTE_TOOLTIP =
+  "Zero weight at snapshot—does not affect the outcome.";
+
+const zeroVpTooltipContentClass =
+  "max-w-[11rem] px-3 py-2 text-xs text-secondary leading-snug";
+
+function isZeroVotingPowerWeight(weight: string): boolean {
+  const raw = (weight ?? "").toString().trim().replace(/,/g, "") || "0";
+  try {
+    return BigInt(raw) === 0n;
+  } catch {
+    const n = Number.parseFloat(raw);
+    return Number.isFinite(n) && n === 0;
+  }
+}
+
+export default function ApprovalProposalSingleVote({
+  vote,
+  resolveEns = true,
+}: {
+  vote: Vote;
+  resolveEns?: boolean;
+}) {
   const { address } = useAccount();
   const {
     address: voterAddress,
@@ -41,7 +65,26 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
   const { data } = useEnsName({
     chainId: 1,
     address: voterAddress as `0x${string}`,
+    query: {
+      enabled: resolveEns && !vote.voterMetadata?.name,
+    },
   });
+
+  const displayName = vote.voterMetadata?.name || data;
+
+  const avatar = () => {
+    if (vote.voterMetadata?.image) {
+      return (
+        <AvatarImage src={vote.voterMetadata.image} alt="avatar" size={20} />
+      );
+    }
+
+    if (!resolveEns) {
+      return <AvatarImage alt="Delegate avatar" size={20} />;
+    }
+
+    return <ENSAvatar ensName={data} className="w-5 h-5" size={20} />;
+  };
 
   const _onOpenChange = async (open: boolean) => {
     if (open) {
@@ -51,6 +94,8 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
       setHovered(open);
     }
   };
+
+  const zeroVpVote = isZeroVotingPowerWeight(weight);
 
   return (
     <VStack>
@@ -65,17 +110,57 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
             justifyContent="justify-between"
             className="mb-2 text-xs leading-4"
           >
-            <div className="text-primary font-semibold flex items-center">
-              <ENSAvatar ensName={data} className="w-5 h-5 mr-1" />
-              <div className="text-primary hover:underline">
-                <Link href={`/delegates/${voterAddress}`}>
-                  <ENSName address={voterAddress} />
-                </Link>
+            <div
+              className={
+                zeroVpVote
+                  ? "text-tertiary font-semibold flex items-center"
+                  : "text-primary font-semibold flex items-center"
+              }
+            >
+              <div
+                className={zeroVpVote ? "mr-1 opacity-30 grayscale" : "mr-1"}
+              >
+                {avatar()}
+              </div>
+              <div
+                className={
+                  zeroVpVote
+                    ? "text-tertiary opacity-40 cursor-default"
+                    : "text-primary hover:underline"
+                }
+              >
+                {zeroVpVote ? (
+                  <span>
+                    {displayName ? (
+                      displayName
+                    ) : resolveEns ? (
+                      <ENSName address={voterAddress} />
+                    ) : (
+                      truncateAddress(voterAddress)
+                    )}
+                  </span>
+                ) : (
+                  <Link href={`/delegates/${voterAddress}`}>
+                    {displayName ? (
+                      displayName
+                    ) : resolveEns ? (
+                      <ENSName address={voterAddress} />
+                    ) : (
+                      truncateAddress(voterAddress)
+                    )}
+                  </Link>
+                )}
               </div>
               {address?.toLowerCase() === voterAddress && (
-                <span className="text-primary">&nbsp;(you)</span>
+                <span
+                  className={
+                    zeroVpVote ? "text-tertiary opacity-40" : "text-primary"
+                  }
+                >
+                  &nbsp;(you)
+                </span>
               )}
-              {hovered && (
+              {hovered && !zeroVpVote && (
                 <>
                   <a
                     href={getBlockScanUrl(hash1)}
@@ -96,7 +181,13 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
                 </>
               )}
             </div>
-            <div className={"font-semibold text-primary"}>
+            <div
+              className={
+                zeroVpVote
+                  ? "font-semibold text-tertiary opacity-40"
+                  : "font-semibold text-primary"
+              }
+            >
               <TooltipProvider delayDuration={0}>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -112,8 +203,12 @@ export default function ApprovalProposalSingleVote({ vote }: { vote: Vote }) {
                       />
                     </div>
                   </TooltipTrigger>
-                  <TooltipContent className="p-4">
-                    {`${formatNumber(vote.weight, token.decimals, 2, false, false)} ${token.symbol} Voted ${capitalizeFirstLetter(vote.support)}`}
+                  <TooltipContent
+                    className={zeroVpVote ? zeroVpTooltipContentClass : "p-4"}
+                  >
+                    {zeroVpVote
+                      ? ZERO_VP_VOTE_TOOLTIP
+                      : `${formatNumber(vote.weight, token.decimals, 2, false, false)} ${token.symbol} Voted ${capitalizeFirstLetter(vote.support)}`}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalVotesList.tsx
+++ b/src/components/Votes/ApprovalProposalVotesList/ApprovalProposalVotesList.tsx
@@ -3,7 +3,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import InfiniteScroll from "react-infinite-scroller";
 import { useAccount } from "wagmi";
-import { type Vote } from "@/app/api/common/votes/vote";
+import type {
+  Vote,
+  VotesSort,
+  VotesSortOrder,
+} from "@/app/api/common/votes/vote";
 import ApprovalProposalSingleVote from "./ApprovalProposalSingleVote";
 import { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
 import { useProposalVotes } from "@/hooks/useProposalVotes";
@@ -12,11 +16,18 @@ import { cn } from "@/lib/utils";
 type Props = {
   fetchVotesForProposal: (
     proposalId: string,
-    pagintation: PaginationParams
+    pagintation: PaginationParams,
+    sort?: VotesSort,
+    offchainProposalId?: string,
+    sortOrder?: VotesSortOrder,
+    voterType?: string
   ) => Promise<PaginatedResult<Vote[]>>;
   fetchUserVotes: (proposalId: string, address: string) => Promise<Vote[]>;
   proposalId: string;
   isThresholdCriteria: boolean;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: string;
 };
 
 const LIMIT = 20;
@@ -26,12 +37,18 @@ export default function ApprovalProposalVotesList({
   fetchUserVotes,
   proposalId,
   isThresholdCriteria,
+  sort,
+  sortOrder,
+  voterType,
 }: Props) {
   const { data: fetchedVotes, isFetched } = useProposalVotes({
     enabled: true,
     limit: LIMIT,
     offset: 0,
-    proposalId: proposalId,
+    proposalId,
+    sort,
+    sortOrder,
+    voterType,
   });
 
   const fetching = useRef(false);
@@ -47,17 +64,31 @@ export default function ApprovalProposalVotesList({
   const loadMore = async () => {
     if (!fetching.current && meta?.has_next) {
       fetching.current = true;
-      const data = await fetchVotesForProposal(proposalId, {
-        limit: LIMIT,
-        offset: meta.next_offset,
-      });
-      const existingIds = new Set(proposalVotes.map((v) => v.transactionHash));
-      const uniqueVotes = data?.data?.filter(
-        (v) => !existingIds.has(v.transactionHash)
-      );
-      setPages((prev) => [...prev, { ...data, votes: uniqueVotes }]);
-      setMeta(data.meta);
-      fetching.current = false;
+      try {
+        const data = await fetchVotesForProposal(
+          proposalId,
+          {
+            limit: LIMIT,
+            offset: meta.next_offset,
+          },
+          sort,
+          undefined,
+          sortOrder,
+          voterType
+        );
+        const existingIds = new Set(
+          proposalVotes.map((v) => v.transactionHash)
+        );
+        const uniqueVotes = data?.data?.filter(
+          (v) => !existingIds.has(v.transactionHash)
+        );
+        setPages((prev) => [...prev, { ...data, votes: uniqueVotes }]);
+        setMeta(data.meta);
+      } catch (error) {
+        console.error("Failed to load more approval proposal votes", error);
+      } finally {
+        fetching.current = false;
+      }
     }
   };
 
@@ -91,14 +122,7 @@ export default function ApprovalProposalVotesList({
   }, [connectedAddress, proposalId, fetchUserVotes, fetchUserVoteAndSet]);
 
   return (
-    <div
-      className={cn(
-        "overflow-y-scroll min-h-[36px]",
-        isThresholdCriteria
-          ? "max-h-[calc(100vh-560px)]"
-          : "max-h-[calc(100vh-527px)]"
-      )}
-    >
+    <div className={cn("overflow-y-scroll min-h-[36px]", "flex-1 min-h-0")}>
       <InfiniteScroll
         hasMore={meta?.has_next}
         pageStart={1}

--- a/src/components/Votes/ApprovalProposalVotesList/ArchiveApprovalProposalVotesList.tsx
+++ b/src/components/Votes/ApprovalProposalVotesList/ArchiveApprovalProposalVotesList.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import InfiniteScroll from "react-infinite-scroller";
+import { useMemo } from "react";
 import { useAccount } from "wagmi";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { Vote } from "@/app/api/common/votes/vote";
+import type {
+  Vote,
+  VotesSort,
+  VotesSortOrder,
+  VoterTypes,
+} from "@/app/api/common/votes/vote";
 import ApprovalProposalSingleVote from "./ApprovalProposalSingleVote";
 import type { ProposalType } from "@/lib/types";
 import { useArchiveVotes } from "@/hooks/useArchiveProposalVotes";
+import { useVisibleRows } from "@/hooks/useVisibleRows";
 import { cn } from "@/lib/utils";
 import { ParsedProposalData } from "@/lib/proposalUtils";
 
@@ -16,14 +21,19 @@ const VOTES_PAGE_SIZE = 20;
 type ArchiveApprovalProposalVotesListProps = {
   proposal: Proposal;
   isThresholdCriteria: boolean;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: VoterTypes["type"];
 };
 
 export default function ArchiveApprovalProposalVotesList({
   proposal,
   isThresholdCriteria,
+  sort,
+  sortOrder,
+  voterType,
 }: ArchiveApprovalProposalVotesListProps) {
   const { address: connectedAddress } = useAccount();
-  const [visibleCount, setVisibleCount] = useState(VOTES_PAGE_SIZE);
 
   const proposalType: ProposalType = proposal.proposalType ?? "STANDARD";
 
@@ -41,11 +51,10 @@ export default function ArchiveApprovalProposalVotesList({
     proposalId: proposal.id,
     proposalType,
     startBlock,
+    sort,
+    sortOrder,
+    voterType,
   });
-
-  useEffect(() => {
-    setVisibleCount(VOTES_PAGE_SIZE);
-  }, [votes.length]);
 
   const approvalOptionLabels = useMemo(() => {
     if (!proposalType?.includes("APPROVAL") || !proposal.proposalData) {
@@ -134,17 +143,21 @@ export default function ArchiveApprovalProposalVotesList({
     );
   }, [normalizedVotes, userVoteAddressSet]);
 
+  const { containerRef, handleScroll, visibleCount } = useVisibleRows({
+    pageSize: VOTES_PAGE_SIZE,
+    resetKey: [
+      proposal.id,
+      sort ?? "weight",
+      sortOrder ?? "desc",
+      voterType ?? "ALL",
+      remainingVotes.length,
+    ].join(":"),
+    totalCount: remainingVotes.length,
+  });
+
   const paginatedVotes = useMemo(() => {
     return remainingVotes.slice(0, visibleCount);
   }, [remainingVotes, visibleCount]);
-
-  const hasMore = visibleCount < remainingVotes.length;
-
-  const loadMore = useCallback(() => {
-    setVisibleCount((prev) =>
-      Math.min(prev + VOTES_PAGE_SIZE, remainingVotes.length)
-    );
-  }, [remainingVotes.length]);
 
   if (isLoading) {
     return (
@@ -164,52 +177,34 @@ export default function ArchiveApprovalProposalVotesList({
 
   return (
     <div
-      className={cn(
-        "overflow-y-scroll min-h-[36px]",
-        isThresholdCriteria
-          ? "max-h-[calc(100vh-560px)]"
-          : "max-h-[calc(100vh-527px)]"
-      )}
+      ref={containerRef}
+      onScroll={handleScroll}
+      className={cn("overflow-y-scroll min-h-[36px]", "flex-1 min-h-0")}
     >
-      <InfiniteScroll
-        hasMore={hasMore}
-        pageStart={0}
-        loadMore={loadMore}
-        useWindow={false}
-        loader={
-          <div
-            className="flex text-xs font-medium text-secondary justify-center pb-2"
-            key={0}
+      <ul className="flex flex-col divide-y">
+        {userVotes.map((vote) => (
+          <li
+            key={
+              vote.transactionHash ||
+              `${vote.address}-${vote.support}-${vote.weight}`
+            }
+            className="p-4"
           >
-            Loading more votes...
-          </div>
-        }
-      >
-        <ul className="flex flex-col divide-y">
-          {userVotes.map((vote) => (
-            <li
-              key={
-                vote.transactionHash ||
-                `${vote.address}-${vote.support}-${vote.weight}`
-              }
-              className="p-4"
-            >
-              <ApprovalProposalSingleVote vote={vote} />
-            </li>
-          ))}
-          {paginatedVotes.map((vote) => (
-            <li
-              key={
-                vote.transactionHash ||
-                `${vote.address}-${vote.support}-${vote.weight}`
-              }
-              className="p-4"
-            >
-              <ApprovalProposalSingleVote vote={vote} />
-            </li>
-          ))}
-        </ul>
-      </InfiniteScroll>
+            <ApprovalProposalSingleVote vote={vote} />
+          </li>
+        ))}
+        {paginatedVotes.map((vote) => (
+          <li
+            key={
+              vote.transactionHash ||
+              `${vote.address}-${vote.support}-${vote.weight}`
+            }
+            className="p-4"
+          >
+            <ApprovalProposalSingleVote vote={vote} />
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/components/Votes/CastVoteInput/CastVoteContext.tsx
+++ b/src/components/Votes/CastVoteInput/CastVoteContext.tsx
@@ -1,5 +1,5 @@
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { VotingPowerData } from "@/app/api/common/voting-power/votingPower";
 import useAdvancedVoting from "@/hooks/useAdvancedVoting";
 import useSponsoredVoting from "@/hooks/useSponsoredVoting";

--- a/src/components/Votes/CastVoteInput/CastVoteInput.tsx
+++ b/src/components/Votes/CastVoteInput/CastVoteInput.tsx
@@ -5,7 +5,7 @@ import { useAgoraContext } from "@/contexts/AgoraContext";
 import { Button } from "@/components/ui/button";
 import { useModal } from "connectkit";
 import { type Proposal } from "@/app/api/common/proposals/proposal";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { type VotingPowerData } from "@/app/api/common/voting-power/votingPower";
 import {
   checkMissingVoteForDelegate,

--- a/src/components/Votes/CopelandProposalVotesList/ArchiveCopelandProposalVotesList.tsx
+++ b/src/components/Votes/CopelandProposalVotesList/ArchiveCopelandProposalVotesList.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import InfiniteScroll from "react-infinite-scroller";
+import { useMemo } from "react";
 import { useAccount } from "wagmi";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { SnapshotVote } from "@/app/api/common/votes/vote";
+import type { SnapshotVote } from "@/app/api/common/votes/vote";
 import CopelandProposalSingleVote from "./CopelandProposalSingleVote";
 import type { ProposalType } from "@/lib/types";
 import { useArchiveVotes } from "@/hooks/useArchiveProposalVotes";
+import { useVisibleRows } from "@/hooks/useVisibleRows";
 import { cn } from "@/lib/utils";
 import { ParsedProposalData } from "@/lib/proposalUtils";
 
@@ -21,7 +21,6 @@ export default function ArchiveCopelandProposalVotesList({
   proposal,
 }: ArchiveCopelandProposalVotesListProps) {
   const { address: connectedAddress } = useAccount();
-  const [visibleCount, setVisibleCount] = useState(VOTES_PAGE_SIZE);
 
   const proposalType: ProposalType = proposal.proposalType ?? "SNAPSHOT";
   const choices =
@@ -43,10 +42,6 @@ export default function ArchiveCopelandProposalVotesList({
     startBlock,
   });
 
-  useEffect(() => {
-    setVisibleCount(VOTES_PAGE_SIZE);
-  }, [votes.length]);
-
   const normalizedVotes = useMemo(() => {
     return votes.map((vote): SnapshotVote => {
       // For Copeland votes, params contains the ranked choices
@@ -61,9 +56,10 @@ export default function ArchiveCopelandProposalVotesList({
         createdAt: vote.timestamp || new Date(),
         choice: "",
         title: "",
+        voterMetadata: vote.voterMetadata,
       } satisfies SnapshotVote;
     });
-  }, [votes]);
+  }, [choices, votes]);
 
   const connectedAddressLower = useMemo(
     () => connectedAddress?.toLowerCase(),
@@ -90,17 +86,15 @@ export default function ArchiveCopelandProposalVotesList({
     );
   }, [normalizedVotes, userVoteAddressSet]);
 
+  const { containerRef, handleScroll, visibleCount } = useVisibleRows({
+    pageSize: VOTES_PAGE_SIZE,
+    resetKey: [proposal.id, remainingVotes.length].join(":"),
+    totalCount: remainingVotes.length,
+  });
+
   const paginatedVotes = useMemo(() => {
     return remainingVotes.slice(0, visibleCount);
   }, [remainingVotes, visibleCount]);
-
-  const hasMore = visibleCount < remainingVotes.length;
-
-  const loadMore = useCallback(() => {
-    setVisibleCount((prev) =>
-      Math.min(prev + VOTES_PAGE_SIZE, remainingVotes.length)
-    );
-  }, [remainingVotes.length]);
 
   if (isLoading) {
     return (
@@ -119,34 +113,23 @@ export default function ArchiveCopelandProposalVotesList({
   }
 
   return (
-    <div className={cn("overflow-y-scroll max-h-[calc(100vh-560px)]")}>
-      <InfiniteScroll
-        hasMore={hasMore}
-        pageStart={0}
-        loadMore={loadMore}
-        useWindow={false}
-        loader={
-          <div
-            className="flex text-xs font-medium text-secondary justify-center pb-2"
-            key={0}
-          >
-            Loading more votes...
-          </div>
-        }
-      >
-        <ul className="flex flex-col divide-y">
-          {userVotes.map((vote) => (
-            <li key={vote.id} className="p-4">
-              <CopelandProposalSingleVote vote={vote} />
-            </li>
-          ))}
-          {paginatedVotes.map((vote) => (
-            <li key={vote.id} className="p-4">
-              <CopelandProposalSingleVote vote={vote} />
-            </li>
-          ))}
-        </ul>
-      </InfiniteScroll>
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      className={cn("overflow-y-scroll flex-1 min-h-0")}
+    >
+      <ul className="flex flex-col divide-y">
+        {userVotes.map((vote) => (
+          <li key={vote.id} className="p-4">
+            <CopelandProposalSingleVote vote={vote} />
+          </li>
+        ))}
+        {paginatedVotes.map((vote) => (
+          <li key={vote.id} className="p-4">
+            <CopelandProposalSingleVote vote={vote} />
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/components/Votes/CopelandProposalVotesList/CopelandProposalSingleVote.tsx
+++ b/src/components/Votes/CopelandProposalVotesList/CopelandProposalSingleVote.tsx
@@ -1,7 +1,7 @@
 import TokenAmountDecorated from "@/components/shared/TokenAmountDecorated";
 import { useAccount } from "wagmi";
-import { SnapshotVote } from "@/app/api/common/votes/vote";
-import { capitalizeFirstLetter, formatNumber } from "@/lib/utils";
+import type { SnapshotVote } from "@/app/api/common/votes/vote";
+import { formatNumber } from "@/lib/utils";
 import ENSAvatar from "@/components/shared/ENSAvatar";
 import ENSName from "@/components/shared/ENSName";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -11,13 +11,23 @@ import { TooltipTrigger } from "@/components/ui/tooltip";
 import Tenant from "@/lib/tenant/tenant";
 import { fontMapper } from "@/styles/fonts";
 import Link from "next/link";
+import AvatarImage from "@/components/shared/AvatarImage";
+import { truncateAddress } from "@/app/lib/utils/text";
 
 const { token, ui } = Tenant.current();
 
+const ZERO_VP_VOTE_TOOLTIP =
+  "Zero weight at snapshot—does not affect the outcome.";
+
+const zeroVpTooltipContentClass =
+  "max-w-[11rem] px-3 py-2 text-xs text-secondary leading-snug";
+
 export default function CopelandProposalSingleVote({
   vote,
+  resolveEns = true,
 }: {
   vote: SnapshotVote;
+  resolveEns?: boolean;
 }) {
   const { address } = useAccount();
   const {
@@ -27,21 +37,81 @@ export default function CopelandProposalSingleVote({
     choiceLabels,
   } = vote;
 
+  const displayName = vote.voterMetadata?.name;
+  const avatar = () => {
+    if (vote.voterMetadata?.image) {
+      return (
+        <AvatarImage src={vote.voterMetadata.image} alt="avatar" size={20} />
+      );
+    }
+
+    if (!resolveEns) {
+      return <AvatarImage alt="Delegate avatar" size={20} />;
+    }
+
+    return <ENSAvatar ensName={voterAddress} className="w-5 h-5" size={20} />;
+  };
+  const zeroVpVote = vote.votingPower === 0 || Math.round(weight) === 0;
+
   return (
     <div className="flex flex-col">
       <div className="flex items-center justify-between mb-2 text-xs leading-4">
-        <div className="text-primary font-semibold flex items-center">
-          <ENSAvatar ensName={voterAddress} className="w-5 h-5 mr-1" />
-          <div className="text-primary hover:underline">
-            <Link href={`/delegates/${voterAddress}`}>
-              <ENSName address={voterAddress} />
-            </Link>
+        <div
+          className={
+            zeroVpVote
+              ? "text-tertiary font-semibold flex items-center"
+              : "text-primary font-semibold flex items-center"
+          }
+        >
+          <div className={zeroVpVote ? "mr-1 opacity-30 grayscale" : "mr-1"}>
+            {avatar()}
+          </div>
+          <div
+            className={
+              zeroVpVote
+                ? "text-tertiary opacity-40 cursor-default"
+                : "text-primary hover:underline"
+            }
+          >
+            {zeroVpVote ? (
+              <span>
+                {displayName ? (
+                  displayName
+                ) : resolveEns ? (
+                  <ENSName address={voterAddress} />
+                ) : (
+                  truncateAddress(voterAddress)
+                )}
+              </span>
+            ) : (
+              <Link href={`/delegates/${voterAddress}`}>
+                {displayName ? (
+                  displayName
+                ) : resolveEns ? (
+                  <ENSName address={voterAddress} />
+                ) : (
+                  truncateAddress(voterAddress)
+                )}
+              </Link>
+            )}
           </div>
           {address?.toLowerCase() === voterAddress && (
-            <span className="text-primary">&nbsp;(you)</span>
+            <span
+              className={
+                zeroVpVote ? "text-tertiary opacity-40" : "text-primary"
+              }
+            >
+              &nbsp;(you)
+            </span>
           )}
         </div>
-        <div className={"font-semibold text-primary"}>
+        <div
+          className={
+            zeroVpVote
+              ? "font-semibold text-tertiary opacity-40"
+              : "font-semibold text-primary"
+          }
+        >
           <TooltipProvider delayDuration={0}>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -58,17 +128,29 @@ export default function CopelandProposalSingleVote({
                   />
                 </div>
               </TooltipTrigger>
-              <TooltipContent className="p-4 max-h-[300px] overflow-y-auto flex flex-col gap-2">
-                <span>
-                  {`${formatNumber(String(Math.round(vote.votingPower)), 0, 2, false, false)} ${token.symbol} Voted`}
-                </span>
-                <div className="flex flex-col gap-1">
-                  {choiceLabels?.map((option: string, index: number) => (
-                    <p key={index}>
-                      {++index}. {option}
-                    </p>
-                  ))}
-                </div>
+              <TooltipContent
+                className={
+                  zeroVpVote
+                    ? zeroVpTooltipContentClass
+                    : "p-4 max-h-[300px] overflow-y-auto flex flex-col gap-2"
+                }
+              >
+                {zeroVpVote ? (
+                  <span>{ZERO_VP_VOTE_TOOLTIP}</span>
+                ) : (
+                  <>
+                    <span>
+                      {`${formatNumber(String(Math.round(vote.votingPower)), 0, 2, false, false)} ${token.symbol} Voted`}
+                    </span>
+                    <div className="flex flex-col gap-1">
+                      {choiceLabels?.map((option: string, index: number) => (
+                        <p key={index}>
+                          {++index}. {option}
+                        </p>
+                      ))}
+                    </div>
+                  </>
+                )}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/src/components/Votes/CopelandProposalVotesList/CopelandProposalVotesList.tsx
+++ b/src/components/Votes/CopelandProposalVotesList/CopelandProposalVotesList.tsx
@@ -7,7 +7,7 @@ import { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
 import { useSnapshotProposalVotes } from "@/hooks/useProposalVotes";
 import { cn } from "@/lib/utils";
 import CopelandProposalSingleVote from "./CopelandProposalSingleVote";
-import { SnapshotVote } from "@/app/api/common/votes/vote";
+import type { SnapshotVote } from "@/app/api/common/votes/vote";
 
 type Props = {
   fetchVotesForProposal: (
@@ -48,15 +48,20 @@ export default function CopelandProposalVotesList({
   const loadMore = async () => {
     if (!fetching.current && meta?.has_next) {
       fetching.current = true;
-      const data = await fetchVotesForProposal(proposalId, {
-        limit: LIMIT,
-        offset: meta.next_offset,
-      });
-      const existingIds = new Set(proposalVotes.map((v) => v.id));
-      const uniqueVotes = data?.data?.filter((v) => !existingIds.has(v.id));
-      setPages((prev) => [...prev, { ...data, votes: uniqueVotes }]);
-      setMeta(data.meta);
-      fetching.current = false;
+      try {
+        const data = await fetchVotesForProposal(proposalId, {
+          limit: LIMIT,
+          offset: meta.next_offset,
+        });
+        const existingIds = new Set(proposalVotes.map((v) => v.id));
+        const uniqueVotes = data?.data?.filter((v) => !existingIds.has(v.id));
+        setPages((prev) => [...prev, { ...data, votes: uniqueVotes }]);
+        setMeta(data.meta);
+      } catch (error) {
+        console.error("Failed to load more Copeland proposal votes", error);
+      } finally {
+        fetching.current = false;
+      }
     }
   };
 
@@ -93,7 +98,7 @@ export default function CopelandProposalVotesList({
     isFetched && proposalVotes.length === 0 && userVotes.length === 0;
 
   return (
-    <div className={cn("overflow-y-scroll max-h-[calc(100vh-560px)]")}>
+    <div className={cn("overflow-y-scroll flex-1 min-h-0")}>
       <InfiniteScroll
         hasMore={meta?.has_next}
         pageStart={1}

--- a/src/components/Votes/EasApprovalCastVoteButton/EasApprovalCastVoteButton.tsx
+++ b/src/components/Votes/EasApprovalCastVoteButton/EasApprovalCastVoteButton.tsx
@@ -18,7 +18,7 @@ import { useArchiveUserVotingPower } from "@/hooks/useArchiveUserVotingPower";
 import { useUserVotes } from "@/hooks/useProposalVotes";
 import { useAccount } from "wagmi";
 import { SuccessMessage } from "../CastVoteInput/CastVoteInput";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { VoteSuccessMessage } from "../components/VoteSuccessMessage";
 
 type Props = {

--- a/src/components/Votes/ProposalVotesList/ArchiveProposalNonVoterList.tsx
+++ b/src/components/Votes/ProposalVotesList/ArchiveProposalNonVoterList.tsx
@@ -1,86 +1,94 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import InfiniteScroll from "react-infinite-scroller";
+import { useCallback, useEffect, useRef, type UIEvent } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import { ProposalSingleNonVoter } from "./ProposalSingleNonVoter";
 import { useArchiveNonVoters } from "@/hooks/useArchiveProposalVotes";
-import ProposalVoterListFilter from "./ProsalVoterListFilter";
-import { VOTER_TYPES } from "@/lib/constants";
-import { VoterTypes } from "@/app/api/common/votes/vote";
+import type {
+  VotesSort,
+  VotesSortOrder,
+  VoterTypes,
+} from "@/app/api/common/votes/vote";
 
-const NON_VOTERS_PAGE_SIZE = 20;
+const NON_VOTER_ROW_ESTIMATE_PX = 60;
+const SCROLL_FETCH_THRESHOLD_PX = 360;
 
 type ArchiveProposalNonVoterListProps = {
   proposal: Proposal;
+  selectedVoterType: VoterTypes;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
 };
 
 export default function ArchiveProposalNonVoterList({
   proposal,
+  selectedVoterType,
+  sort,
+  sortOrder,
 }: ArchiveProposalNonVoterListProps) {
-  const [visibleCount, setVisibleCount] = useState(NON_VOTERS_PAGE_SIZE);
-  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>(
-    proposal.proposalType?.includes("HYBRID") ||
-      proposal.proposalType?.includes("OFFCHAIN")
-      ? VOTER_TYPES[0]
-      : VOTER_TYPES[VOTER_TYPES.length - 1]
-  );
-
-  const { nonVoters, isLoading, error } = useArchiveNonVoters({
+  const scrollParentRef = useRef<HTMLDivElement | null>(null);
+  const {
+    nonVoters,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useArchiveNonVoters({
     proposalId: proposal.id,
+    sort,
+    sortOrder,
+    voterType: selectedVoterType.type,
   });
 
+  const rowCount = hasNextPage ? nonVoters.length + 1 : nonVoters.length;
+
+  const rowVirtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => scrollParentRef.current,
+    estimateSize: () => NON_VOTER_ROW_ESTIMATE_PX,
+    overscan: 8,
+  });
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+
+  const loadNextPageIfScrolledNearBottom = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element || !hasNextPage || isFetchingNextPage) {
+        return;
+      }
+
+      if (element.scrollHeight <= element.clientHeight) {
+        return;
+      }
+
+      const distanceFromBottom =
+        element.scrollHeight - element.scrollTop - element.clientHeight;
+
+      if (distanceFromBottom <= SCROLL_FETCH_THRESHOLD_PX) {
+        void fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      loadNextPageIfScrolledNearBottom(event.currentTarget);
+    },
+    [loadNextPageIfScrolledNearBottom]
+  );
+
   useEffect(() => {
-    setVisibleCount(NON_VOTERS_PAGE_SIZE);
-  }, [selectedVoterType]);
-
-  // Determine if we should show the filter
-  const shouldShowFilter =
-    proposal.proposalType?.includes("HYBRID") ||
-    proposal.proposalType?.includes("OFFCHAIN") ||
-    !!proposal.offchainProposalId;
-
-  // Filter non-voters by citizen type
-  const filteredNonVoters = useMemo(() => {
-    if (!shouldShowFilter || !selectedVoterType) {
-      return nonVoters;
+    if (
+      scrollParentRef.current &&
+      scrollParentRef.current.scrollTop > 0 &&
+      nonVoters.length
+    ) {
+      loadNextPageIfScrolledNearBottom(scrollParentRef.current);
     }
-
-    return nonVoters.filter((nonVoter) => {
-      const citizenType = nonVoter.citizen_type?.toUpperCase();
-      const selectedType = selectedVoterType.type.toUpperCase();
-
-      // Token House: show non-voters without citizen type
-      if (selectedType === "TH" && !citizenType) {
-        return true;
-      }
-
-      // Map citizen types to voter types
-      if (selectedType === "CHAIN" && citizenType === "CHAIN") {
-        return true;
-      }
-      if (selectedType === "APP" && citizenType === "APP") {
-        return true;
-      }
-      if (selectedType === "USER" && citizenType === "USER") {
-        return true;
-      }
-
-      return false;
-    });
-  }, [nonVoters, selectedVoterType, shouldShowFilter]);
-
-  const paginatedNonVoters = useMemo(() => {
-    return filteredNonVoters.slice(0, visibleCount);
-  }, [filteredNonVoters, visibleCount]);
-
-  const hasMore = visibleCount < filteredNonVoters.length;
-
-  const loadMore = useCallback(() => {
-    setVisibleCount((prev) =>
-      Math.min(prev + NON_VOTERS_PAGE_SIZE, filteredNonVoters.length)
-    );
-  }, [filteredNonVoters.length]);
+  }, [nonVoters.length, loadNextPageIfScrolledNearBottom]);
 
   if (isLoading) {
     return (
@@ -95,53 +103,61 @@ export default function ArchiveProposalNonVoterList({
   }
 
   if (!nonVoters.length) {
+    const emptyMessage =
+      selectedVoterType.type === "ALL"
+        ? "No non-voters data available."
+        : "No non-voters match this filter.";
+
     return (
-      <div className="px-4 pb-4 text-secondary text-xs">
-        No non-voters data available.
+      <div className="px-4 pb-4 min-h-[160px] text-secondary text-xs">
+        {emptyMessage}
       </div>
     );
   }
 
-  const isOffchain = proposal.proposalType?.includes("OFFCHAIN") ?? false;
-
   return (
     <>
-      {shouldShowFilter && (
-        <ProposalVoterListFilter
-          selectedVoterType={selectedVoterType}
-          onVoterTypeChange={setSelectedVoterType}
-          isOffchain={isOffchain}
-        />
-      )}
       <div
-        className="px-4 pb-4 overflow-y-auto min-h-[36px]"
-        style={{
-          maxHeight: shouldShowFilter
-            ? "calc(100vh - 487px)"
-            : "calc(100vh - 437px)",
-        }}
+        ref={scrollParentRef}
+        onScroll={handleScroll}
+        className="px-4 pb-4 overflow-y-auto flex-1 min-h-0"
       >
-        <InfiniteScroll
-          key={selectedVoterType.type}
-          hasMore={hasMore}
-          pageStart={0}
-          loadMore={loadMore}
-          useWindow={false}
-          loader={
-            <div className="flex text-xs font-medium text-secondary" key={0}>
-              Loading ...
-            </div>
-          }
-          element="main"
+        <div
+          className="relative w-full"
+          style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
         >
-          <ul className="flex flex-col gap-2">
-            {paginatedNonVoters.map((nonVoter) => (
-              <li key={nonVoter.delegate}>
+          {virtualRows.map((virtualRow) => {
+            const nonVoter = nonVoters[virtualRow.index];
+            const isLoaderRow = virtualRow.index > nonVoters.length - 1;
+
+            if (isLoaderRow) {
+              return (
+                <div
+                  key="archive-non-voter-loader"
+                  className="absolute left-0 top-0 w-full py-2 text-xs text-secondary"
+                  style={{ transform: `translateY(${virtualRow.start}px)` }}
+                >
+                  {hasNextPage ? "Loading more non-voters..." : null}
+                </div>
+              );
+            }
+
+            if (!nonVoter) {
+              return null;
+            }
+
+            return (
+              <div
+                key={`${nonVoter.delegate}-${nonVoter.citizen_type ?? "TH"}`}
+                data-index={virtualRow.index}
+                className="absolute left-0 top-0 w-full"
+                style={{ transform: `translateY(${virtualRow.start}px)` }}
+              >
                 <ProposalSingleNonVoter voter={nonVoter} proposal={proposal} />
-              </li>
-            ))}
-          </ul>
-        </InfiniteScroll>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </>
   );

--- a/src/components/Votes/ProposalVotesList/ArchiveProposalVotesList.tsx
+++ b/src/components/Votes/ProposalVotesList/ArchiveProposalVotesList.tsx
@@ -1,25 +1,36 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import InfiniteScroll from "react-infinite-scroller";
+import { useMemo, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { useAccount } from "wagmi";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { Vote } from "@/app/api/common/votes/vote";
+import type {
+  VotesSort,
+  VotesSortOrder,
+  VoterTypes,
+  Vote,
+} from "@/app/api/common/votes/vote";
 import { ProposalSingleVote } from "./ProposalSingleVote";
 import type { ProposalType } from "@/lib/types";
 import { useArchiveVotes } from "@/hooks/useArchiveProposalVotes";
 
-const VOTES_PAGE_SIZE = 20;
+const VOTE_ROW_ESTIMATE_PX = 56;
 
 type ArchiveProposalVotesListProps = {
   proposal: Proposal;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: VoterTypes["type"];
 };
 
 export default function ArchiveProposalVotesList({
   proposal,
+  sort,
+  sortOrder,
+  voterType,
 }: ArchiveProposalVotesListProps) {
   const { address: connectedAddress } = useAccount();
-  const [visibleCount, setVisibleCount] = useState(VOTES_PAGE_SIZE);
+  const scrollParentRef = useRef<HTMLDivElement | null>(null);
 
   const proposalType: ProposalType = proposal.proposalType ?? "STANDARD";
 
@@ -37,11 +48,10 @@ export default function ArchiveProposalVotesList({
     proposalId: proposal.id,
     proposalType,
     startBlock,
+    sort,
+    sortOrder,
+    voterType,
   });
-
-  useEffect(() => {
-    setVisibleCount(VOTES_PAGE_SIZE);
-  }, [votes.length]);
 
   const normalizedVotes = useMemo(() => {
     return votes.map(
@@ -89,17 +99,18 @@ export default function ArchiveProposalVotesList({
     );
   }, [normalizedVotes, userVoteAddressSet]);
 
-  const paginatedVotes = useMemo(() => {
-    return remainingVotes.slice(0, visibleCount);
-  }, [remainingVotes, visibleCount]);
+  const listVotes = useMemo(() => {
+    return [...userVotes, ...remainingVotes];
+  }, [remainingVotes, userVotes]);
 
-  const hasMore = visibleCount < remainingVotes.length;
+  const rowVirtualizer = useVirtualizer({
+    count: listVotes.length,
+    getScrollElement: () => scrollParentRef.current,
+    estimateSize: () => VOTE_ROW_ESTIMATE_PX,
+    overscan: 8,
+  });
 
-  const loadMore = useCallback(() => {
-    setVisibleCount((prev) =>
-      Math.min(prev + VOTES_PAGE_SIZE, remainingVotes.length)
-    );
-  }, [remainingVotes.length]);
+  const virtualRows = rowVirtualizer.getVirtualItems();
 
   if (isLoading) {
     return (
@@ -113,47 +124,43 @@ export default function ArchiveProposalVotesList({
 
   if (!normalizedVotes.length) {
     return (
-      <div className="px-4 pb-4 text-secondary text-xs">No votes yet.</div>
+      <div className="px-4 pb-4 min-h-[160px] text-secondary text-xs">
+        No votes yet.
+      </div>
     );
   }
 
   return (
-    <div className="px-4 pb-4 overflow-y-auto min-h-[36px] max-h-[calc(100vh-437px)]">
-      <InfiniteScroll
-        hasMore={hasMore}
-        pageStart={0}
-        loadMore={loadMore}
-        useWindow={false}
-        loader={
-          <div className="flex text-xs font-medium text-secondary" key={0}>
-            Loading more votes...
-          </div>
-        }
-        element="main"
+    <div
+      ref={scrollParentRef}
+      className="px-4 pb-4 overflow-y-auto flex-1 min-h-0"
+    >
+      <div
+        className="relative w-full"
+        style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
       >
-        <ul className="flex flex-col">
-          {userVotes.map((vote) => (
-            <li
+        {virtualRows.map((virtualRow) => {
+          const vote = listVotes[virtualRow.index];
+          if (!vote) {
+            return null;
+          }
+
+          return (
+            <div
               key={
                 vote.transactionHash ||
-                `${vote.address}-${vote.support}-${vote.weight}`
+                `${vote.address}-${vote.support}-${vote.weight}-${virtualRow.index}`
               }
+              ref={rowVirtualizer.measureElement}
+              data-index={virtualRow.index}
+              className="absolute left-0 top-0 w-full"
+              style={{ transform: `translateY(${virtualRow.start}px)` }}
             >
               <ProposalSingleVote vote={vote} />
-            </li>
-          ))}
-          {paginatedVotes.map((vote) => (
-            <li
-              key={
-                vote.transactionHash ||
-                `${vote.address}-${vote.support}-${vote.weight}`
-              }
-            >
-              <ProposalSingleVote vote={vote} />
-            </li>
-          ))}
-        </ul>
-      </InfiniteScroll>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/components/Votes/ProposalVotesList/ProposalNonVoterList.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalNonVoterList.tsx
@@ -7,22 +7,28 @@ import InfiniteScroll from "react-infinite-scroller";
 import { useProposalNonVotes } from "@/hooks/useProposalNonVotes";
 import { Proposal } from "@/app/api/common/proposals/proposal";
 import { ParsedProposalData } from "@/lib/proposalUtils";
-import { Vote, VoterTypes } from "@/app/api/common/votes/vote";
+import type { Vote, VoterTypes } from "@/app/api/common/votes/vote";
 import { ProposalSingleNonVoter } from "./ProposalSingleNonVoter";
 import ProposalVoterListFilter from "./ProsalVoterListFilter";
 import { VOTER_TYPES } from "@/lib/constants";
+import type { VotesSort, VotesSortOrder } from "@/app/api/common/votes/vote";
 
 const LIMIT = 20;
 
 type ProposalNonVoterListProps = {
   proposal: Proposal;
   offchainProposalId?: string;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  selectedVoterType: VoterTypes;
 };
 
 type ProposalNonVoterListContentProps = {
   proposal: Proposal;
   offchainProposalId?: string;
   selectedVoterType: VoterTypes;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
 };
 
 const isApprovalProposal = (proposal: Proposal) => {
@@ -34,6 +40,8 @@ const ProposalNonVoterListContent = ({
   proposal,
   offchainProposalId,
   selectedVoterType,
+  sort,
+  sortOrder,
 }: ProposalNonVoterListContentProps) => {
   const { data: fetchedNonVotes, isFetched } = useProposalNonVotes({
     enabled: true,
@@ -42,40 +50,55 @@ const ProposalNonVoterListContent = ({
     proposalId: proposal.id,
     offchainProposalId,
     type: selectedVoterType.type,
+    sort,
+    sortOrder,
   });
 
   const fetching = useRef(false);
   const [pages, setPages] = useState<PaginatedResult<any[]>[]>([]);
   const [meta, setMeta] = useState<PaginatedResult<Vote[]>["meta"]>();
 
+  // Reset pages when sort/filter changes
+  useEffect(() => {
+    setPages([]);
+    setMeta(undefined);
+  }, [selectedVoterType, sort, sortOrder]);
+
   useEffect(() => {
     if (isFetched && fetchedNonVotes) {
       setPages([fetchedNonVotes]);
       setMeta(fetchedNonVotes.meta);
     }
-  }, [fetchedNonVotes, isFetched]);
+  }, [fetchedNonVotes, isFetched, selectedVoterType, sort, sortOrder]);
 
   const loadMore = useCallback(async () => {
     if (!fetching.current && meta?.has_next) {
       fetching.current = true;
       const voterTypeAtRequest = selectedVoterType.type;
-      const data = await fetchVotersWhoHaveNotVotedForProposal(
-        proposal.id,
-        {
-          limit: LIMIT,
-          offset: meta.next_offset,
-        },
-        offchainProposalId,
-        voterTypeAtRequest
-      );
+      try {
+        const data = await fetchVotersWhoHaveNotVotedForProposal(
+          proposal.id,
+          {
+            limit: LIMIT,
+            offset: meta.next_offset,
+          },
+          offchainProposalId,
+          voterTypeAtRequest,
+          sort,
+          sortOrder
+        );
 
-      if (selectedVoterType.type === voterTypeAtRequest) {
-        setPages((prev) => [...prev, { ...data, votes: data.data }]);
-        setMeta(data.meta);
+        if (selectedVoterType.type === voterTypeAtRequest) {
+          setPages((prev) => [...prev, { ...data, votes: data.data }]);
+          setMeta(data.meta);
+        }
+      } catch (error) {
+        console.error("Failed to load more proposal non-voters", error);
+      } finally {
+        fetching.current = false;
       }
-      fetching.current = false;
     }
-  }, [proposal, meta, selectedVoterType, offchainProposalId]);
+  }, [proposal, meta, selectedVoterType, offchainProposalId, sort, sortOrder]);
 
   const voters = useMemo(() => {
     return pages.flatMap((page) => page.data);
@@ -87,23 +110,8 @@ const ProposalNonVoterListContent = ({
       .proposalSettings?.criteria === "THRESHOLD";
 
   // Calculate max height
-  let baseHeight = 437;
-  if (isThresholdCriteria || proposal.proposalType === "SNAPSHOT") {
-    baseHeight = 560;
-  } else if (isApprovalProposal(proposal)) {
-    baseHeight = 527;
-  }
-
-  // Only add 50px for offchainProposalId to account for filter
-  if (offchainProposalId) {
-    baseHeight += 50;
-  }
-
   return (
-    <div
-      className="px-4 pb-4 overflow-y-auto min-h-[36px]"
-      style={{ maxHeight: `calc(100vh - ${baseHeight}px)` }}
-    >
+    <div className="px-4 pb-4 overflow-y-auto flex-1 min-h-0">
       {isFetched && fetchedNonVotes ? (
         <InfiniteScroll
           hasMore={meta?.has_next}
@@ -123,6 +131,11 @@ const ProposalNonVoterListContent = ({
                 <ProposalSingleNonVoter voter={voter} proposal={proposal} />
               </li>
             ))}
+            {voters.length === 0 && (
+              <div className="px-4 pb-4 text-center text-secondary text-xs">
+                No votes yet
+              </div>
+            )}
           </ul>
         </InfiniteScroll>
       ) : (
@@ -135,30 +148,21 @@ const ProposalNonVoterListContent = ({
 export const ProposalNonVoterList = ({
   proposal,
   offchainProposalId,
+  sort,
+  sortOrder,
+  selectedVoterType,
 }: ProposalNonVoterListProps) => {
-  const [selectedVoterType, setSelectedVoterType] = useState<VoterTypes>(
-    proposal.proposalType?.includes("HYBRID") ||
-      proposal.proposalType?.includes("OFFCHAIN")
-      ? VOTER_TYPES[0]
-      : VOTER_TYPES[VOTER_TYPES.length - 1]
-  );
-
   const isOffchain = proposal.proposalType?.includes("OFFCHAIN") ?? false;
 
   return (
     <>
-      {offchainProposalId && (
-        <ProposalVoterListFilter
-          selectedVoterType={selectedVoterType}
-          onVoterTypeChange={setSelectedVoterType}
-          isOffchain={isOffchain}
-        />
-      )}
       <ProposalNonVoterListContent
-        key={selectedVoterType.type}
+        key={selectedVoterType.type + sort + sortOrder}
         proposal={proposal}
         offchainProposalId={offchainProposalId}
         selectedVoterType={selectedVoterType}
+        sort={sort}
+        sortOrder={sortOrder}
       />
     </>
   );

--- a/src/components/Votes/ProposalVotesList/ProposalSingleNonVoter.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalSingleNonVoter.tsx
@@ -15,13 +15,16 @@ import ENSName from "@/components/shared/ENSName";
 import { fontMapper } from "@/styles/fonts";
 import Link from "next/link";
 import useBlockCacheWrappedEns from "@/hooks/useBlockCacheWrappedEns";
-import { resolveIPFSUrl } from "@/lib/utils";
+import { truncateAddress } from "@/app/lib/utils/text";
+import AvatarImage from "@/components/shared/AvatarImage";
 
 export function ProposalSingleNonVoter({
   voter,
   proposal,
+  resolveEns = true,
 }: {
   proposal: Proposal;
+  resolveEns?: boolean;
   voter: {
     delegate: string;
     voting_power: string;
@@ -34,6 +37,7 @@ export function ProposalSingleNonVoter({
       image: string;
       type: string;
     } | null;
+    votingPowerSource?: "cpls_snapshot";
   };
 }) {
   const { namespace, ui } = Tenant.current();
@@ -44,54 +48,35 @@ export function ProposalSingleNonVoter({
 
   const { data: ensFromBlockCache } = useBlockCacheWrappedEns({
     address: voter.delegate as `0x${string}`,
+    enabled: resolveEns && !voter.voterMetadata?.name,
   });
 
   const { address: connectedAddress } = useAccount();
+  const usesCplsSnapshotVotingPower =
+    voter.votingPowerSource === "cpls_snapshot";
 
   const { data: pastVotes } = useGetVotes({
     address: voter.delegate as `0x${string}`,
-    blockNumber: BigInt(proposal.snapshotBlockNumber),
-    enabled: namespace !== TENANT_NAMESPACES.UNISWAP && !useArchiveVoteHistory,
+    blockNumber: proposal.snapshotBlockNumber
+      ? BigInt(proposal.snapshotBlockNumber)
+      : undefined,
+    enabled:
+      namespace !== TENANT_NAMESPACES.UNISWAP &&
+      !useArchiveVoteHistory &&
+      !usesCplsSnapshotVotingPower,
   });
 
   const ensAvatar = () => {
     if (voter.voterMetadata?.image) {
-      return (
-        <div
-          className={`overflow-hidden rounded-full flex justify-center items-center w-8 h-8`}
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={voter.voterMetadata.image}
-            alt="avatar"
-            className="w-full h-full object-cover"
-          />
-        </div>
-      );
+      return <AvatarImage src={voter.voterMetadata.image} alt="avatar" />;
     }
     if (ensFromBlockCache?.avatar) {
-      const avatarUrl = resolveIPFSUrl(ensFromBlockCache.avatar);
-      if (avatarUrl) {
-        return (
-          <div
-            className={`overflow-hidden rounded-full flex justify-center items-center w-8 h-8`}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={avatarUrl}
-              alt="avatar"
-              className="w-full h-full object-cover"
-            />
-          </div>
-        );
-      }
+      return <AvatarImage src={ensFromBlockCache.avatar} alt="avatar" />;
     }
-    return (
-      <ENSAvatar
-        ensName={ensFromBlockCache?.name || voter.delegate}
-        className="w-8 h-8"
-      />
-    );
+    if (!resolveEns || !ensFromBlockCache?.name) {
+      return <AvatarImage alt="Delegate avatar" />;
+    }
+    return <ENSAvatar ensName={ensFromBlockCache.name} className="w-8 h-8" />;
   };
 
   return (
@@ -111,8 +96,10 @@ export function ProposalSingleNonVoter({
               <Link href={`/delegates/${voter.delegate}`}>
                 {voter.voterMetadata?.name || ensFromBlockCache?.name ? (
                   voter.voterMetadata?.name || ensFromBlockCache?.name
-                ) : (
+                ) : resolveEns ? (
                   <ENSName address={voter.delegate} />
+                ) : (
+                  truncateAddress(voter.delegate)
                 )}
               </Link>
             </div>
@@ -189,7 +176,9 @@ export function ProposalSingleNonVoter({
               amount={
                 voter.citizen_type
                   ? voter.voting_power
-                  : pastVotes || voter.voting_power
+                  : usesCplsSnapshotVotingPower
+                    ? voter.voting_power
+                    : (pastVotes ?? voter.voting_power)
               }
               hideCurrency
               specialFormatting

--- a/src/components/Votes/ProposalVotesList/ProposalSingleVote.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalSingleVote.tsx
@@ -1,14 +1,14 @@
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { useAccount } from "wagmi";
 import { HStack, VStack } from "@/components/Layout/Stack";
 import TokenAmountDecorated from "@/components/shared/TokenAmountDecorated";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 import {
   capitalizeFirstLetter,
+  cn,
   formatNumber,
   getBlockScanUrl,
   timeout,
-  resolveIPFSUrl,
 } from "@/lib/utils";
 import { useState } from "react";
 import ENSAvatar from "@/components/shared/ENSAvatar";
@@ -26,6 +26,8 @@ import { fontMapper } from "@/styles/fonts";
 import Link from "next/link";
 import { HoverCard, HoverCardTrigger } from "@/components/ui/hover-card";
 import useBlockCacheWrappedEns from "@/hooks/useBlockCacheWrappedEns";
+import { truncateAddress } from "@/app/lib/utils/text";
+import AvatarImage from "@/components/shared/AvatarImage";
 
 const { token, ui } = Tenant.current();
 
@@ -67,14 +69,50 @@ function getVoteTooltipText(vote: Vote) {
   return `${amountStr} ${token.symbol} ${verb} ${supportText}`;
 }
 
-// Using Lucide icons instead of Heroicons for better support of strokeWidth
-const SUPPORT_TO_ICON: Record<Support, React.ReactNode> = {
-  ["FOR"]: <CheckIcon strokeWidth={4} className="w-3 h-3 text-positive" />,
-  ["AGAINST"]: <X strokeWidth={4} className="w-3 h-3 text-negative" />,
-  ["ABSTAIN"]: <MinusIcon strokeWidth={4} className="w-3 h-3 text-tertiary" />,
-};
+const ZERO_VP_VOTE_TOOLTIP =
+  "0 VP at snapshot. Vote is recorded onchain but does not affect the proposal outcome.";
 
-export function ProposalSingleVote({ vote }: { vote: Vote }) {
+const zeroVpTooltipContentClass =
+  "max-w-[11rem] px-3 py-2 text-xs text-secondary leading-snug";
+
+function isZeroVotingPowerVote(vote: Vote): boolean {
+  const raw = (vote.weight ?? "").toString().trim().replace(/,/g, "") || "0";
+  try {
+    return BigInt(raw) === 0n;
+  } catch {
+    const n = Number.parseFloat(raw);
+    return Number.isFinite(n) && n === 0;
+  }
+}
+
+function supportIconForVote(support: Support, muteColors: boolean) {
+  const cls = cn(
+    "w-3 h-3",
+    muteColors
+      ? "text-tertiary"
+      : support === "AGAINST"
+        ? "text-negative"
+        : support === "FOR"
+          ? "text-positive"
+          : "text-tertiary"
+  );
+  switch (support) {
+    case "FOR":
+      return <CheckIcon strokeWidth={4} className={cls} />;
+    case "AGAINST":
+      return <X strokeWidth={4} className={cls} />;
+    default:
+      return <MinusIcon strokeWidth={4} className={cls} />;
+  }
+}
+
+export function ProposalSingleVote({
+  vote,
+  resolveEns = true,
+}: {
+  vote: Vote;
+  resolveEns?: boolean;
+}) {
   const { address: connectedAddress } = useAccount();
   const [hovered, setHovered] = useState(false);
   const [hash1, hash2] = vote.transactionHash?.split("|") || [];
@@ -84,6 +122,7 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
 
   const { data: ensFromBlockCache } = useBlockCacheWrappedEns({
     address: vote.address as `0x${string}`,
+    enabled: resolveEns && !vote.voterMetadata?.name,
   });
 
   const _onOpenChange = async (open: boolean) => {
@@ -96,38 +135,17 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
   };
 
   const name = vote.voterMetadata?.name || ensFromBlockCache?.name;
+  const zeroVpVote = isZeroVotingPowerVote(vote);
 
   const ensAvatar = () => {
     if (vote.voterMetadata?.image) {
-      return (
-        <div
-          className={`overflow-hidden rounded-full flex justify-center items-center w-8 h-8`}
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={vote.voterMetadata.image}
-            alt="avatar"
-            className="w-full h-full object-cover"
-          />
-        </div>
-      );
+      return <AvatarImage src={vote.voterMetadata.image} alt="avatar" />;
     }
     if (ensFromBlockCache?.avatar) {
-      const avatarUrl = resolveIPFSUrl(ensFromBlockCache.avatar);
-      if (avatarUrl) {
-        return (
-          <div
-            className={`overflow-hidden rounded-full flex justify-center items-center w-8 h-8`}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={avatarUrl}
-              alt="avatar"
-              className="w-full h-full object-cover"
-            />
-          </div>
-        );
-      }
+      return <AvatarImage src={ensFromBlockCache.avatar} alt="avatar" />;
+    }
+    if (!resolveEns) {
+      return <AvatarImage alt="Delegate avatar" />;
     }
     return <ENSAvatar ensName={ensFromBlockCache?.name} className="w-8 h-8" />;
   };
@@ -150,20 +168,52 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
               className="font-semibold text-secondary"
             >
               <HStack gap={1} alignItems="items-center">
-                {ensAvatar()}
+                <div
+                  className={
+                    zeroVpVote ? "shrink-0 opacity-30 grayscale" : "shrink-0"
+                  }
+                >
+                  {ensAvatar()}
+                </div>
                 <div className="flex flex-col">
-                  <div className="text-primary font-bold hover:underline">
-                    <Link
-                      href={
-                        vote.citizenType
-                          ? `https://atlas.optimism.io/voter_address_info/${vote.address}`
-                          : `/delegates/${vote.address}`
-                      }
-                      target={vote.citizenType ? "_blank" : undefined}
-                      rel={vote.citizenType ? "noopener noreferrer" : undefined}
-                    >
-                      {name ? name : <ENSName address={vote.address} />}
-                    </Link>
+                  <div
+                    className={
+                      zeroVpVote
+                        ? "text-tertiary opacity-40 font-bold cursor-default"
+                        : "text-primary font-bold hover:underline"
+                    }
+                  >
+                    {zeroVpVote ? (
+                      <span>
+                        {name ? (
+                          name
+                        ) : resolveEns ? (
+                          <ENSName address={vote.address} />
+                        ) : (
+                          truncateAddress(vote.address)
+                        )}
+                      </span>
+                    ) : (
+                      <Link
+                        href={
+                          vote.citizenType
+                            ? `https://atlas.optimism.io/voter_address_info/${vote.address}`
+                            : `/delegates/${vote.address}`
+                        }
+                        target={vote.citizenType ? "_blank" : undefined}
+                        rel={
+                          vote.citizenType ? "noopener noreferrer" : undefined
+                        }
+                      >
+                        {name ? (
+                          name
+                        ) : resolveEns ? (
+                          <ENSName address={vote.address} />
+                        ) : (
+                          truncateAddress(vote.address)
+                        )}
+                      </Link>
+                    )}
                   </div>
                   {vote.citizenType && (
                     <div className="text-[9px] font-bold text-tertiary">
@@ -173,9 +223,15 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
                   )}
                 </div>
                 {vote.address === connectedAddress?.toLowerCase() && (
-                  <p className="text-primary">(you)</p>
+                  <p
+                    className={
+                      zeroVpVote ? "text-tertiary opacity-40" : "text-primary"
+                    }
+                  >
+                    (you)
+                  </p>
                 )}
-                {hovered && (!!hash1 || !!hash2) && (
+                {hovered && (!!hash1 || !!hash2) && !zeroVpVote && (
                   <>
                     <a
                       href={getBlockScanUrl(hash1)}
@@ -202,7 +258,9 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
                     <TooltipTrigger asChild>
                       <div
                         className={
-                          vote.support === "AGAINST"
+                          zeroVpVote
+                            ? "text-tertiary opacity-40"
+                            : vote.support === "AGAINST"
                             ? "text-negative"
                             : vote.support === "FOR"
                               ? "text-positive"
@@ -218,12 +276,19 @@ export function ProposalSingleVote({ vote }: { vote: Vote }) {
                             fontMapper[ui?.customization?.tokenAmountFont || ""]
                               ?.variable
                           }
-                          icon={SUPPORT_TO_ICON[vote.support as Support]}
+                          icon={supportIconForVote(
+                            vote.support as Support,
+                            zeroVpVote
+                          )}
                         />
                       </div>
                     </TooltipTrigger>
-                    <TooltipContent className="p-4">
-                      {getVoteTooltipText(vote)}
+                    <TooltipContent
+                      className={zeroVpVote ? zeroVpTooltipContentClass : "p-4"}
+                    >
+                      {zeroVpVote
+                        ? ZERO_VP_VOTE_TOOLTIP
+                        : getVoteTooltipText(vote)}
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>

--- a/src/components/Votes/ProposalVotesList/ProposalVotesList.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalVotesList.tsx
@@ -3,7 +3,7 @@
 import InfiniteScroll from "react-infinite-scroller";
 import { useAccount } from "wagmi";
 import { ProposalSingleVote } from "./ProposalSingleVote";
-import { Vote, VoterTypes } from "@/app/api/common/votes/vote";
+import type { Vote, VoterTypes } from "@/app/api/common/votes/vote";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   fetchProposalVotes,
@@ -11,10 +11,14 @@ import {
 } from "@/app/proposals/actions";
 import { PaginatedResult } from "@/app/lib/pagination";
 import { useProposalVotes } from "@/hooks/useProposalVotes";
+import type { VotesSort, VotesSortOrder } from "@/app/api/common/votes/vote";
 
 interface Props {
   proposalId: string;
   offchainProposalId?: string;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: string;
 }
 
 const LIMIT = 10;
@@ -22,6 +26,9 @@ const LIMIT = 10;
 export default function ProposalVotesList({
   proposalId,
   offchainProposalId,
+  sort = "weight",
+  sortOrder = "desc",
+  voterType = "ALL",
 }: Props) {
   const { data: fetchedVotes, isFetched } = useProposalVotes({
     enabled: true,
@@ -29,6 +36,9 @@ export default function ProposalVotesList({
     offset: 0,
     proposalId: proposalId,
     offchainProposalId,
+    sort,
+    sortOrder,
+    voterType,
   });
 
   const { address: connectedAddress } = useAccount();
@@ -65,7 +75,7 @@ export default function ProposalVotesList({
         meta: fetchedVotes.meta,
       });
     }
-  }, [fetchedVotes, isFetched]);
+  }, [fetchedVotes, isFetched, sort, sortOrder, voterType]); // Reset on sort/filter change
 
   useEffect(() => {
     if (connectedAddress) {
@@ -86,25 +96,39 @@ export default function ProposalVotesList({
   const loadMore = useCallback(async () => {
     if (!fetching.current && voteState.meta?.has_next) {
       fetching.current = true;
-      const data = await fetchProposalVotes(
-        proposalId,
-        {
-          limit: LIMIT,
-          offset: voteState.meta.next_offset,
-        },
-        undefined,
-        offchainProposalId
-      );
-      setVoteState((prev) => ({
-        pages: [...prev.pages, { ...data, votes: data.data }],
-        meta: data.meta,
-      }));
-      fetching.current = false;
+      try {
+        const data = await fetchProposalVotes(
+          proposalId,
+          {
+            limit: LIMIT,
+            offset: voteState.meta.next_offset,
+          },
+          sort,
+          offchainProposalId,
+          sortOrder,
+          voterType
+        );
+        setVoteState((prev) => ({
+          pages: [...prev.pages, { ...data, votes: data.data }],
+          meta: data.meta,
+        }));
+      } catch (error) {
+        console.error("Failed to load more proposal votes", error);
+      } finally {
+        fetching.current = false;
+      }
     }
-  }, [proposalId, voteState.meta]);
+  }, [
+    proposalId,
+    voteState.meta,
+    sort,
+    sortOrder,
+    voterType,
+    offchainProposalId,
+  ]);
 
   return (
-    <div className="px-4 pb-4 overflow-y-auto min-h-[36px] max-h-[calc(100vh-437px)]">
+    <div className="px-4 pb-4 overflow-y-auto flex-1 min-h-0">
       {isFetched && fetchedVotes ? (
         <InfiniteScroll
           hasMore={voteState.meta?.has_next}
@@ -132,6 +156,11 @@ export default function ProposalVotesList({
                 <ProposalSingleVote vote={vote} />
               </li>
             ))}
+            {userVotes.length === 0 && proposalVotes.length === 0 && (
+              <div className="px-4 pb-4 text-center text-secondary text-xs">
+                No votes yet
+              </div>
+            )}
           </ul>
         </InfiniteScroll>
       ) : (

--- a/src/components/Votes/ProposalVotesList/ProposalVotesSort.tsx
+++ b/src/components/Votes/ProposalVotesList/ProposalVotesSort.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown } from "lucide-react";
+import { ArrowDownAZ } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { VotesSort, VotesSortOrder } from "@/app/api/common/votes/vote";
+
+export type SortParams = {
+  sortKey: VotesSort;
+  sortOrder: VotesSortOrder;
+  label: string;
+};
+
+const sortOptions: SortParams[] = [
+  {
+    sortKey: "block_number",
+    sortOrder: "desc",
+    label: "Most Recent",
+  },
+  {
+    sortKey: "block_number",
+    sortOrder: "asc",
+    label: "Oldest",
+  },
+  {
+    sortKey: "weight",
+    sortOrder: "desc",
+    label: "Most Voting Power",
+  },
+  {
+    sortKey: "weight",
+    sortOrder: "asc",
+    label: "Least Voting Power",
+  },
+];
+
+interface ProposalVotesSortProps {
+  sortOption: SortParams;
+  onSortChange: (option: SortParams) => void;
+  hideTimeSortOptions?: boolean;
+}
+
+export default function ProposalVotesSort({
+  sortOption,
+  onSortChange,
+  hideTimeSortOptions = false,
+}: ProposalVotesSortProps) {
+  const visibleOptions = hideTimeSortOptions
+    ? sortOptions.filter((opt) => opt.sortKey !== "block_number")
+    : sortOptions;
+
+  return (
+    <div className="text-primary ml-auto flex-1 min-w-0">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="text-primary w-full bg-transparent hover:bg-wash transition-colors font-medium rounded-lg py-1.5 px-2 flex items-center justify-between text-[11px] min-h-[32px]"
+          >
+            <ArrowDownAZ className="stroke-primary w-3.5 h-3.5 mr-1.5 flex-shrink-0" />
+            <span className="text-left flex-1 leading-tight break-words">
+              {sortOption.label}
+            </span>
+            <ChevronDown className="h-4 w-4 ml-2 opacity-30 hover:opacity-100 flex-shrink-0" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          sideOffset={8}
+          className="w-max min-w-[180px] bg-neutral border border-line p-2 rounded-2xl flex flex-col gap-1 shadow-xl"
+        >
+          {visibleOptions.map((option) => (
+            <DropdownMenuItem
+              key={option.label}
+              onSelect={() => onSortChange(option)}
+              className={cn(
+                "cursor-pointer text-xs py-2 px-3 border rounded-xl font-medium",
+                sortOption.label === option.label
+                  ? "text-primary bg-wash border-line"
+                  : "text-tertiary border-transparent hover:bg-wash"
+              )}
+            >
+              {option.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/src/components/Votes/ProposalVotesList/ProsalVoterListFilter.tsx
+++ b/src/components/Votes/ProposalVotesList/ProsalVoterListFilter.tsx
@@ -4,67 +4,72 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
-  DropdownMenuRadioItem,
+  DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
-import { DropdownMenuRadioGroup } from "@radix-ui/react-dropdown-menu";
+import { ChevronDown } from "lucide-react";
 import { FilterIcon } from "@/icons/filter";
 import { cn } from "@/lib/utils";
 import { VOTER_TYPES } from "@/lib/constants";
-import { VoterTypes } from "@/app/api/common/votes/vote";
+import type { VoterTypes } from "@/app/api/common/votes/vote";
 
 interface ProposalVoterListFilterProps {
   selectedVoterType: VoterTypes;
   onVoterTypeChange: (type: VoterTypes) => void;
-  isOffchain?: boolean;
+  showCitizenHouseFilters?: boolean;
 }
 
 export default function ProposalVoterListFilter({
   selectedVoterType,
   onVoterTypeChange,
-  isOffchain = false,
+  showCitizenHouseFilters = false,
 }: ProposalVoterListFilterProps) {
-  const availableVoterTypes = isOffchain
-    ? VOTER_TYPES.filter((type) => type.type !== "TH")
-    : VOTER_TYPES;
+  const availableVoterTypes = [
+    { type: "ALL", value: "All" },
+    ...(showCitizenHouseFilters
+      ? VOTER_TYPES.map((type) =>
+          type.type === "TH"
+            ? { ...type, value: "Token House (Delegates)" }
+            : type
+        )
+      : []),
+  ];
+
+  if (availableVoterTypes.length <= 1) return null;
 
   return (
-    <div className="flex flex-row items-center justify-between px-4 py-2">
-      <span>{selectedVoterType.value}</span>
+    <div className="text-primary flex-1 min-w-0">
       <DropdownMenu>
-        <DropdownMenuTrigger
-          className={`text-tertiary cursor-pointer outline-none`}
-        >
-          <div className="border border-line rounded-lg px-[10px] py-[6px] flex flex-row items-center gap-2">
-            <FilterIcon className="stroke-primary" />
-            <span className="text-primary">Filter</span>
-          </div>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuRadioGroup
-            value={selectedVoterType.type}
-            onValueChange={(value: string) => {
-              const selectedType = availableVoterTypes.find(
-                (type) => type.type === value
-              );
-              if (selectedType) onVoterTypeChange(selectedType);
-            }}
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="text-primary w-full bg-transparent hover:bg-wash transition-colors font-medium rounded-lg py-1.5 px-2 flex items-center justify-between text-[11px] min-h-[32px]"
           >
-            {availableVoterTypes.map((type) => (
-              <DropdownMenuRadioItem
-                key={type.value}
-                value={type.type}
-                checked={type.type === selectedVoterType.type}
-                className={cn(
-                  "relative flex cursor-pointer select-none items-center rounded-lg p-3 text-base outline-none transition-colors hover:bg-neutral/50",
-                  type.type === selectedVoterType.type
-                    ? "text-primary"
-                    : "text-secondary"
-                )}
-              >
-                {type.value}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
+            <FilterIcon className="stroke-primary w-3.5 h-3.5 mr-1.5 flex-shrink-0" />
+            <span className="text-left flex-1 leading-tight break-words">
+              {selectedVoterType.value}
+            </span>
+            <ChevronDown className="h-4 w-4 ml-2 opacity-30 hover:opacity-100 flex-shrink-0" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          sideOffset={8}
+          className="w-max min-w-[200px] bg-neutral border border-line p-2 rounded-2xl flex flex-col gap-1 shadow-xl"
+        >
+          {availableVoterTypes.map((type) => (
+            <DropdownMenuItem
+              key={type.value}
+              onSelect={() => onVoterTypeChange(type)}
+              className={cn(
+                "cursor-pointer text-xs py-2 px-3 border rounded-xl font-medium",
+                selectedVoterType.type === type.type
+                  ? "text-primary bg-wash border-line"
+                  : "text-tertiary border-transparent hover:bg-wash"
+              )}
+            >
+              {type.value}
+            </DropdownMenuItem>
+          ))}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/components/Votes/__tests__/archiveResolveEnsRows.test.tsx
+++ b/src/components/Votes/__tests__/archiveResolveEnsRows.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SnapshotVote, Vote } from "@/app/api/common/votes/vote";
+import ApprovalProposalSingleVote from "../ApprovalProposalVotesList/ApprovalProposalSingleVote";
+import CopelandProposalSingleVote from "../CopelandProposalVotesList/CopelandProposalSingleVote";
+
+const mocks = vi.hoisted(() => ({
+  useEnsName: vi.fn(),
+}));
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({ address: undefined }),
+  useEnsName: mocks.useEnsName,
+}));
+
+vi.mock("@/lib/tenant/tenant", () => ({
+  default: {
+    current: () => ({
+      token: { decimals: 18, symbol: "OP" },
+      ui: {
+        assets: { delegate: "/delegate.png" },
+        customization: { tokenAmountFont: "" },
+      },
+    }),
+  },
+}));
+
+vi.mock("@/styles/fonts", () => ({
+  fontMapper: {},
+}));
+
+vi.mock("@/lib/utils", () => ({
+  capitalizeFirstLetter: (value: string) => value,
+  formatNumber: (value: string) => value,
+  getBlockScanUrl: () => "#",
+  timeout: () => Promise.resolve(),
+}));
+
+vi.mock("@/app/lib/utils/text", () => ({
+  truncateAddress: (address: string) => `truncated:${address}`,
+}));
+
+vi.mock("@/components/Layout/Stack", () => ({
+  HStack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  VStack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/shared/TokenAmountDecorated", () => ({
+  default: ({ amount }: { amount: string }) => (
+    <span data-testid="token-amount">{amount}</span>
+  ),
+}));
+
+vi.mock("@/components/shared/ENSAvatar", () => ({
+  default: () => <span data-testid="ens-avatar" />,
+}));
+
+vi.mock("@/components/shared/ENSName", () => ({
+  default: () => <span data-testid="ens-name">ens-name</span>,
+}));
+
+vi.mock("@/components/shared/AvatarImage", () => ({
+  default: ({ src }: { src?: string | null }) => (
+    <span data-testid="avatar">{src || "fallback-avatar"}</span>
+  ),
+}));
+
+vi.mock("@/components/shared/Markdown/Markdown", () => ({
+  default: ({ content }: { content: string }) => <span>{content}</span>,
+}));
+
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipProvider: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const voterAddress = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+function makeApprovalVote(overrides: Partial<Vote> = {}): Vote {
+  return {
+    transactionHash: null,
+    address: voterAddress,
+    proposalId: "1",
+    support: "FOR",
+    weight: "1",
+    reason: null,
+    params: ["Choice A"],
+    proposalValue: 0n,
+    proposalTitle: "Proposal",
+    proposalType: "APPROVAL",
+    timestamp: null,
+    blockNumber: undefined,
+    citizenType: null,
+    voterMetadata: null,
+    ...overrides,
+  };
+}
+
+function makeCopelandVote(overrides: Partial<SnapshotVote> = {}): SnapshotVote {
+  return {
+    id: "vote-1",
+    address: voterAddress,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    choice: "",
+    votingPower: 1,
+    title: "Proposal",
+    reason: "",
+    choiceLabels: ["Choice A"],
+    voterMetadata: null,
+    ...overrides,
+  };
+}
+
+describe("archive vote rows with visible-row ENS resolution", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    mocks.useEnsName.mockReset();
+    mocks.useEnsName.mockReturnValue({ data: "resolved.eth" });
+  });
+
+  it("uses approval archive metadata without resolving ENS", () => {
+    render(
+      <ApprovalProposalSingleVote
+        vote={makeApprovalVote({
+          voterMetadata: {
+            name: "Archive Alice",
+            image: "ipfs://alice",
+            type: "",
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText("Archive Alice")).toBeInTheDocument();
+    expect(screen.getByTestId("avatar")).toHaveTextContent("ipfs://alice");
+    expect(screen.queryByTestId("ens-name")).not.toBeInTheDocument();
+    expect(mocks.useEnsName).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { enabled: false },
+      })
+    );
+  });
+
+  it("resolves approval ENS names for visible rows without metadata", () => {
+    render(<ApprovalProposalSingleVote vote={makeApprovalVote()} />);
+
+    expect(screen.getByText("resolved.eth")).toBeInTheDocument();
+    expect(screen.getByTestId("ens-avatar")).toBeInTheDocument();
+    expect(mocks.useEnsName).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { enabled: true },
+      })
+    );
+  });
+
+  it("resolves Copeland ENS names for visible rows without metadata", () => {
+    render(<CopelandProposalSingleVote vote={makeCopelandVote()} />);
+
+    expect(screen.getByTestId("ens-name")).toBeInTheDocument();
+    expect(screen.getByTestId("ens-avatar")).toBeInTheDocument();
+    expect(
+      screen.queryByText(`truncated:${voterAddress}`)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/duna-editor/DunaContentRenderer.tsx
+++ b/src/components/duna-editor/DunaContentRenderer.tsx
@@ -159,6 +159,7 @@ export default function DunaContentRenderer({
   );
   const isMarkdown = !looksLikeHtml(sanitizedContent);
   const renderedContent = useMemo(() => {
+    if (!content) return null;
     if (isMarkdown) {
       return (
         <div className="p-4 prose prose-sm max-w-none">

--- a/src/components/shared/AvatarImage.tsx
+++ b/src/components/shared/AvatarImage.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useMemo, useState } from "react";
+import Tenant from "@/lib/tenant/tenant";
+import { cn, resolveIPFSUrl } from "@/lib/utils";
+
+type AvatarImageProps = {
+  alt: string;
+  className?: string;
+  imageClassName?: string;
+  size?: number;
+  src?: string | null;
+};
+
+export default function AvatarImage({
+  alt,
+  className,
+  imageClassName,
+  size = 32,
+  src,
+}: AvatarImageProps) {
+  const { ui } = Tenant.current();
+  const [hasLoadError, setHasLoadError] = useState(false);
+  const resolvedSrc = useMemo(() => {
+    const trimmedSrc = src?.trim();
+    return trimmedSrc ? resolveIPFSUrl(trimmedSrc) : null;
+  }, [src]);
+
+  useEffect(() => {
+    setHasLoadError(false);
+  }, [resolvedSrc]);
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-full flex justify-center items-center bg-wash shrink-0",
+        className
+      )}
+      style={{ height: size, width: size }}
+    >
+      {resolvedSrc && !hasLoadError ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={resolvedSrc}
+          alt={alt}
+          className={cn("w-full h-full object-cover", imageClassName)}
+          loading="lazy"
+          decoding="async"
+          referrerPolicy="no-referrer"
+          onError={() => setHasLoadError(true)}
+        />
+      ) : (
+        <Image
+          alt={alt}
+          className="animate-in"
+          src={ui.assets.delegate}
+          width={size}
+          height={size}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/ENSAvatar.tsx
+++ b/src/components/shared/ENSAvatar.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useEnsAvatar } from "wagmi";
-import Tenant from "@/lib/tenant/tenant";
 import { GetEnsNameData } from "wagmi/query";
-import Image from "next/image";
-import { resolveIPFSUrl } from "@/lib/utils";
+import AvatarImage from "./AvatarImage";
 
 // TODO: Might be better to load the avatar on the server
 export default function ENSAvatar({
@@ -17,47 +14,18 @@ export default function ENSAvatar({
   className?: string;
   size?: number;
 }) {
-  const { ui } = Tenant.current();
   const { data } = useEnsAvatar({
     chainId: 1,
     name: ensName as string,
   });
 
-  const [avatar, setAvatar] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (data) {
-      // Resolve IPFS URLs to HTTP gateway URLs
-      // Note: resolveIPFSUrl returns null for NFT references (eip155:...)
-      // wagmi's useEnsAvatar should already resolve NFT avatars, but if it returns
-      // an unresolved NFT reference, we skip it and show the placeholder
-      const resolvedUrl = resolveIPFSUrl(data);
-      setAvatar(resolvedUrl);
-    } else {
-      // Reset avatar when data changes to null
-      setAvatar(null);
-    }
-  }, [data, ensName]);
-
   return (
-    <div
-      className={`overflow-hidden rounded-full flex justify-center items-center ${className}`}
-    >
-      {avatar ? (
-        <img
-          alt="ENS Avatar"
-          className={`animate-in w-[${size}px] h-[${size}px] object-contain`}
-          src={avatar}
-        />
-      ) : (
-        <Image
-          alt="ENS Avatar"
-          className="animate-in"
-          src={ui.assets.delegate}
-          width={size}
-          height={size}
-        />
-      )}
-    </div>
+    <AvatarImage
+      src={data}
+      alt="ENS Avatar"
+      className={className}
+      imageClassName="object-contain"
+      size={size}
+    />
   );
 }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -18,8 +18,11 @@ const DropdownMenuContent = React.forwardRef<
     <DropdownMenuPrimitive.Content
       ref={ref}
       align="end"
-      className="w-[335px] rounded-xl flex flex-col justify-start items-start overflow-hidden bg-white shadow-lg z-50"
-      sideOffset={5}
+      className={cn(
+        "w-[335px] rounded-xl flex flex-col justify-start items-start overflow-hidden bg-white shadow-lg z-50",
+        className
+      )}
+      sideOffset={sideOffset}
       sticky="always"
       collisionPadding={16}
       {...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -15,15 +15,18 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-neutral px-3 py-1.5 text-sm text-secondary shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 cursor-auto",
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      collisionPadding={16}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-neutral px-3 py-1.5 text-sm text-secondary shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 cursor-auto",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/src/hooks/__tests__/useVisibleRows.test.tsx
+++ b/src/hooks/__tests__/useVisibleRows.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { UIEvent } from "react";
+import { useVisibleRows } from "../useVisibleRows";
+
+vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+  return window.setTimeout(() => callback(0), 0);
+});
+vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+  window.clearTimeout(id);
+});
+
+function scrollEvent({
+  clientHeight = 100,
+  scrollHeight = 1000,
+  scrollTop,
+}: {
+  clientHeight?: number;
+  scrollHeight?: number;
+  scrollTop: number;
+}) {
+  return {
+    currentTarget: {
+      clientHeight,
+      scrollHeight,
+      scrollTop,
+    },
+  } as UIEvent<HTMLDivElement>;
+}
+
+describe("useVisibleRows", () => {
+  it("loads another page when the scroll container is near the bottom", () => {
+    const { result } = renderHook(() =>
+      useVisibleRows({
+        pageSize: 20,
+        resetKey: "initial",
+        totalCount: 100,
+      })
+    );
+
+    expect(result.current.visibleCount).toBe(20);
+
+    act(() => {
+      result.current.handleScroll(scrollEvent({ scrollTop: 700 }));
+    });
+
+    expect(result.current.visibleCount).toBe(40);
+  });
+
+  it("resets visible rows when the reset key changes", () => {
+    const { result, rerender } = renderHook(
+      ({ resetKey }) =>
+        useVisibleRows({
+          pageSize: 20,
+          resetKey,
+          totalCount: 100,
+        }),
+      { initialProps: { resetKey: "old" } }
+    );
+
+    act(() => {
+      result.current.handleScroll(scrollEvent({ scrollTop: 700 }));
+    });
+    expect(result.current.visibleCount).toBe(40);
+
+    rerender({ resetKey: "new" });
+
+    expect(result.current.visibleCount).toBe(20);
+  });
+
+  it("does not load beyond the total row count", () => {
+    const { result } = renderHook(() =>
+      useVisibleRows({
+        pageSize: 20,
+        resetKey: "initial",
+        totalCount: 25,
+      })
+    );
+
+    act(() => {
+      result.current.handleScroll(scrollEvent({ scrollTop: 700 }));
+      result.current.handleScroll(scrollEvent({ scrollTop: 700 }));
+    });
+
+    expect(result.current.visibleCount).toBe(25);
+  });
+
+  it("does not auto-load when the container has no scrollable overflow", () => {
+    const { result } = renderHook(() =>
+      useVisibleRows({
+        pageSize: 20,
+        resetKey: "initial",
+        totalCount: 100,
+      })
+    );
+
+    act(() => {
+      result.current.handleScroll(
+        scrollEvent({ clientHeight: 1000, scrollHeight: 1000, scrollTop: 0 })
+      );
+    });
+
+    expect(result.current.visibleCount).toBe(20);
+  });
+});

--- a/src/hooks/useArchiveProposalVotes.ts
+++ b/src/hooks/useArchiveProposalVotes.ts
@@ -1,84 +1,28 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import type { ProposalType } from "@/lib/types";
-import type { ArchiveVoteRow, ArchiveNonVoterRow } from "@/lib/archiveUtils";
+import type { ArchiveVoteRow } from "@/lib/archiveUtils";
 import { parseSupport } from "@/lib/voteUtils";
-
-export type ArchiveVote = {
-  transactionHash: string | null;
-  address: string;
-  support: "AGAINST" | "ABSTAIN" | "FOR" | null;
-  weight: string;
-  citizenType: string | null;
-  voterMetadata: {
-    name: string | null;
-    image: string | null;
-    type: string | null;
-  } | null;
-  proposalId: string;
-  proposalType: ProposalType;
-  params: number[] | null;
-  reason: string | null;
-  blockNumber: bigint;
-  timestamp: Date | null;
-};
-
-export type ArchiveNonVoter = {
-  delegate: string;
-  voting_power: string;
-  twitter: string | null;
-  warpcast: string | null;
-  discord: string | null;
-  citizen_type: string | null;
-  voterMetadata: {
-    name: string;
-    image: string;
-    type: string;
-  } | null;
-};
+import type {
+  VotesSort,
+  VotesSortOrder,
+  VoterTypes,
+} from "@/app/api/common/votes/vote";
+import type { PaginatedResult } from "@/app/lib/pagination";
+import Tenant from "@/lib/tenant/tenant";
+import {
+  canArchiveVotesSortByTime,
+  processArchiveVotes,
+  transformArchiveVoteRows,
+  type ArchiveNonVoter,
+  type ArchiveVote,
+} from "@/lib/archiveVoteHistory";
+export type { ArchiveNonVoter, ArchiveVote } from "@/lib/archiveVoteHistory";
 
 const ARCHIVE_VOTES_QK = "archiveVotes";
 const ARCHIVE_NON_VOTERS_QK = "archiveNonVoters";
 
-/**
- * Get citizen type priority for sorting
- */
-function getCitizenTypePriority(
-  citizenType: string | null | undefined
-): number {
-  const citizenTypePriority: Record<string, number> = {
-    CHAIN: 1,
-    APP: 2,
-    USER: 3,
-  };
-
-  if (!citizenType || typeof citizenType !== "string") {
-    return 999;
-  }
-
-  return citizenTypePriority[citizenType.toUpperCase()] ?? 999;
-}
-
-/**
- * Sort by citizen type priority, then by numeric value (descending)
- */
-function sortByCitizenTypeAndValue<T>(
-  items: T[],
-  getValue: (item: T) => number,
-  getCitizenType: (item: T) => string | null | undefined
-): T[] {
-  return items.sort((a, b) => {
-    const aPriority = getCitizenTypePriority(getCitizenType(a));
-    const bPriority = getCitizenTypePriority(getCitizenType(b));
-
-    // First sort by citizen type priority
-    if (aPriority !== bPriority) {
-      return aPriority - bPriority;
-    }
-
-    // Then sort by value (descending) within the same citizen type
-    return getValue(b) - getValue(a);
-  });
-}
+const ARCHIVE_NON_VOTERS_PAGE_SIZE = 100;
 
 /**
  * Fetch and transform archive votes
@@ -87,13 +31,16 @@ async function fetchArchiveVotes({
   proposalId,
   proposalType,
   startBlock,
+  signal,
 }: {
   proposalId: string;
   proposalType: ProposalType;
   startBlock: bigint | number | null;
+  signal?: AbortSignal;
 }): Promise<ArchiveVote[]> {
   const response = await fetch(`/api/archive/votes/${proposalId}`, {
     cache: "no-store",
+    signal,
   });
 
   if (!response.ok) {
@@ -104,67 +51,28 @@ async function fetchArchiveVotes({
     data?: ArchiveVoteRow[];
   };
 
-  // Transform raw data using proposal details
-  const startBlockString =
-    startBlock !== undefined && startBlock !== null
-      ? typeof startBlock === "bigint"
-        ? startBlock.toString()
-        : String(startBlock)
-      : null;
-
-  const parseWeight = (value: string) => {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-  };
-
-  const votes =
-    payload.data?.map((row) => {
-      const support =
-        row.support === null
-          ? null
-          : parseSupport(row.support ?? null, proposalType, startBlockString);
-      const vp = row.weight !== undefined ? String(row.weight) : undefined;
-      const vpForCopelanProposalType =
-        row.vp !== undefined ? String(row.vp) : undefined;
-
-      return {
-        transactionHash: row.transaction_hash ?? null,
-        address: row.voter?.toLowerCase(),
-        support,
-        weight: vp || vpForCopelanProposalType || "0",
-        citizenType: row.citizen_type ?? null,
-        voterMetadata:
-          row.name || row.ens
-            ? {
-                name: row.name || row.ens || "",
-                image: row.image ?? null,
-                type: row.citizen_type || "",
-              }
-            : null,
-        proposalId,
-        proposalType,
-        reason: row.reason ?? null,
-        params: row.params || row.choice || null,
-        blockNumber: row.block_number,
-        timestamp: row.ts ? new Date(Number(row.ts)) : null,
-      } satisfies ArchiveVote;
-    }) ?? [];
-
-  return sortByCitizenTypeAndValue(
-    votes,
-    (vote) => parseWeight(vote.weight),
-    (vote) => vote.citizenType
-  );
+  return transformArchiveVoteRows(payload.data ?? [], {
+    parseSupport,
+    proposalId,
+    proposalType,
+    startBlock,
+  });
 }
 
 export function useArchiveVotes({
   proposalId,
   proposalType,
   startBlock,
+  sort = "weight", // Default to weight
+  sortOrder = "desc", // Default to desc
+  voterType = "ALL",
 }: {
   proposalId: string;
   proposalType: ProposalType;
   startBlock: bigint | number | null;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: VoterTypes["type"];
 }) {
   const startBlockString =
     startBlock !== undefined && startBlock !== null
@@ -175,14 +83,35 @@ export function useArchiveVotes({
 
   const { data, isLoading, error } = useQuery({
     queryKey: [ARCHIVE_VOTES_QK, proposalId, proposalType, startBlockString],
-    queryFn: () => fetchArchiveVotes({ proposalId, proposalType, startBlock }),
+    queryFn: ({ signal }) =>
+      fetchArchiveVotes({ proposalId, proposalType, startBlock, signal }),
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
     retry: 2,
   });
 
+  const processedVotes = useMemo(() => {
+    if (!data) return [];
+
+    return processArchiveVotes(data, {
+      sort,
+      sortOrder,
+      voterType,
+      tokenDecimals: Tenant.current().token.decimals,
+    });
+  }, [data, sort, sortOrder, voterType]);
+
+  const canSortByTime = useMemo(() => {
+    if (!processedVotes.length) {
+      return false;
+    }
+
+    return canArchiveVotesSortByTime(processedVotes);
+  }, [processedVotes]);
+
   return {
-    votes: data ?? [],
+    votes: processedVotes,
+    canSortByTime,
     isLoading,
     error: error ? (error as Error).message : null,
   };
@@ -193,78 +122,92 @@ export function useArchiveVotes({
  */
 async function fetchArchiveNonVoters({
   proposalId,
+  sort,
+  sortOrder,
+  voterType,
+  limit = ARCHIVE_NON_VOTERS_PAGE_SIZE,
+  offset = 0,
+  signal,
 }: {
   proposalId: string;
-}): Promise<ArchiveNonVoter[]> {
-  const response = await fetch(`/api/archive/non-voters/${proposalId}`, {
-    cache: "no-store",
+  sort: VotesSort;
+  sortOrder: VotesSortOrder;
+  voterType: VoterTypes["type"];
+  limit?: number;
+  offset?: number;
+  signal?: AbortSignal;
+}): Promise<PaginatedResult<ArchiveNonVoter[]>> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+    sort,
+    sortOrder,
+    voterType,
   });
+
+  const response = await fetch(
+    `/api/archive/non-voters/${proposalId}?${params}`,
+    {
+      cache: "no-store",
+      signal,
+    }
+  );
 
   if (!response.ok) {
     throw new Error(await response.text());
   }
 
-  const payload = (await response.json()) as {
-    data?: ArchiveNonVoterRow[];
-  };
-
-  // Transform raw data on client side and deduplicate by citizen_type + address
-  const seen = new Set<string>();
-  const nonVoters =
-    payload.data?.reduce<ArchiveNonVoter[]>((acc, row) => {
-      const address = row.addr?.toLowerCase();
-      const citizenType = row.citizen_type ?? "";
-      const dedupeKey = `${citizenType}:${address}`;
-
-      if (!address || seen.has(dedupeKey)) {
-        return acc;
-      }
-
-      seen.add(dedupeKey);
-
-      acc.push({
-        delegate: address,
-        voting_power: row.vp !== undefined ? String(row.vp) : "0",
-        twitter: row.x ?? null,
-        warpcast: row.warpcast ?? null,
-        discord: row.discord ?? null,
-        citizen_type: row.citizen_type ?? null,
-        voterMetadata:
-          row.name || row.ens
-            ? {
-                name: row.name || row.ens || "",
-                image: row.image || "",
-                type: row.citizen_type || "",
-              }
-            : null,
-      } satisfies ArchiveNonVoter);
-
-      return acc;
-    }, []) ?? [];
-
-  const parseVotingPower = (value: string) => {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-  };
-
-  return sortByCitizenTypeAndValue(
-    nonVoters,
-    (nonVoter) => parseVotingPower(nonVoter.voting_power),
-    (nonVoter) => nonVoter.citizen_type
-  );
+  return (await response.json()) as PaginatedResult<ArchiveNonVoter[]>;
 }
 
-export function useArchiveNonVoters({ proposalId }: { proposalId: string }) {
-  const { data, isLoading, error } = useQuery({
-    queryKey: [ARCHIVE_NON_VOTERS_QK, proposalId],
-    queryFn: () => fetchArchiveNonVoters({ proposalId }),
+export function useArchiveNonVoters({
+  proposalId,
+  sort = "weight",
+  sortOrder = "desc",
+  voterType = "ALL",
+}: {
+  proposalId: string;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: VoterTypes["type"];
+}) {
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: [ARCHIVE_NON_VOTERS_QK, proposalId, sort, sortOrder, voterType],
+    queryFn: ({ pageParam, signal }) =>
+      fetchArchiveNonVoters({
+        proposalId,
+        sort,
+        sortOrder,
+        voterType,
+        offset: pageParam,
+        signal,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.meta.has_next ? lastPage.meta.next_offset : undefined,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
     retry: 2,
   });
 
+  const processedNonVoters = useMemo(() => {
+    if (!data) return [];
+
+    return data.pages.flatMap((page) => page.data);
+  }, [data]);
+
   return {
-    nonVoters: data ?? [],
+    nonVoters: processedNonVoters,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
     isLoading,
     error: error ? (error as Error).message : null,
   };

--- a/src/hooks/useBlockCacheWrappedEns.ts
+++ b/src/hooks/useBlockCacheWrappedEns.ts
@@ -19,7 +19,7 @@ const useBlockCacheWrappedEns = ({
 }: UseBlockCacheWrappedEnsProps) => {
   const { data } = useQuery<EnsData>({
     queryKey: ["blockCacheEns", chainId, address],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const headers: HeadersInit = {};
 
       // Add Alchemy API key header if available
@@ -34,6 +34,7 @@ const useBlockCacheWrappedEns = ({
         `https://blockcache-production.up.railway.app/ens_avatar/${chainId}/${address}`,
         {
           headers,
+          signal,
         }
       );
 

--- a/src/hooks/useFetchAllForVoting.ts
+++ b/src/hooks/useFetchAllForVoting.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type Proposal } from "@/app/api/common/proposals/proposal";
 import { VotingPowerData } from "@/app/api/common/voting-power/votingPower";
 import { Delegate } from "@/app/api/common/delegates/delegate";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 
 const useFetchAllForVoting = ({
   proposal,

--- a/src/hooks/useGetVotes.ts
+++ b/src/hooks/useGetVotes.ts
@@ -11,7 +11,7 @@ export const useGetVotes = ({
   enabled,
 }: {
   address: `0x${string}`;
-  blockNumber: bigint;
+  blockNumber: bigint | undefined;
   enabled: boolean;
 }) => {
   const client = getPublicClient();
@@ -20,7 +20,7 @@ export const useGetVotes = ({
 
   const res = useQuery({
     enabled: enabled,
-    queryKey: [VOTES_QK, address, blockNumber.toString()],
+    queryKey: [VOTES_QK, address, blockNumber?.toString()],
     queryFn: async () => {
       let votes: bigint;
       if (namespace === TENANT_NAMESPACES.UNISWAP) {

--- a/src/hooks/useProposalNonVotes.ts
+++ b/src/hooks/useProposalNonVotes.ts
@@ -1,7 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { PaginatedResult } from "@/app/lib/pagination";
 import { fetchVotersWhoHaveNotVotedForProposal } from "@/app/proposals/actions";
-import { VoterTypes } from "@/app/api/common/votes/vote";
+import type {
+  VoterTypes,
+  VotesSort,
+  VotesSortOrder,
+} from "@/app/api/common/votes/vote";
 
 interface Props {
   enabled: boolean;
@@ -10,6 +14,8 @@ interface Props {
   proposalId: string;
   offchainProposalId?: string;
   type?: VoterTypes["type"];
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
 }
 
 const QK = "nonvotes";
@@ -21,10 +27,20 @@ export const useProposalNonVotes = ({
   proposalId,
   offchainProposalId,
   type,
+  sort,
+  sortOrder,
 }: Props) => {
   const { data, isFetching, isFetched } = useQuery({
     enabled: enabled,
-    queryKey: [QK, proposalId, offset, type, offchainProposalId],
+    queryKey: [
+      QK,
+      proposalId,
+      offset,
+      type,
+      offchainProposalId,
+      sort,
+      sortOrder,
+    ],
     queryFn: async () => {
       return (await fetchVotersWhoHaveNotVotedForProposal(
         proposalId,
@@ -33,7 +49,9 @@ export const useProposalNonVotes = ({
           limit: limit || 20,
         },
         offchainProposalId,
-        type
+        type,
+        sort,
+        sortOrder
       )) as PaginatedResult<any[]>;
     },
     staleTime: 30000, // 30 second cache

--- a/src/hooks/useProposalVotes.ts
+++ b/src/hooks/useProposalVotes.ts
@@ -6,7 +6,12 @@ import {
 
 import { useQuery } from "@tanstack/react-query";
 import { PaginatedResult } from "@/app/lib/pagination";
-import { SnapshotVote, Vote } from "@/app/api/common/votes/vote";
+import type {
+  SnapshotVote,
+  Vote,
+  VotesSort,
+  VotesSortOrder,
+} from "@/app/api/common/votes/vote";
 
 interface Props {
   enabled: boolean;
@@ -14,6 +19,9 @@ interface Props {
   offset?: number;
   proposalId: string;
   offchainProposalId?: string;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: string;
 }
 
 const QK = "votes";
@@ -24,10 +32,13 @@ export const useProposalVotes = ({
   offset,
   proposalId,
   offchainProposalId,
+  sort,
+  sortOrder,
+  voterType,
 }: Props) => {
   const { data, isFetching, isFetched } = useQuery({
     enabled: enabled,
-    queryKey: [QK, proposalId, offset],
+    queryKey: [QK, proposalId, offset, sort, sortOrder, voterType],
     queryFn: async () => {
       return (await fetchProposalVotes(
         proposalId,
@@ -35,8 +46,10 @@ export const useProposalVotes = ({
           limit: limit || 20,
           offset: offset || 0,
         },
-        undefined,
-        offchainProposalId
+        sort,
+        offchainProposalId,
+        sortOrder,
+        voterType
       )) as PaginatedResult<Vote[]>;
     },
     staleTime: 60000, // 1 minute cache

--- a/src/hooks/useVisibleRows.ts
+++ b/src/hooks/useVisibleRows.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { UIEvent } from "react";
+
+const SCROLL_THRESHOLD_PX = 240;
+
+export function useVisibleRows({
+  pageSize,
+  resetKey,
+  totalCount,
+}: {
+  pageSize: number;
+  resetKey: string;
+  totalCount: number;
+}) {
+  const [visibleCount, setVisibleCount] = useState(pageSize);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const hasMore = visibleCount < totalCount;
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((prev) => Math.min(prev + pageSize, totalCount));
+  }, [pageSize, totalCount]);
+
+  const loadMoreIfNeeded = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element || !hasMore) {
+        return;
+      }
+
+      const distanceFromBottom =
+        element.scrollHeight - element.scrollTop - element.clientHeight;
+
+      if (element.scrollHeight <= element.clientHeight) {
+        return;
+      }
+
+      if (distanceFromBottom <= SCROLL_THRESHOLD_PX) {
+        loadMore();
+      }
+    },
+    [hasMore, loadMore]
+  );
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      loadMoreIfNeeded(event.currentTarget);
+    },
+    [loadMoreIfNeeded]
+  );
+
+  useEffect(() => {
+    setVisibleCount(pageSize);
+
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0;
+    }
+  }, [pageSize, resetKey]);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      loadMoreIfNeeded(containerRef.current);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [loadMoreIfNeeded, visibleCount, totalCount]);
+
+  return {
+    containerRef,
+    handleScroll,
+    hasMore,
+    visibleCount,
+  };
+}

--- a/src/lib/__tests__/archiveVoteHistory.test.ts
+++ b/src/lib/__tests__/archiveVoteHistory.test.ts
@@ -1,0 +1,540 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildArchiveNonVotersResult,
+  canArchiveVotesSortByTime,
+  processArchiveNonVoters,
+  processArchiveVotes,
+  transformArchiveNonVoterRows,
+  transformArchiveVoteRows,
+  type ArchiveNonVoter,
+  type ArchiveVote,
+} from "../archiveVoteHistory";
+import type { ArchiveNonVoterRow, ArchiveVoteRow } from "../archiveUtils";
+
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_AGORA_INSTANCE_NAME = "optimism";
+  process.env.NEXT_PUBLIC_AGORA_ENV = "prod";
+  process.env.NEXT_PUBLIC_ALCHEMY_ID = "test";
+});
+
+const makeNonVoter = (
+  delegate: string,
+  voting_power: string,
+  citizen_type: string | null = null
+): ArchiveNonVoter => ({
+  delegate,
+  voting_power,
+  citizen_type,
+  twitter: null,
+  warpcast: null,
+  discord: null,
+  voterMetadata: null,
+});
+
+const makeVote = ({
+  address,
+  weight,
+  blockNumber,
+  citizenType = null,
+  timestamp = null,
+}: {
+  address: string;
+  weight: string;
+  blockNumber: bigint | null;
+  citizenType?: string | null;
+  timestamp?: Date | null;
+}): ArchiveVote => ({
+  transactionHash: null,
+  address,
+  support: "FOR",
+  weight,
+  citizenType,
+  voterMetadata: null,
+  proposalId: "1",
+  proposalType: "STANDARD",
+  params: null,
+  reason: null,
+  blockNumber,
+  timestamp,
+});
+
+describe("archive vote-history row transforms", () => {
+  it("transforms archive vote rows with metadata, Copeland VP, params, and temporal fields", () => {
+    const rows: ArchiveVoteRow[] = [
+      {
+        voter: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        support: "1",
+        vp: "42",
+        choice: [2, 1],
+        block_number: "123",
+        transaction_hash: "0xhash",
+        ts: "1700000000000",
+        ens: "alice.eth",
+        image: "ipfs://avatar",
+      },
+    ];
+
+    expect(
+      transformArchiveVoteRows(rows, {
+        parseSupport: (support) => (support === "1" ? "FOR" : "ABSTAIN"),
+        proposalId: "7",
+        proposalType: "SNAPSHOT",
+        startBlock: 1n,
+      })
+    ).toEqual([
+      expect.objectContaining({
+        address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        blockNumber: 123n,
+        params: [2, 1],
+        proposalId: "7",
+        support: "FOR",
+        transactionHash: "0xhash",
+        voterMetadata: {
+          name: "alice.eth",
+          image: "ipfs://avatar",
+          type: "",
+        },
+        weight: "42",
+      }),
+    ]);
+  });
+
+  it("dedupes non-voter rows within each voter type and preserves optional voting power source", () => {
+    const rows: ArchiveNonVoterRow[] = [
+      {
+        addr: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        vp: "100",
+        ens: "alice.eth",
+      },
+      {
+        addr: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        vp: "50",
+        ens: "ignored.eth",
+      },
+      {
+        addr: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        vp: "1",
+        citizen_type: "USER",
+        name: "Citizen Alice",
+      },
+    ];
+
+    expect(
+      transformArchiveNonVoterRows(rows, {
+        votingPowerSource: "cpls_snapshot",
+      })
+    ).toEqual([
+      {
+        delegate: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        voting_power: "100",
+        twitter: null,
+        warpcast: null,
+        discord: null,
+        citizen_type: null,
+        voterMetadata: {
+          name: "alice.eth",
+          image: "",
+          type: "",
+        },
+        votingPowerSource: "cpls_snapshot",
+      },
+      {
+        delegate: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        voting_power: "1",
+        twitter: null,
+        warpcast: null,
+        discord: null,
+        citizen_type: "USER",
+        voterMetadata: {
+          name: "Citizen Alice",
+          image: "",
+          type: "USER",
+        },
+        votingPowerSource: "cpls_snapshot",
+      },
+    ]);
+  });
+});
+
+describe("processArchiveNonVoters", () => {
+  it("sorts archive non-voters by snapshot VP descending and ascending", () => {
+    const nonVoters = [
+      makeNonVoter("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "100"),
+      makeNonVoter(
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "9007199254740993001"
+      ),
+      makeNonVoter(
+        "0xcccccccccccccccccccccccccccccccccccccccc",
+        "9007199254740993000"
+      ),
+    ];
+
+    expect(
+      processArchiveNonVoters(nonVoters, {
+        sort: "weight",
+        sortOrder: "desc",
+      }).map((row) => row.delegate)
+    ).toEqual([
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+
+    expect(
+      processArchiveNonVoters(nonVoters, {
+        sort: "weight",
+        sortOrder: "asc",
+      }).map((row) => row.delegate)
+    ).toEqual([
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]);
+  });
+
+  it("sorts non-voters by displayed VP across houses", () => {
+    const nonVoters = [
+      makeNonVoter("0xcccccccccccccccccccccccccccccccccccccccc", "1", "USER"),
+      makeNonVoter(
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "100000000000000000000"
+      ),
+      makeNonVoter("0xdddddddddddddddddddddddddddddddddddddddd", "5", "APP"),
+      makeNonVoter(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "500000000000000000"
+      ),
+      makeNonVoter(
+        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "1000000000000000000"
+      ),
+    ];
+
+    expect(
+      processArchiveNonVoters(nonVoters, {
+        sort: "weight",
+        sortOrder: "desc",
+        voterType: "ALL",
+      }).map((row) => row.delegate)
+    ).toEqual([
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "0xdddddddddddddddddddddddddddddddddddddddd",
+      "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+
+    expect(
+      processArchiveNonVoters(nonVoters, {
+        sort: "weight",
+        sortOrder: "asc",
+        voterType: "ALL",
+      }).map((row) => row.delegate)
+    ).toEqual([
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "0xdddddddddddddddddddddddddddddddddddddddd",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]);
+  });
+
+  it("filters archive non-voters by voter type", () => {
+    const nonVoters = [
+      makeNonVoter("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "100"),
+      makeNonVoter("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "1", "USER"),
+      makeNonVoter("0xcccccccccccccccccccccccccccccccccccccccc", "1", "APP"),
+      makeNonVoter("0xdddddddddddddddddddddddddddddddddddddddd", "1", "CHAIN"),
+    ];
+
+    expect(
+      processArchiveNonVoters(nonVoters, { voterType: "TH" }).map(
+        (row) => row.delegate
+      )
+    ).toEqual(["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]);
+    expect(
+      processArchiveNonVoters(nonVoters, { voterType: "CH" }).map(
+        (row) => row.delegate
+      )
+    ).toHaveLength(3);
+    expect(
+      processArchiveNonVoters(nonVoters, { voterType: "USER" }).map(
+        (row) => row.delegate
+      )
+    ).toEqual(["0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]);
+  });
+
+  it("uses deterministic delegate ordering for block number fallback", () => {
+    const nonVoters = [
+      makeNonVoter("0xcccccccccccccccccccccccccccccccccccccccc", "1"),
+      makeNonVoter("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "3"),
+      makeNonVoter("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "2"),
+    ];
+
+    expect(
+      processArchiveNonVoters(nonVoters, {
+        sort: "block_number",
+        sortOrder: "asc",
+      }).map((row) => row.delegate)
+    ).toEqual([
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+    ]);
+  });
+
+  it("filters, sorts, and paginates before slicing rows", () => {
+    const nonVoters = [
+      makeNonVoter("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "1"),
+      makeNonVoter("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "4", "USER"),
+      makeNonVoter("0xcccccccccccccccccccccccccccccccccccccccc", "2", "USER"),
+      makeNonVoter("0xdddddddddddddddddddddddddddddddddddddddd", "3", "APP"),
+    ];
+
+    expect(
+      buildArchiveNonVotersResult({
+        nonVoters,
+        pagination: { offset: 1, limit: 1 },
+        sort: "weight",
+        sortOrder: "desc",
+        voterType: "CH",
+      })
+    ).toEqual({
+      meta: {
+        has_next: true,
+        total_returned: 1,
+        next_offset: 2,
+      },
+      data: [
+        makeNonVoter("0xdddddddddddddddddddddddddddddddddddddddd", "3", "APP"),
+      ],
+    });
+  });
+});
+
+describe("processArchiveVotes", () => {
+  it("sorts archive votes by weight and block number", () => {
+    const votes = [
+      makeVote({
+        address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        weight: "100",
+        blockNumber: 20n,
+      }),
+      makeVote({
+        address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        weight: "300",
+        blockNumber: 10n,
+      }),
+      makeVote({
+        address: "0xcccccccccccccccccccccccccccccccccccccccc",
+        weight: "200",
+        blockNumber: 30n,
+      }),
+    ];
+
+    expect(
+      processArchiveVotes(votes, {
+        sort: "weight",
+        sortOrder: "desc",
+      }).map((vote) => vote.address)
+    ).toEqual([
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+
+    expect(
+      processArchiveVotes(votes, {
+        sort: "block_number",
+        sortOrder: "desc",
+      }).map((vote) => vote.address)
+    ).toEqual([
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]);
+  });
+
+  it("filters archive votes by voter type", () => {
+    const votes = [
+      makeVote({
+        address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        weight: "100",
+        blockNumber: 1n,
+      }),
+      makeVote({
+        address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        weight: "1",
+        blockNumber: 2n,
+        citizenType: "USER",
+      }),
+    ];
+
+    expect(
+      processArchiveVotes(votes, { voterType: "TH" }).map(
+        (vote) => vote.address
+      )
+    ).toEqual(["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]);
+    expect(
+      processArchiveVotes(votes, { voterType: "USER" }).map(
+        (vote) => vote.address
+      )
+    ).toEqual(["0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]);
+  });
+
+  it("sorts votes by displayed VP across houses", () => {
+    const votes = [
+      makeVote({
+        address: "0xcccccccccccccccccccccccccccccccccccccccc",
+        weight: "1",
+        blockNumber: 3n,
+        citizenType: "USER",
+      }),
+      makeVote({
+        address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        weight: "100000000000000000000",
+        blockNumber: 2n,
+      }),
+      makeVote({
+        address: "0xdddddddddddddddddddddddddddddddddddddddd",
+        weight: "5",
+        blockNumber: 4n,
+        citizenType: "APP",
+      }),
+      makeVote({
+        address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        weight: "500000000000000000",
+        blockNumber: 1n,
+      }),
+      makeVote({
+        address: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        weight: "1000000000000000000",
+        blockNumber: 5n,
+      }),
+    ];
+
+    expect(
+      processArchiveVotes(votes, {
+        sort: "weight",
+        sortOrder: "desc",
+        voterType: "ALL",
+      }).map((vote) => vote.address)
+    ).toEqual([
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "0xdddddddddddddddddddddddddddddddddddddddd",
+      "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+
+    expect(
+      processArchiveVotes(votes, {
+        sort: "weight",
+        sortOrder: "asc",
+        voterType: "ALL",
+      }).map((vote) => vote.address)
+    ).toEqual([
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "0xdddddddddddddddddddddddddddddddddddddddd",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]);
+  });
+
+  it("sorts only temporal archive votes when some rows lack temporal data", () => {
+    const votes = [
+      makeVote({
+        address: "0xcccccccccccccccccccccccccccccccccccccccc",
+        weight: "1",
+        blockNumber: null,
+        citizenType: "USER",
+      }),
+      makeVote({
+        address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        weight: "100",
+        blockNumber: 20n,
+      }),
+      makeVote({
+        address: "0xdddddddddddddddddddddddddddddddddddddddd",
+        weight: "1",
+        blockNumber: null,
+        citizenType: "APP",
+      }),
+      makeVote({
+        address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        weight: "1",
+        blockNumber: 10n,
+      }),
+    ];
+
+    expect(
+      processArchiveVotes(votes, {
+        sort: "block_number",
+        sortOrder: "desc",
+      }).map((vote) => vote.address)
+    ).toEqual([
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "0xdddddddddddddddddddddddddddddddddddddddd",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+
+    expect(
+      processArchiveVotes(votes, {
+        sort: "block_number",
+        sortOrder: "asc",
+      }).map((vote) => vote.address)
+    ).toEqual([
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "0xdddddddddddddddddddddddddddddddddddddddd",
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ]);
+  });
+
+  it("allows time sorting when any active archive vote has temporal data", () => {
+    expect(
+      canArchiveVotesSortByTime([
+        makeVote({
+          address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          weight: "1",
+          blockNumber: 1n,
+        }),
+        makeVote({
+          address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          weight: "1",
+          blockNumber: 2n,
+        }),
+      ])
+    ).toBe(true);
+
+    expect(
+      canArchiveVotesSortByTime([
+        makeVote({
+          address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          weight: "1",
+          blockNumber: null,
+          timestamp: null,
+        }),
+        makeVote({
+          address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          weight: "1",
+          blockNumber: 2n,
+        }),
+      ])
+    ).toBe(true);
+
+    expect(
+      canArchiveVotesSortByTime([
+        makeVote({
+          address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          weight: "1",
+          blockNumber: null,
+          timestamp: null,
+        }),
+      ])
+    ).toBe(false);
+  });
+});

--- a/src/lib/__tests__/copelandCalculation.test.ts
+++ b/src/lib/__tests__/copelandCalculation.test.ts
@@ -1,5 +1,5 @@
 import { calculateCopelandVote } from "../copelandCalculation";
-import { SnapshotVote } from "@/app/api/common/votes/vote";
+import type { SnapshotVote } from "@/app/api/common/votes/vote";
 import { expect, describe, it, vi } from "vitest";
 
 vi.mock("../../lib/tenant/tenant", () => ({

--- a/src/lib/__tests__/voteUtils.test.ts
+++ b/src/lib/__tests__/voteUtils.test.ts
@@ -1,6 +1,6 @@
 import { calculateVoteMetadata, Support } from "../voteUtils";
 import { Proposal } from "@/app/api/common/proposals/proposal";
-import { Vote } from "@/app/api/common/votes/vote";
+import type { Vote } from "@/app/api/common/votes/vote";
 import { expect, describe, it, vi } from "vitest";
 
 vi.mock("../tenant/tenant", () => ({

--- a/src/lib/archiveUtils.ts
+++ b/src/lib/archiveUtils.ts
@@ -157,7 +157,7 @@ export const fetchProposalFromArchive = async (
 export type ArchiveVoteRow = {
   citizen_type?: string | null;
   transaction_hash?: string | null;
-  block_number: bigint;
+  block_number?: bigint | number | string | null;
   chain_id?: number | null;
   voter: string;
   support?: string | null;

--- a/src/lib/archiveVoteHistory.ts
+++ b/src/lib/archiveVoteHistory.ts
@@ -1,0 +1,556 @@
+import type { PaginatedResult, PaginationParams } from "@/app/lib/pagination";
+import type {
+  VotesSort,
+  VotesSortOrder,
+  VoterTypes,
+} from "@/app/api/common/votes/vote";
+import type { ProposalType } from "@/lib/types";
+import type { ArchiveNonVoterRow, ArchiveVoteRow } from "@/lib/archiveUtils";
+import type { Support } from "@/lib/voteUtils";
+
+export type ArchiveVote = {
+  transactionHash: string | null;
+  address: string;
+  support: Support | null;
+  weight: string;
+  citizenType: string | null;
+  voterMetadata: {
+    name: string | null;
+    image: string | null;
+    type: string | null;
+  } | null;
+  proposalId: string;
+  proposalType: ProposalType;
+  params: number[] | null;
+  reason: string | null;
+  blockNumber: bigint | null;
+  timestamp: Date | null;
+};
+
+export type ArchiveVotingPowerSource = "cpls_snapshot";
+
+export type ArchiveNonVoter = {
+  delegate: string;
+  voting_power: string;
+  twitter: string | null;
+  warpcast: string | null;
+  discord: string | null;
+  citizen_type: string | null;
+  voterMetadata: {
+    name: string;
+    image: string;
+    type: string;
+  } | null;
+  votingPowerSource?: ArchiveVotingPowerSource;
+};
+
+type ArchiveVotesProcessingOptions = {
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: VoterTypes["type"];
+  tokenDecimals?: number;
+};
+
+type ParseArchiveSupport = (
+  support: string | null,
+  proposalType: ProposalType,
+  startBlock: string | null
+) => Support;
+
+export const DEFAULT_ARCHIVE_TOKEN_DECIMALS = 18;
+
+function parseComparableBigInt(
+  value: string | number | bigint | null | undefined
+) {
+  if (typeof value === "bigint") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? BigInt(Math.trunc(value)) : 0n;
+  }
+
+  if (typeof value === "string") {
+    try {
+      return BigInt(value);
+    } catch {
+      return 0n;
+    }
+  }
+
+  return 0n;
+}
+
+function parseNullableBigInt(
+  value: string | number | bigint | null | undefined
+) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+function getTokenScale(tokenDecimals = DEFAULT_ARCHIVE_TOKEN_DECIMALS) {
+  return 10n ** BigInt(Math.max(0, Math.trunc(tokenDecimals)));
+}
+
+function parseUnitAmountToBaseUnits(
+  value: string | number | bigint | null | undefined,
+  tokenDecimals = DEFAULT_ARCHIVE_TOKEN_DECIMALS
+) {
+  const scale = getTokenScale(tokenDecimals);
+
+  if (typeof value === "bigint") {
+    return value * scale;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return 0n;
+    }
+
+    return BigInt(Math.trunc(value * Number(scale)));
+  }
+
+  if (typeof value !== "string") {
+    return 0n;
+  }
+
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return 0n;
+  }
+
+  if (trimmedValue.includes("e") || trimmedValue.includes("E")) {
+    const parsedValue = Number(trimmedValue);
+    return Number.isFinite(parsedValue)
+      ? BigInt(Math.trunc(parsedValue * Number(scale)))
+      : 0n;
+  }
+
+  const [wholePartRaw, fractionalPartRaw = ""] = trimmedValue.split(".");
+  const wholePart = wholePartRaw || "0";
+  const fractionalPart = fractionalPartRaw
+    .slice(0, tokenDecimals)
+    .padEnd(tokenDecimals, "0");
+
+  try {
+    return BigInt(wholePart) * scale + BigInt(fractionalPart || "0");
+  } catch {
+    return 0n;
+  }
+}
+
+function getArchiveVotingPowerSortValue(
+  value: string | number | bigint | null | undefined,
+  citizenType: string | null | undefined,
+  tokenDecimals = DEFAULT_ARCHIVE_TOKEN_DECIMALS
+) {
+  return citizenType
+    ? parseUnitAmountToBaseUnits(value, tokenDecimals)
+    : parseComparableBigInt(value);
+}
+
+function compareArchiveVotingPower(
+  aValue: string | number | bigint | null | undefined,
+  aCitizenType: string | null | undefined,
+  bValue: string | number | bigint | null | undefined,
+  bCitizenType: string | null | undefined,
+  tokenDecimals = DEFAULT_ARCHIVE_TOKEN_DECIMALS
+) {
+  const aPower = getArchiveVotingPowerSortValue(
+    aValue,
+    aCitizenType,
+    tokenDecimals
+  );
+  const bPower = getArchiveVotingPowerSortValue(
+    bValue,
+    bCitizenType,
+    tokenDecimals
+  );
+
+  if (aPower === bPower) {
+    return 0;
+  }
+
+  return aPower < bPower ? -1 : 1;
+}
+
+function getArchiveHouseOrder(
+  citizenType: string | null | undefined,
+  sortOrder: VotesSortOrder
+) {
+  const isCitizenHouse = !!citizenType;
+  if (sortOrder === "asc") {
+    return isCitizenHouse ? 0 : 1;
+  }
+
+  return isCitizenHouse ? 1 : 0;
+}
+
+function hasArchiveTemporalValue(
+  vote: Pick<ArchiveVote, "blockNumber" | "timestamp">
+) {
+  return vote.blockNumber !== undefined && vote.blockNumber !== null
+    ? true
+    : !!vote.timestamp;
+}
+
+export function canArchiveVotesSortByTime(votes: ArchiveVote[]) {
+  return votes.some(hasArchiveTemporalValue);
+}
+
+function getArchiveTemporalSortValue(vote: ArchiveVote) {
+  if (vote.blockNumber !== undefined && vote.blockNumber !== null) {
+    return parseComparableBigInt(vote.blockNumber);
+  }
+
+  const timestamp = vote.timestamp?.getTime();
+  if (timestamp !== undefined && Number.isFinite(timestamp)) {
+    return BigInt(timestamp);
+  }
+
+  return null;
+}
+
+function compareArchiveTemporalVotes(
+  a: { vote: ArchiveVote; index: number },
+  b: { vote: ArchiveVote; index: number },
+  direction: number
+) {
+  const aValue = getArchiveTemporalSortValue(a.vote);
+  const bValue = getArchiveTemporalSortValue(b.vote);
+
+  if (aValue !== null && bValue !== null && aValue !== bValue) {
+    return (aValue < bValue ? -1 : 1) * direction;
+  }
+
+  return a.index - b.index;
+}
+
+function sortArchiveVotesByTime(votes: ArchiveVote[], direction: number) {
+  const indexedVotes = votes.map((vote, index) => ({ vote, index }));
+  const temporalVotes = indexedVotes.filter(({ vote }) =>
+    hasArchiveTemporalValue(vote)
+  );
+
+  if (!temporalVotes.length) {
+    return votes;
+  }
+
+  const sortedTemporalVotes = [...temporalVotes].sort((a, b) =>
+    compareArchiveTemporalVotes(a, b, direction)
+  );
+
+  if (temporalVotes.length === indexedVotes.length) {
+    return sortedTemporalVotes.map(({ vote }) => vote);
+  }
+
+  let temporalIndex = 0;
+  return indexedVotes.map(({ vote }) => {
+    if (!hasArchiveTemporalValue(vote)) {
+      return vote;
+    }
+
+    return sortedTemporalVotes[temporalIndex++].vote;
+  });
+}
+
+export function matchesArchiveVoterType(
+  citizenType: string | null | undefined,
+  voterType: VoterTypes["type"]
+) {
+  const normalizedCitizenType = citizenType?.toUpperCase();
+  const selectedType = voterType.toUpperCase();
+
+  if (selectedType === "ALL") {
+    return true;
+  }
+
+  if (selectedType === "TH") {
+    return !normalizedCitizenType;
+  }
+
+  if (selectedType === "CH") {
+    return !!normalizedCitizenType;
+  }
+
+  return normalizedCitizenType === selectedType;
+}
+
+export function processArchiveVotes(
+  votes: ArchiveVote[],
+  {
+    sort = "weight",
+    sortOrder = "desc",
+    voterType = "ALL",
+    tokenDecimals = DEFAULT_ARCHIVE_TOKEN_DECIMALS,
+  }: ArchiveVotesProcessingOptions
+) {
+  const direction = sortOrder === "asc" ? 1 : -1;
+  const shouldUseHouseTieBreaker = voterType === "ALL" && sort === "weight";
+
+  const filteredVotes = votes.filter((vote) =>
+    matchesArchiveVoterType(vote.citizenType, voterType)
+  );
+
+  if (sort === "block_number") {
+    return sortArchiveVotesByTime(filteredVotes, direction);
+  }
+
+  return [...filteredVotes].sort((a, b) => {
+    const comparison = compareArchiveVotingPower(
+      a.weight,
+      a.citizenType,
+      b.weight,
+      b.citizenType,
+      tokenDecimals
+    );
+
+    if (comparison !== 0) {
+      return comparison * direction;
+    }
+
+    if (shouldUseHouseTieBreaker) {
+      const houseComparison =
+        getArchiveHouseOrder(a.citizenType, sortOrder) -
+        getArchiveHouseOrder(b.citizenType, sortOrder);
+
+      if (houseComparison !== 0) {
+        return houseComparison;
+      }
+    }
+
+    return a.address.localeCompare(b.address);
+  });
+}
+
+export function processArchiveNonVoters<
+  TArchiveNonVoter extends ArchiveNonVoter,
+>(
+  nonVoters: TArchiveNonVoter[],
+  {
+    sort = "weight",
+    sortOrder = "desc",
+    voterType = "ALL",
+    tokenDecimals = DEFAULT_ARCHIVE_TOKEN_DECIMALS,
+  }: ArchiveVotesProcessingOptions
+) {
+  const direction = sortOrder === "asc" ? 1 : -1;
+  const shouldUseHouseTieBreaker = voterType === "ALL" && sort === "weight";
+
+  return nonVoters
+    .filter((nonVoter) =>
+      matchesArchiveVoterType(nonVoter.citizen_type, voterType)
+    )
+    .sort((a, b) => {
+      const comparison =
+        sort === "block_number"
+          ? a.delegate.localeCompare(b.delegate)
+          : compareArchiveVotingPower(
+              a.voting_power,
+              a.citizen_type,
+              b.voting_power,
+              b.citizen_type,
+              tokenDecimals
+            );
+
+      if (comparison !== 0) {
+        return comparison * direction;
+      }
+
+      if (shouldUseHouseTieBreaker) {
+        const houseComparison =
+          getArchiveHouseOrder(a.citizen_type, sortOrder) -
+          getArchiveHouseOrder(b.citizen_type, sortOrder);
+
+        if (houseComparison !== 0) {
+          return houseComparison;
+        }
+      }
+
+      return a.delegate.localeCompare(b.delegate);
+    });
+}
+
+export function paginateArchiveRows<T>(
+  rows: T[],
+  pagination: PaginationParams
+): PaginatedResult<T[]> {
+  if (pagination.limit <= 0 || pagination.offset < 0) {
+    throw new Error(
+      "Limit must be greater than 0 and offset must be non-negative"
+    );
+  }
+
+  const page = rows.slice(
+    pagination.offset,
+    pagination.offset + pagination.limit + 1
+  );
+  const has_next = page.length > pagination.limit;
+  const data = page.slice(0, pagination.limit);
+
+  return {
+    meta: {
+      has_next,
+      total_returned: data.length,
+      next_offset: has_next ? pagination.offset + pagination.limit : 0,
+    },
+    data,
+  };
+}
+
+export function transformArchiveVoteRows(
+  rows: ArchiveVoteRow[],
+  {
+    parseSupport,
+    proposalId,
+    proposalType,
+    startBlock,
+  }: {
+    parseSupport: ParseArchiveSupport;
+    proposalId: string;
+    proposalType: ProposalType;
+    startBlock: bigint | number | string | null;
+  }
+) {
+  const startBlockString =
+    startBlock !== undefined && startBlock !== null
+      ? typeof startBlock === "bigint"
+        ? startBlock.toString()
+        : String(startBlock)
+      : null;
+
+  return rows.reduce<ArchiveVote[]>((acc, row) => {
+    const address = row.voter?.toLowerCase();
+    if (!address) {
+      return acc;
+    }
+
+    const support =
+      row.support === null
+        ? null
+        : parseSupport(row.support ?? null, proposalType, startBlockString);
+    const vp = row.weight !== undefined ? String(row.weight) : undefined;
+    const vpForCopelanProposalType =
+      row.vp !== undefined ? String(row.vp) : undefined;
+
+    acc.push({
+      transactionHash: row.transaction_hash ?? null,
+      address,
+      support,
+      weight: vp || vpForCopelanProposalType || "0",
+      citizenType: row.citizen_type ?? null,
+      voterMetadata:
+        row.name || row.ens
+          ? {
+              name: row.name || row.ens || "",
+              image: row.image ?? null,
+              type: row.citizen_type || "",
+            }
+          : null,
+      proposalId,
+      proposalType,
+      reason: row.reason ?? null,
+      params: row.params || row.choice || null,
+      blockNumber: parseNullableBigInt(row.block_number),
+      timestamp: row.ts ? new Date(Number(row.ts)) : null,
+    });
+
+    return acc;
+  }, []);
+}
+
+export function transformArchiveNonVoterRows<
+  TVotingPowerSource extends ArchiveVotingPowerSource | undefined = undefined,
+>(
+  rows: ArchiveNonVoterRow[],
+  options: { votingPowerSource?: TVotingPowerSource } = {}
+): Array<
+  ArchiveNonVoter &
+    (TVotingPowerSource extends string
+      ? { votingPowerSource: TVotingPowerSource }
+      : object)
+> {
+  const seen = new Set<string>();
+
+  return rows.reduce<
+    Array<
+      ArchiveNonVoter &
+        (TVotingPowerSource extends string
+          ? { votingPowerSource: TVotingPowerSource }
+          : object)
+    >
+  >((acc, row) => {
+    const address = row.addr?.toLowerCase();
+    const citizenType = row.citizen_type ?? "";
+    const dedupeKey = `${citizenType}:${address}`;
+
+    if (!address || seen.has(dedupeKey)) {
+      return acc;
+    }
+
+    seen.add(dedupeKey);
+
+    const nonVoter: ArchiveNonVoter = {
+      delegate: address,
+      voting_power: row.vp !== undefined ? String(row.vp) : "0",
+      twitter: row.x ?? null,
+      warpcast: row.warpcast ?? null,
+      discord: row.discord ?? null,
+      citizen_type: row.citizen_type ?? null,
+      voterMetadata:
+        row.name || row.ens
+          ? {
+              name: row.name || row.ens || "",
+              image: row.image || "",
+              type: row.citizen_type || "",
+            }
+          : null,
+    };
+
+    acc.push({
+      ...nonVoter,
+      ...(options.votingPowerSource
+        ? { votingPowerSource: options.votingPowerSource }
+        : {}),
+    } as ArchiveNonVoter &
+      (TVotingPowerSource extends string
+        ? { votingPowerSource: TVotingPowerSource }
+        : object));
+
+    return acc;
+  }, []);
+}
+
+export function buildArchiveNonVotersResult<
+  TArchiveNonVoter extends ArchiveNonVoter,
+>({
+  nonVoters,
+  pagination,
+  sort = "weight",
+  sortOrder = "desc",
+  voterType = "ALL",
+  tokenDecimals = DEFAULT_ARCHIVE_TOKEN_DECIMALS,
+}: {
+  nonVoters: TArchiveNonVoter[];
+  pagination: PaginationParams;
+  sort?: VotesSort;
+  sortOrder?: VotesSortOrder;
+  voterType?: VoterTypes["type"];
+  tokenDecimals?: number;
+}): PaginatedResult<TArchiveNonVoter[]> {
+  const processedNonVoters = processArchiveNonVoters(nonVoters, {
+    sort,
+    sortOrder,
+    voterType,
+    tokenDecimals,
+  });
+
+  return paginateArchiveRows(processedNonVoters, pagination);
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-import { VoterTypes } from "@/app/api/common/votes/vote";
+import type { VoterTypes } from "@/app/api/common/votes/vote";
 import { type Chain } from "viem";
 import {
   mainnet,
@@ -268,9 +268,10 @@ export type EASApprovalCriteria =
 export const EAS_DEFAULT_OPTIMISTIC_TIERS = [20, 20, 20];
 
 export const ARCHIVE_GCS_BUCKET =
-  process.env.NEXT_PUBLIC_AGORA_ENV === "prod"
+  process.env.ARCHIVE_GCS_BUCKET_OVERRIDE ||
+  (process.env.NEXT_PUBLIC_AGORA_ENV === "prod"
     ? "https://storage.googleapis.com/cpls-usmr-prd-25q4"
-    : "https://storage.googleapis.com/cpls-usmr-dev-test-26q1";
+    : "https://storage.googleapis.com/cpls-usmr-dev-test-26q1");
 
 export const getArchiveSlugGCSbucket = (namespace: string) => {
   return `${ARCHIVE_GCS_BUCKET}/data/${namespace}`;

--- a/src/lib/copelandCalculation.ts
+++ b/src/lib/copelandCalculation.ts
@@ -8,7 +8,7 @@
  * @returns Object containing calculated Copeland scores, winners, and details
  */
 
-import { SnapshotVote } from "@/app/api/common/votes/vote";
+import type { SnapshotVote } from "@/app/api/common/votes/vote";
 
 // Constants
 const NONE_BELOW = "none below";

--- a/src/lib/voteUtils.ts
+++ b/src/lib/voteUtils.ts
@@ -8,7 +8,7 @@ import {
   calculateHybridOptimisticProposalMetrics,
 } from "./proposalUtils";
 import { getHumanBlockTime } from "./blockTimes";
-import {
+import type {
   SnapshotVote,
   Vote,
   VotePayload,


### PR DESCRIPTION
## Summary
- Backports #1522 onto `release/uniswap23rdApr`
- Adds the vote-history sort controls and passes sort/order/voter type through proposal vote list fetches
- Updates archive/non-voter vote history helpers and related row rendering from the merged main change

## Verification
- `pnpm exec vitest run src/lib/__tests__/archiveVoteHistory.test.ts src/hooks/__tests__/useVisibleRows.test.tsx src/components/Votes/__tests__/archiveResolveEnsRows.test.tsx src/app/api/common/votes/__tests__/cplsNonVoters.test.ts`

Context: prod Uniswap is deployed from `release/uniswap23rdApr`, which did not include #1522, so proposal 82 was still using the older weight-first vote history behavior instead of the merged sort-aware behavior from `main`.