### PR TITLE
Live validation: Claude subscription opens two multi-repo PRs

### DIFF
--- a/docs/dogfood/multi-repo-claude-subscription-two-prs.md
+++ b/docs/dogfood/multi-repo-claude-subscription-two-prs.md
@@ -1,0 +1,18 @@
+# TakeAIt Live Validation — Multi-Repo Claude Subscription (Two PRs)
+
+This file is a disposable live-validation artifact created by the TakeAIt agent system.
+
+**Ticket:** #326
+**Execution profile:** Claude subscription
+**Validation type:** Multi-repository PR creation
+
+## Target repositories
+
+- `voteagora/takeait`
+- `voteagora/agora-next` (this repository)
+
+## Purpose
+
+Validates that the multi-repository runner path correctly opens one PR in each of the two target repositories when using the Claude subscription execution profile.
+
+This file may be safely deleted after the validation PRs are reviewed and merged (or closed).


### PR DESCRIPTION
<!-- takeait:run-summary:start -->
## TakeAIt Run Summary

- Run: `84d2c045-7803-4402-9af6-bf7410cd5b33`
- Ticket: #326
- Engine: Claude - Subscription - claude_code_oauth_token - claude-sonnet-4-6
- Profile: default - 6a0ccdcfbe80
- Branch: `tai-326-Live-validation-Claude-subscription-opens-two-multi-repo-PRs`
- Repository: `voteagora/agora-next` (supporting)
- Checkout path: `voteagora-agora-next`
- Repository PRs:
  - `voteagora/takeait`: https://github.com/voteagora/takeait/pull/132
  - `voteagora/agora-next`: https://github.com/voteagora/agora-next/pull/1562

## Summary
- Added a disposable live-validation Markdown artifact to both `voteagora/takeait` and `voteagora/agora-next` under `docs/dogfood/multi-repo-claude-subscription-two-prs.md`, confirming that the multi-repository runner path can open one PR per repository when using the Claude subscription execution profile (ticket #326).

## Files Or Areas Touched
- `docs/dogfood/multi-repo-claude-subscription-two-prs.md` (new file, new directory) in `voteagora/takeait`
- `docs/dogfood/multi-repo-claude-subscription-two-prs.md` (new file, new directory) in `voteagora/agora-next`

## Verification
- `git diff --check` passed with no output in both repositories (no trailing whitespace or formatting issues).
- No test suites were run, consistent with ticket instructions to skip expensive test runs.
- Changes committed and pushed to branch `tai-326-Live-validation-Claude-subscription-opens-two-multi-repo-PRs` in both repositories.

## User Or Operator Impact
- Two PRs were opened by the runner, one per target repository:
  - `voteagora/takeait`: https://github.com/voteagora/takeait/pull/132
  - `voteagora/agora-next`: https://github.com/voteagora/agora-next/pull/1562
- Each PR adds a single Markdown file that is purely a validation artifact and has no effect on application behavior.

## Risks And Follow-ups
- The added files are disposable; they should be deleted (or the PRs closed without merge) once the validation is confirmed.
- No deployment steps required — no application code was modified.
<!-- takeait:run-summary:end -->