### PR TITLE
Fix: Attach Mirador tx hints at submission instead of after confirmation

### DIFF
--- a/src/app/admin/membership/page.tsx
+++ b/src/app/admin/membership/page.tsx
@@ -49,11 +49,6 @@ const AdminMembershipPage = () => {
     const trackedMemberAddress = activeMemberAddressRef.current ?? address;
 
     if (isSuccess) {
-      attachMiradorTransactionArtifacts(traceRef.current, {
-        chainId: tenant.contracts.token.chain.id,
-        txHash,
-        txDetails: "Membership safeMint transaction",
-      });
       void closeFrontendMiradorFlowTrace(traceRef.current, {
         reason: "membership_admin_succeeded",
         eventName: "membership_admin_succeeded",
@@ -160,9 +155,8 @@ const AdminMembershipPage = () => {
       });
       attachMiradorTransactionArtifacts(trace, {
         chainId: tenant.contracts.token.chain.id,
-        inputData,
-        txHash: hash,
-        txDetails: "Membership safeMint transaction",
+        submittedTxHash: hash,
+        submittedTxDetails: "Submitted membership safeMint transaction",
       });
       setTxHash(hash);
     } catch (submitError) {

--- a/src/app/proposals/components/AgoraGovCancel.tsx
+++ b/src/app/proposals/components/AgoraGovCancel.tsx
@@ -21,6 +21,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface Props {
@@ -46,14 +47,16 @@ export const AgoraGovCancel = ({
       hash: data,
     });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.governor.chain.id,
+    details: "Submitted cancel governance proposal transaction",
+  });
+
   useEffect(() => {
     if (isSuccess) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.governor.chain.id,
-          txHash: data,
-          txDetails: "Cancel governance proposal transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",

--- a/src/app/proposals/components/AgoraGovExecute.tsx
+++ b/src/app/proposals/components/AgoraGovExecute.tsx
@@ -27,6 +27,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface Props {
@@ -65,14 +66,16 @@ export const AgoraGovExecute = ({
   const { isLoading, isSuccess, isError, isFetched, error } =
     useWaitForTransactionReceipt({ hash: data });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.governor.chain.id,
+    details: "Submitted execute governance proposal transaction",
+  });
+
   useEffect(() => {
     if (isSuccess) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.governor.chain.id,
-          txHash: data,
-          txDetails: "Execute governance proposal transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",

--- a/src/app/proposals/components/AgoraGovQueue.tsx
+++ b/src/app/proposals/components/AgoraGovQueue.tsx
@@ -15,6 +15,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface Props {
@@ -34,14 +35,16 @@ export const AgoraGovQueue = ({ proposal, className, style }: Props) => {
       hash: data,
     });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.governor.chain.id,
+    details: "Submitted queue governance proposal transaction",
+  });
+
   useEffect(() => {
     if (isSuccess) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.governor.chain.id,
-          txHash: data,
-          txDetails: "Queue governance proposal transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",

--- a/src/app/proposals/components/BravoGovCancel.tsx
+++ b/src/app/proposals/components/BravoGovCancel.tsx
@@ -15,6 +15,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface Props {
@@ -37,14 +38,16 @@ export const BravoGovCancel = ({ proposal }: Props) => {
       hash: data,
     });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.governor.chain.id,
+    details: "Submitted cancel governance proposal transaction",
+  });
+
   useEffect(() => {
     if (isSuccess) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.governor.chain.id,
-          txHash: data,
-          txDetails: "Cancel governance proposal transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",

--- a/src/app/proposals/components/BravoGovExecute.tsx
+++ b/src/app/proposals/components/BravoGovExecute.tsx
@@ -22,6 +22,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface Props {
@@ -63,14 +64,16 @@ export const BravoGovExecute = ({ proposal }: Props) => {
     }
   }, [executionDelayFetched]);
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.governor.chain.id,
+    details: "Submitted execute governance proposal transaction",
+  });
+
   useEffect(() => {
     if (isSuccess) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.governor.chain.id,
-          txHash: data,
-          txDetails: "Execute governance proposal transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",

--- a/src/app/proposals/components/BravoGovQueue.tsx
+++ b/src/app/proposals/components/BravoGovQueue.tsx
@@ -11,6 +11,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface Props {
@@ -28,14 +29,16 @@ export const BravoGovQueue = ({ proposal }: Props) => {
       hash: data,
     });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.governor.chain.id,
+    details: "Submitted queue governance proposal transaction",
+  });
+
   useEffect(() => {
     if (isSuccess) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.governor.chain.id,
-          txHash: data,
-          txDetails: "Queue governance proposal transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",

--- a/src/app/proposals/components/OZGovExecute.tsx
+++ b/src/app/proposals/components/OZGovExecute.tsx
@@ -24,6 +24,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface Props {
@@ -79,14 +80,16 @@ export const OZGovExecute = ({ proposal }: Props) => {
     }
   }, [fetchedRole, fetchedDelay]);
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.governor.chain.id,
+    details: "Submitted execute governance proposal transaction",
+  });
+
   useEffect(() => {
     if (isSuccess) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.governor.chain.id,
-          txHash: data,
-          txDetails: "Execute governance proposal transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",

--- a/src/app/proposals/components/OZGovQueue.tsx
+++ b/src/app/proposals/components/OZGovQueue.tsx
@@ -12,6 +12,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface Props {
@@ -29,14 +30,16 @@ export const OZGovQueue = ({ proposal }: Props) => {
       hash: data,
     });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.governor.chain.id,
+    details: "Submitted queue governance proposal transaction",
+  });
+
   useEffect(() => {
     if (isSuccess) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.governor.chain.id,
-          txHash: data,
-          txDetails: "Queue governance proposal transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",

--- a/src/app/proposals/components/OffchainCancel.tsx
+++ b/src/app/proposals/components/OffchainCancel.tsx
@@ -102,8 +102,9 @@ export const OffchainCancel = ({ proposal }: Props) => {
       attachMiradorTransactionArtifacts(trace, {
         chainId: attestationChainId ?? chain.id,
         inputData: txInputData,
-        txHash,
-        txDetails: "Offchain proposal cancellation attestation transaction",
+        submittedTxHash: txHash,
+        submittedTxDetails:
+          "Submitted offchain proposal cancellation attestation transaction",
       });
       const traceContext = getFrontendMiradorTraceContext(trace, {
         flow: MIRADOR_FLOW.proposalAttestation,
@@ -141,8 +142,9 @@ export const OffchainCancel = ({ proposal }: Props) => {
       attachMiradorTransactionArtifacts(trace, {
         chainId: failedTxContext.chainId ?? chain?.id,
         inputData: failedTxContext.txInputData,
-        txHash: failedTxContext.txHash,
-        txDetails: "Offchain proposal cancellation attestation transaction",
+        submittedTxHash: failedTxContext.txHash,
+        submittedTxDetails:
+          "Failed offchain proposal cancellation attestation transaction",
       });
       void closeFrontendMiradorFlowTrace(trace, {
         reason: "proposal_attestation_failed",

--- a/src/app/proposals/components/UpdateVotableSupplyOracle.tsx
+++ b/src/app/proposals/components/UpdateVotableSupplyOracle.tsx
@@ -94,11 +94,6 @@ export const UpdateVotableSupplyOracle = ({
   useEffect(() => {
     if (isTxConfirmed) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId,
-          txHash,
-          txDetails: "Update votable supply oracle transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "governance_admin_succeeded",
           eventName: "governance_admin_succeeded",
@@ -187,9 +182,9 @@ export const UpdateVotableSupplyOracle = ({
       setTxHash(hash);
       attachMiradorTransactionArtifacts(trace, {
         chainId,
-        inputData,
-        txHash: hash,
-        txDetails: "Update votable supply oracle transaction",
+        submittedTxHash: hash,
+        submittedTxDetails:
+          "Submitted update votable supply oracle transaction",
       });
     } catch (err) {
       console.error("Error updating votable supply:", err);

--- a/src/app/proposals/sponsor/components/OffchainProposalAction.tsx
+++ b/src/app/proposals/sponsor/components/OffchainProposalAction.tsx
@@ -237,8 +237,9 @@ const OffchainProposalAction = ({
       attachMiradorTransactionArtifacts(trace, {
         chainId: attestationChainId ?? chain.id,
         inputData: txInputData,
-        txHash,
-        txDetails: "Offchain proposal attestation transaction",
+        submittedTxHash: txHash,
+        submittedTxDetails:
+          "Submitted offchain proposal attestation transaction",
       });
       const traceContext = getFrontendMiradorTraceContext(trace, {
         flow: MIRADOR_FLOW.proposalAttestation,
@@ -305,8 +306,8 @@ const OffchainProposalAction = ({
       attachMiradorTransactionArtifacts(trace, {
         chainId: failedTxContext.chainId ?? chain.id,
         inputData: failedTxContext.txInputData,
-        txHash: failedTxContext.txHash,
-        txDetails: "Offchain proposal attestation transaction",
+        submittedTxHash: failedTxContext.txHash,
+        submittedTxDetails: "Failed offchain proposal attestation transaction",
       });
       void closeFrontendMiradorFlowTrace(trace, {
         reason: "proposal_attestation_failed",

--- a/src/app/staking/[addressOrENSName]/deposits/Deposit.tsx
+++ b/src/app/staking/[addressOrENSName]/deposits/Deposit.tsx
@@ -28,6 +28,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface DepositProps {
@@ -53,15 +54,17 @@ export const Deposit = ({ deposit, refreshPath }: DepositProps) => {
   const { isLoading: isProcessingWithdrawal, isFetched: didProcessWithdrawal } =
     useWaitForTransactionReceipt({ hash: data });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.staker!.chain.id,
+    details: "Submitted withdraw stake transaction",
+  });
+
   useEffect(() => {
     // Refresh route and invalidate cache if withdrawal was processed
     if (didProcessWithdrawal) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.staker!.chain.id,
-          txHash: data,
-          txDetails: "Withdraw stake transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "staking_withdraw_succeeded",
           eventName: "staking_withdraw_succeeded",

--- a/src/app/staking/components/PanelSetAllowance.tsx
+++ b/src/app/staking/components/PanelSetAllowance.tsx
@@ -17,6 +17,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface PanelSetAllowanceProps {
@@ -43,20 +44,16 @@ export const PanelSetAllowance = ({ amount }: PanelSetAllowanceProps) => {
       hash: data,
     });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.token.chain.id,
+    details: "Submitted token allowance approval transaction",
+  });
+
   useEffect(() => {
     if (didUpdateAllowance) {
       if (traceRef.current) {
-        attachMiradorTransactionArtifacts(traceRef.current, {
-          chainId: contracts.token.chain.id,
-          inputData:
-            config?.request &&
-            "data" in config.request &&
-            typeof config.request.data === "string"
-              ? config.request.data
-              : undefined,
-          txHash: data,
-          txDetails: "Token allowance approval transaction",
-        });
         void closeFrontendMiradorFlowTrace(traceRef.current, {
           reason: "staking_allowance_succeeded",
           eventName: "staking_allowance_succeeded",

--- a/src/app/staking/deposits/[deposit_id]/components/EditDepositConfirm.tsx
+++ b/src/app/staking/deposits/[deposit_id]/components/EditDepositConfirm.tsx
@@ -22,6 +22,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface EditDepositConfirmProps {
@@ -71,19 +72,15 @@ export const EditDepositConfirm = ({
   });
   const isTransactionConfirmed = Boolean(data && !isLoading);
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.staker!.chain.id,
+    details: "Submitted stake more transaction",
+  });
+
   useEffect(() => {
     if (isSuccess && traceRef.current) {
-      attachMiradorTransactionArtifacts(traceRef.current, {
-        chainId: contracts.staker!.chain.id,
-        inputData:
-          config?.request &&
-          "data" in config.request &&
-          typeof config.request.data === "string"
-            ? config.request.data
-            : undefined,
-        txHash: data,
-        txDetails: "Stake more transaction",
-      });
       void closeFrontendMiradorFlowTrace(traceRef.current, {
         reason: "staking_submit_succeeded",
         eventName: "staking_submit_succeeded",

--- a/src/app/staking/deposits/[deposit_id]/delegate/components/EditDelegateConfirm.tsx
+++ b/src/app/staking/deposits/[deposit_id]/delegate/components/EditDelegateConfirm.tsx
@@ -18,6 +18,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface EditDelegateConfirmProps {
@@ -49,19 +50,15 @@ export const EditDelegateConfirm = ({
   });
   const isTransactionConfirmed = Boolean(data && !isLoading);
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.staker!.chain.id,
+    details: "Submitted alter delegate transaction",
+  });
+
   useEffect(() => {
     if (isSuccess && traceRef.current) {
-      attachMiradorTransactionArtifacts(traceRef.current, {
-        chainId: contracts.staker!.chain.id,
-        inputData:
-          config?.request &&
-          "data" in config.request &&
-          typeof config.request.data === "string"
-            ? config.request.data
-            : undefined,
-        txHash: data,
-        txDetails: "Alter delegate transaction",
-      });
       void closeFrontendMiradorFlowTrace(traceRef.current, {
         reason: "staking_submit_succeeded",
         eventName: "staking_submit_succeeded",

--- a/src/app/staking/new/components/NewStakeConfirm.tsx
+++ b/src/app/staking/new/components/NewStakeConfirm.tsx
@@ -20,6 +20,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface NewStakeConfirmProps {
@@ -71,19 +72,15 @@ export const NewStakeConfirm = ({
   });
   const isTransactionConfirmed = Boolean(data && !isLoading);
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef,
+    txHash: data,
+    chainId: contracts.staker!.chain.id,
+    details: "Submitted stake transaction",
+  });
+
   useEffect(() => {
     if (isSuccess && traceRef.current) {
-      attachMiradorTransactionArtifacts(traceRef.current, {
-        chainId: contracts.staker!.chain.id,
-        inputData:
-          config?.request &&
-          "data" in config.request &&
-          typeof config.request.data === "string"
-            ? config.request.data
-            : undefined,
-        txHash: data,
-        txDetails: "Stake transaction",
-      });
       void closeFrontendMiradorFlowTrace(traceRef.current, {
         reason: "staking_submit_succeeded",
         eventName: "staking_submit_succeeded",

--- a/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
+++ b/src/components/Dialogs/DelegateDialog/DelegateDialog.tsx
@@ -39,6 +39,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 export function DelegateDialog({
@@ -160,17 +161,20 @@ export function DelegateDialog({
     }
   }, [didProcessDelegation, didProcessSponsoredDelegation]);
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef: delegationTraceRef,
+    txHash: directDelegationTxHash,
+    chainId: contracts.token.chain.id,
+    details: "Submitted delegation transaction",
+    enabled: !isGasRelayLive,
+  });
+
   useEffect(() => {
     if (isGasRelayLive || !delegationTraceRef.current) {
       return;
     }
 
     if (didProcessDelegation) {
-      attachMiradorTransactionArtifacts(delegationTraceRef.current, {
-        chainId: contracts.token.chain.id,
-        txHash: directDelegationTxHash,
-        txDetails: "Delegation transaction",
-      });
       void closeFrontendMiradorFlowTrace(delegationTraceRef.current, {
         reason: "governance_delegation_succeeded",
         eventName: "governance_delegation_succeeded",
@@ -189,6 +193,7 @@ export function DelegateDialog({
         eventName: "governance_delegation_failed",
         details: {
           delegatee: delegate.address,
+          transactionHash: directDelegationTxHash,
           error: "Delegation transaction failed",
         },
       });
@@ -287,8 +292,6 @@ export function DelegateDialog({
             "data" in request && typeof request.data === "string"
               ? request.data
               : inputData,
-          txHash,
-          txDetails: "Delegation transaction",
         });
         setLocalDelegateTxHash(txHash);
       } catch (error) {

--- a/src/components/Dialogs/UndelegateDialog/UndelegateDialog.tsx
+++ b/src/components/Dialogs/UndelegateDialog/UndelegateDialog.tsx
@@ -30,6 +30,7 @@ import {
   closeFrontendMiradorFlowTrace,
   FrontendMiradorTrace,
   startFrontendMiradorFlowTrace,
+  useAttachMiradorSubmittedTxHash,
 } from "@/lib/mirador/frontendFlowTrace";
 
 interface UndelegateActionButtonsProps {
@@ -186,6 +187,14 @@ export function UndelegateDialog({
     hash: isGasRelayLive ? undefined : delegateTxHash,
   });
 
+  useAttachMiradorSubmittedTxHash({
+    traceRef: delegationTraceRef,
+    txHash: delegateTxHash,
+    chainId: contracts.token.chain.id,
+    details: "Submitted undelegation transaction",
+    enabled: !isGasRelayLive,
+  });
+
   const fetchData = useCallback(async () => {
     setIsReady(false);
     if (!accountAddress) return;
@@ -263,11 +272,6 @@ export function UndelegateDialog({
   useEffect(() => {
     if (didProcessDelegation) {
       if (delegationTraceRef.current) {
-        attachMiradorTransactionArtifacts(delegationTraceRef.current, {
-          chainId: contracts.token.chain.id,
-          txHash: delegateTxHash,
-          txDetails: "Undelegation transaction",
-        });
         void closeFrontendMiradorFlowTrace(delegationTraceRef.current, {
           reason: "governance_delegation_succeeded",
           eventName: "governance_delegation_succeeded",

--- a/src/hooks/__tests__/useSponsoredDelegation.test.tsx
+++ b/src/hooks/__tests__/useSponsoredDelegation.test.tsx
@@ -177,9 +177,9 @@ describe("useSponsoredDelegation", () => {
     expect(attachMiradorTransactionArtifactsMock).toHaveBeenCalledWith(
       { traceId: "trace-id" },
       expect.objectContaining({
-        txHash:
+        submittedTxHash:
           "0x000000000000000000000000000000000000000000000000000000000000000a",
-        txDetails: "Sponsored delegation transaction",
+        submittedTxDetails: "Submitted sponsored delegation transaction",
       })
     );
     expect(result.current.isFetched).toBe(true);

--- a/src/hooks/useAdvancedVoting.tsx
+++ b/src/hooks/useAdvancedVoting.tsx
@@ -165,24 +165,30 @@ const useAdvancedVoting = ({
           args: args as any,
           chainId: contracts.governor.chain.id,
         });
+        attachMiradorTransactionArtifacts(trace, {
+          chainId: contracts.governor.chain.id,
+          submittedTxHash: directTx,
+          submittedTxDetails: "Submitted governance vote transaction",
+        });
         const { status, transactionHash } =
           await wrappedWaitForTransactionReceipt({
             hash: directTx,
             address: address as `0x${string}`,
           });
-        if (status === "success") {
+        if (transactionHash && transactionHash !== directTx) {
           attachMiradorTransactionArtifacts(trace, {
             chainId: contracts.governor.chain.id,
-            inputData,
             submittedTxHash: directTx,
-            submittedTxType: directTx !== transactionHash ? "safe" : "tx",
-            submittedTxDetails:
-              directTx !== transactionHash
-                ? "Submitted Safe governance vote transaction"
-                : "Submitted governance vote transaction",
+            submittedTxType: "safe",
+            submittedTxDetails: "Submitted Safe governance vote transaction",
             txHash: transactionHash,
-            txDetails: "Governance vote transaction",
+            txDetails:
+              status === "success"
+                ? "Governance vote transaction"
+                : "Reverted governance vote transaction",
           });
+        }
+        if (status === "success") {
           await trackEvent({
             event_name: ANALYTICS_EVENT_NAMES.STANDARD_VOTE,
             event_data: {
@@ -277,24 +283,31 @@ const useAdvancedVoting = ({
           args: args as any,
           chainId: contracts.alligator?.chain.id,
         });
+        attachMiradorTransactionArtifacts(trace, {
+          chainId: contracts.alligator?.chain.id,
+          submittedTxHash: advancedTx,
+          submittedTxDetails: "Submitted advanced governance vote transaction",
+        });
         const { status, transactionHash } =
           await wrappedWaitForTransactionReceipt({
             hash: advancedTx,
             address: address as `0x${string}`,
           });
-        if (status === "success") {
+        if (transactionHash && transactionHash !== advancedTx) {
           attachMiradorTransactionArtifacts(trace, {
             chainId: contracts.alligator?.chain.id,
-            inputData,
             submittedTxHash: advancedTx,
-            submittedTxType: advancedTx !== transactionHash ? "safe" : "tx",
+            submittedTxType: "safe",
             submittedTxDetails:
-              advancedTx !== transactionHash
-                ? "Submitted Safe advanced governance vote transaction"
-                : "Submitted advanced governance vote transaction",
+              "Submitted Safe advanced governance vote transaction",
             txHash: transactionHash,
-            txDetails: "Advanced governance vote transaction",
+            txDetails:
+              status === "success"
+                ? "Advanced governance vote transaction"
+                : "Reverted advanced governance vote transaction",
           });
+        }
+        if (status === "success") {
           await trackEvent({
             event_name: ANALYTICS_EVENT_NAMES.ADVANCED_VOTE,
             event_data: {

--- a/src/hooks/useEASV2.ts
+++ b/src/hooks/useEASV2.ts
@@ -115,8 +115,8 @@ export function useEASV2() {
       attachMiradorTransactionArtifacts(trace, {
         chainId: result.chainId ?? chainId,
         inputData: result.txInputData,
-        txHash: getMiradorResultTxHash(result),
-        txDetails,
+        submittedTxHash: getMiradorResultTxHash(result),
+        submittedTxDetails: `Submitted ${txDetails.toLowerCase()}`,
       });
       void closeFrontendMiradorFlowTrace(trace, {
         reason: successEventName,
@@ -134,8 +134,8 @@ export function useEASV2() {
       attachMiradorTransactionArtifacts(trace, {
         chainId: failedTxContext.chainId ?? chainId,
         inputData: failedTxContext.txInputData,
-        txHash: failedTxContext.txHash,
-        txDetails,
+        submittedTxHash: failedTxContext.txHash,
+        submittedTxDetails: `Failed ${txDetails.toLowerCase()}`,
       });
       void closeFrontendMiradorFlowTrace(trace, {
         reason: failureEventName,

--- a/src/hooks/useSponsoredDelegation.ts
+++ b/src/hooks/useSponsoredDelegation.ts
@@ -174,10 +174,10 @@ export const useSponsoredDelegation = ({ address, delegate }: Props) => {
 
       attachMiradorTransactionArtifacts(trace, {
         chainId: contracts.token.chain.id,
-        txHash: relayTxHash,
-        txDetails: isUndelegation
-          ? "Sponsored undelegation transaction"
-          : "Sponsored delegation transaction",
+        submittedTxHash: relayTxHash,
+        submittedTxDetails: isUndelegation
+          ? "Submitted sponsored undelegation transaction"
+          : "Submitted sponsored delegation transaction",
       });
 
       addMiradorEvent(trace, "governance_delegation_submitted", {

--- a/src/hooks/useSponsoredVoting.tsx
+++ b/src/hooks/useSponsoredVoting.tsx
@@ -157,18 +157,17 @@ const useSponsoredVoting = ({
           )
         );
         const voteTxHash = await response.json();
+        attachMiradorTransactionArtifacts(trace, {
+          chainId: contracts.governor.chain.id,
+          submittedTxHash: voteTxHash,
+          submittedTxDetails: "Submitted sponsored governance vote transaction",
+        });
         const { status } = await waitForTransactionReceipt(config, {
           hash: voteTxHash,
           chainId: contracts.governor.chain.id,
         });
 
         if (status === "success") {
-          attachMiradorTransactionArtifacts(trace, {
-            chainId: contracts.governor.chain.id,
-            inputData,
-            txHash: voteTxHash,
-            txDetails: "Sponsored governance vote transaction",
-          });
           setSponsoredVoteTxHash(voteTxHash);
           setSponsoredVoteSuccess(true);
           await trackEvent({

--- a/src/hooks/useStandardVoting.tsx
+++ b/src/hooks/useStandardVoting.tsx
@@ -117,25 +117,33 @@ const useStandardVoting = ({
           chainId: contracts.governor.chain.id,
         });
 
+        attachMiradorTransactionArtifacts(trace, {
+          chainId: contracts.governor.chain.id,
+          submittedTxHash: directTx,
+          submittedTxDetails: "Submitted governance vote transaction",
+        });
+
         const { status, transactionHash } =
           await wrappedWaitForTransactionReceipt({
             hash: directTx,
             address: address as `0x${string}`,
           });
 
-        if (status === "success") {
+        if (transactionHash && transactionHash !== directTx) {
           attachMiradorTransactionArtifacts(trace, {
             chainId: contracts.governor.chain.id,
-            inputData,
             submittedTxHash: directTx,
-            submittedTxType: directTx !== transactionHash ? "safe" : "tx",
-            submittedTxDetails:
-              directTx !== transactionHash
-                ? "Submitted Safe governance vote transaction"
-                : "Submitted governance vote transaction",
+            submittedTxType: "safe",
+            submittedTxDetails: "Submitted Safe governance vote transaction",
             txHash: transactionHash,
-            txDetails: "Governance vote transaction",
+            txDetails:
+              status === "success"
+                ? "Governance vote transaction"
+                : "Reverted governance vote transaction",
           });
+        }
+
+        if (status === "success") {
           setStandardTxHash(transactionHash);
 
           await trackEvent({

--- a/src/lib/mirador/frontendFlowTrace.ts
+++ b/src/lib/mirador/frontendFlowTrace.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { RefObject, useEffect, useRef } from "react";
 import { buildFrontendTraceContext } from "./clientTraceContext";
 import { getMiradorChainNameFromChainId } from "./chains";
 import { isMiradorFlowTracingEnabled } from "./config";
@@ -111,14 +112,20 @@ export function attachMiradorTransactionArtifacts(
     return;
   }
 
-  addMiradorTxInputData(trace, inputData);
+  if (inputData) {
+    addMiradorTxInputData(trace, inputData);
+  }
 
   const miradorChain = getMiradorChainNameFromChainId(chainId);
   if (!miradorChain) {
     return;
   }
 
-  if (submittedTxHash && txHash && submittedTxHash !== txHash) {
+  // Attach the submitted hash whenever it is known and distinct from the
+  // resolved on-chain hash. Calling this at submission time (with `txHash`
+  // absent) lets Mirador begin watching the tx from mempool instead of only
+  // correlating it after the receipt resolves.
+  if (submittedTxHash && submittedTxHash !== txHash) {
     if (submittedTxType === "safe") {
       addMiradorSafeTxHint(
         trace,
@@ -136,10 +143,51 @@ export function attachMiradorTransactionArtifacts(
     }
   }
 
-  const resolvedTxHash = txHash ?? submittedTxHash;
-  if (resolvedTxHash) {
-    addMiradorTxHint(trace, resolvedTxHash, miradorChain, txDetails);
+  if (txHash) {
+    addMiradorTxHint(trace, txHash, miradorChain, txDetails);
   }
+}
+
+/**
+ * Watches a wagmi-style transaction hash and attaches it to the active trace
+ * as a submitted tx hint the moment it becomes defined. This lets Mirador
+ * start watching the tx from mempool — independent of receipt outcome — so
+ * reverted and dropped transactions remain observable.
+ *
+ * Idempotent against repeated renders: the same hash is attached at most once
+ * per component instance.
+ */
+export function useAttachMiradorSubmittedTxHash({
+  traceRef,
+  txHash,
+  chainId,
+  details,
+  enabled = true,
+}: {
+  traceRef: RefObject<FrontendMiradorTrace>;
+  txHash: string | null | undefined;
+  chainId?: number | string;
+  details: string;
+  enabled?: boolean;
+}) {
+  const attachedHashRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (
+      !enabled ||
+      !traceRef.current ||
+      !txHash ||
+      attachedHashRef.current === txHash
+    ) {
+      return;
+    }
+    attachMiradorTransactionArtifacts(traceRef.current, {
+      chainId,
+      submittedTxHash: txHash,
+      submittedTxDetails: details,
+    });
+    attachedHashRef.current = txHash;
+  }, [chainId, details, enabled, traceRef, txHash]);
 }
 
 export async function closeFrontendMiradorFlowTrace(


### PR DESCRIPTION
## Summary

Mirador tx hints were only attached after `wrappedWaitForTransactionReceipt` resolved with `status === "success"`. This made reverted, dropped, and tab-closed-before-confirmation transactions invisible to Mirador, and delayed correlation of every successful tx by the full receipt-wait time.

## What changed

- **Helper**: `attachMiradorTransactionArtifacts` is now safe to call twice (submission + resolution) without double-attaching the same hash.
- **New hook**: `useAttachMiradorSubmittedTxHash` for the wagmi `useWriteContract → useWaitForTransactionReceipt` pattern. Attaches the hash via `useEffect` the moment it's exposed, idempotent across re-renders.
- **21 call sites** updated across:
  - Voting hooks (`useStandardVoting`, `useAdvancedVoting`, `useSponsoredVoting`)
  - Delegation hooks/dialogs (`useSponsoredDelegation`, `DelegateDialog`, `UndelegateDialog`)
  - Proposal admin components (Agora/OZ/Bravo `*GovQueue` / `*GovExecute` / `*GovCancel`)
  - Staking flows (`Deposit`, `PanelSetAllowance`, `NewStakeConfirm`, `EditDepositConfirm`, `EditDelegateConfirm`)
  - EAS attestation helpers (`useEASV2`, `OffchainProposalAction`, `OffchainCancel`)
  - `admin/membership/page.tsx`, `UpdateVotableSupplyOracle`
- `useSponsoredDelegation` test assertions updated to expect `submittedTxHash`/`submittedTxDetails`.

## Test plan

- [ ] `npm run typecheck` — clean for all touched files (pre-existing unrelated errors remain)
- [ ] `npm run lint` — no new errors/warnings introduced
- [ ] `npx vitest run src/hooks/__tests__/useSponsoredDelegation.test.tsx` — passes
- [ ] Manually cast a vote and check Mirador shows the tx hash hint at submission time (mempool watch), not just after receipt
- [ ] Manually trigger a revert (e.g. vote on a closed proposal) and confirm Mirador still shows the tx hash with `Reverted ...` details
