### PR TITLE
Document the agora-next ↔ takeait link in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Companion repo:** [TakeAIt](https://github.com/voteagora/takeait) is the companion AI-native ticket and agent platform used alongside agora-next for governance workflows.
+
 ## Getting Started
 
 1. Git clone this repo


### PR DESCRIPTION
<!-- takeait:run-summary:start -->
## TakeAIt Run Summary

- Run: `4f01b9bb-7ef9-4724-80d6-c8941b5924f6`
- Ticket: #331
- Engine: Claude - Subscription - claude_code_oauth_token - claude-sonnet-4-6
- Profile: default - 6a0ccdcfbe80
- Branch: `tai-331-Document-the-agora-next-takeait-link-in-both-READMEs`
- Repository: `voteagora/agora-next` (supporting)
- Checkout path: `voteagora-agora-next`
- Repository PRs:
  - `voteagora/takeait`: https://github.com/voteagora/takeait/pull/135
  - `voteagora/agora-next`: https://github.com/voteagora/agora-next/pull/1564

## Summary
- Added a cross-reference blockquote note to `README.md` in `voteagora/takeait` pointing to `agora-next` as the companion governance frontend.
- Added a cross-reference blockquote note to `README.md` in `voteagora/agora-next` pointing to `takeait` as the companion AI-native ticket and agent platform.
- No source code was modified; documentation only.

## Files Or Areas Touched
- `voteagora/takeait` — `README.md`: one blockquote line inserted after the intro description (line 3), linking to `agora-next`.
- `voteagora/agora-next` — `README.md`: one blockquote line inserted before the `## Getting Started` section, linking to `takeait`.

## Verification
- No tests applicable (documentation-only change).
- Both commits pushed successfully to branch `tai-331-Document-the-agora-next-takeait-link-in-both-READMEs` in each repository.
- PRs opened: [voteagora/takeait#135](https://github.com/voteagora/takeait/pull/135) and [voteagora/agora-next#1564](https://github.com/voteagora/agora-next/pull/1564).

## User Or Operator Impact
- Visitors to either repository's README will now see a clearly visible companion-repo note near the top, with a direct link to the other repo. No runtime behavior, API, or configuration is affected.

## Risks And Follow-ups
- None. Change is additive and documentation-only; no deployment steps required. Both PRs need human review and merge.
<!-- takeait:run-summary:end -->