### PR TITLE
Fix Mirador wallet outcome handling

### DIFF
--- a/src/hooks/__tests__/useEnsureSiweSession.test.tsx
+++ b/src/hooks/__tests__/useEnsureSiweSession.test.tsx
@@ -12,9 +12,12 @@ const {
   isSafeOffchainMessageTrackingEnabledMock,
   isSafeWalletMock,
   openDialogMock,
+  createMessageMock,
+  verifyMessageMock,
   shouldTrackMiradorSiweLoginMock,
   signMessageAsyncMock,
   signOutMock,
+  useAccountMock,
   waitForStoredSiweJwtMock,
 } = vi.hoisted(() => ({
   clearStoredSafeOffchainSigningStateMock: vi.fn(),
@@ -23,13 +26,17 @@ const {
   isSafeOffchainMessageTrackingEnabledMock: vi.fn(() => false),
   isSafeWalletMock: vi.fn(),
   openDialogMock: vi.fn(),
+  createMessageMock: vi.fn(),
+  verifyMessageMock: vi.fn(),
   shouldTrackMiradorSiweLoginMock: vi.fn(() => false),
   signMessageAsyncMock: vi.fn(),
   signOutMock: vi.fn(),
+  useAccountMock: vi.fn(),
   waitForStoredSiweJwtMock: vi.fn(),
 }));
 
 vi.mock("wagmi", () => ({
+  useAccount: useAccountMock,
   useSignMessage: () => ({ signMessageAsync: signMessageAsyncMock }),
 }));
 
@@ -40,8 +47,8 @@ vi.mock("@tanstack/react-query", () => ({
 vi.mock("@/components/shared/SiweProviderConfig", () => ({
   siweProviderConfig: {
     getNonce: vi.fn().mockResolvedValue("testnonce"),
-    createMessage: vi.fn().mockResolvedValue("test siwe message"),
-    verifyMessage: vi.fn().mockResolvedValue(true),
+    createMessage: createMessageMock,
+    verifyMessage: verifyMessageMock,
   },
 }));
 
@@ -91,8 +98,13 @@ describe("useEnsureSiweSession", () => {
     getStoredSiweJwtMock.mockReturnValue(null);
     isSafeOffchainMessageTrackingEnabledMock.mockReturnValue(false);
     isSafeWalletMock.mockResolvedValue(true);
+    createMessageMock.mockImplementation(({ chainId }) =>
+      Promise.resolve(`test siwe message ${chainId}`)
+    );
+    verifyMessageMock.mockResolvedValue(true);
     signMessageAsyncMock.mockResolvedValue("0xsignature");
     signOutMock.mockResolvedValue(undefined);
+    useAccountMock.mockReturnValue({ connector: undefined });
     waitForStoredSiweJwtMock.mockResolvedValue("safe-jwt");
     shouldTrackMiradorSiweLoginMock.mockReturnValue(false);
   });
@@ -114,10 +126,77 @@ describe("useEnsureSiweSession", () => {
     expect(jwt).toBe("safe-jwt");
     expect(clearStoredSafeOffchainSigningStateMock).toHaveBeenCalledTimes(1);
     expect(clearStoredSiweSessionMock).toHaveBeenCalledTimes(1);
-    expect(signMessageAsyncMock).toHaveBeenCalledTimes(1);
+    expect(signMessageAsyncMock).toHaveBeenCalledWith({
+      message: "test siwe message 1",
+    });
     expect(waitForStoredSiweJwtMock).toHaveBeenCalledWith({
       expectedAddress: "0x1234567890123456789012345678901234567890",
     });
     expect(openDialogMock).not.toHaveBeenCalled();
+  });
+
+  it("retries a connector chain mismatch once using the live connector chain", async () => {
+    const connector = { getChainId: vi.fn().mockResolvedValue(10) };
+    const mismatch = Object.assign(new Error("chain mismatch"), {
+      name: "ConnectorChainMismatchError",
+    });
+    useAccountMock.mockReturnValue({ connector });
+    signMessageAsyncMock
+      .mockRejectedValueOnce(mismatch)
+      .mockResolvedValueOnce("0xsignature");
+
+    const { result } = renderHook(() =>
+      useEnsureSiweSession({
+        address: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+        purpose: "notification_preferences",
+      })
+    );
+
+    await act(async () => {
+      await result.current.ensureSiweSession();
+    });
+
+    expect(createMessageMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ chainId: 1, nonce: "testnonce" })
+    );
+    expect(createMessageMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ chainId: 10, nonce: "testnonce" })
+    );
+    expect(signMessageAsyncMock).toHaveBeenNthCalledWith(1, {
+      message: "test siwe message 1",
+    });
+    expect(signMessageAsyncMock).toHaveBeenNthCalledWith(2, {
+      message: "test siwe message 10",
+      connector,
+    });
+    expect(verifyMessageMock).toHaveBeenCalledWith({
+      message: "test siwe message 10",
+      signature: "0xsignature",
+    });
+  });
+
+  it("does not retry other signing errors", async () => {
+    const connector = { getChainId: vi.fn().mockResolvedValue(10) };
+    useAccountMock.mockReturnValue({ connector });
+    signMessageAsyncMock.mockRejectedValueOnce(new Error("wallet failed"));
+
+    const { result } = renderHook(() =>
+      useEnsureSiweSession({
+        address: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+        purpose: "notification_preferences",
+      })
+    );
+
+    await act(async () => {
+      await expect(result.current.ensureSiweSession()).rejects.toThrow(
+        "wallet failed"
+      );
+    });
+    expect(signMessageAsyncMock).toHaveBeenCalledTimes(1);
+    expect(connector.getChainId).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useEnsureSiweSession.ts
+++ b/src/hooks/useEnsureSiweSession.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useSIWE, SIWE_NONCE_QUERY_KEY } from "connectkit";
 import { useQueryClient } from "@tanstack/react-query";
-import { useSignMessage } from "wagmi";
+import { useAccount, useSignMessage } from "wagmi";
 import { getAddress } from "viem";
 
 import { siweProviderConfig } from "@/components/shared/SiweProviderConfig";
@@ -78,6 +78,7 @@ export function useEnsureSiweSession(params: {
 }) {
   const { address, chainId, purpose } = params;
   const { signOut } = useSIWE();
+  const { connector } = useAccount();
   const { signMessageAsync } = useSignMessage();
   const queryClient = useQueryClient();
   const openDialog = useOpenDialog();
@@ -145,20 +146,38 @@ export function useEnsureSiweSession(params: {
       throw new Error("Wallet not connected");
     }
     const nonce = await siweProviderConfig.getNonce();
-    const message = await siweProviderConfig.createMessage({
+    let message = await siweProviderConfig.createMessage({
       // siwe library requires EIP-55 checksummed address; params.address is lowercased
       address: getAddress(address),
       chainId,
       nonce,
     });
-    const signature = await signMessageAsync({ message });
+    let signature: `0x${string}`;
+    try {
+      signature = await signMessageAsync({ message });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        error.name !== "ConnectorChainMismatchError" ||
+        !connector
+      ) {
+        throw error;
+      }
+
+      message = await siweProviderConfig.createMessage({
+        address: getAddress(address),
+        chainId: await connector.getChainId(),
+        nonce,
+      });
+      signature = await signMessageAsync({ message, connector });
+    }
     const success = await siweProviderConfig.verifyMessage({
       message,
       signature,
     });
     void queryClient.invalidateQueries({ queryKey: [SIWE_NONCE_QUERY_KEY] });
     return success;
-  }, [address, chainId, signMessageAsync, queryClient]);
+  }, [address, chainId, connector, signMessageAsync, queryClient]);
 
   const openSafeSiweDialog = useCallback(
     (options?: EnsureSiweSessionOptions) => {

--- a/src/lib/mirador/__tests__/eventSeverity.test.ts
+++ b/src/lib/mirador/__tests__/eventSeverity.test.ts
@@ -81,4 +81,78 @@ describe("inferMiradorEventSeverity", () => {
       })
     ).toBe("error");
   });
+
+  it.each([
+    [
+      "governance_vote_failed",
+      {
+        voteKind: "standard",
+        error: "Connect your wallet before submitting this transaction.",
+      },
+    ],
+    [
+      "governance_delegation_failed",
+      { error: "RPC endpoint returned too many errors, retrying shortly." },
+    ],
+    [
+      "governance_vote_failed",
+      { voteKind: "sponsored", error: "The device must be opened first." },
+    ],
+    [
+      "governance_vote_failed",
+      { voteKind: "standard", error: "Extension context invalidated." },
+    ],
+    [
+      "governance_vote_failed",
+      {
+        voteKind: "standard",
+        error: "nonce too low: next nonce 95, tx nonce 94",
+      },
+    ],
+    [
+      "governance_vote_failed",
+      {
+        voteKind: "standard",
+        error: "GovernorVotingSimple: vote already cast",
+      },
+    ],
+    [
+      "governance_vote_failed",
+      {
+        voteKind: "standard",
+        error: "insufficient funds for gas * price + value",
+      },
+    ],
+    [
+      "siwe_login_failed",
+      { message: "Cannot read properties of undefined (reading 'includes')" },
+    ],
+    ["siwe_login_failed", { message: "Request expired. Please try again." }],
+  ])("downgrades a known client outcome for %s", (eventName, details) => {
+    expect(inferMiradorEventSeverity(eventName, details)).toBe("warn");
+  });
+
+  it("treats wallet scan cancellation as info", () => {
+    expect(
+      inferMiradorEventSeverity("governance_delegation_failed", {
+        error: "Keyring Controller signTypedMessage: Scan cancelled",
+      })
+    ).toBe("info");
+  });
+
+  it.each([
+    ["relay_vote_submission_failed", { error: "nonce too low" }],
+    ["siwe_login_failed", { error: "An internal error has occurred" }],
+    ["governance_vote_failed", { error: "Error processing the transaction" }],
+    [
+      "governance_vote_failed",
+      { voteKind: "sponsored", error: "nonce too low" },
+    ],
+    [
+      "governance_vote_failed",
+      { voteKind: "standard", error: "tx hint expired after 6 hours" },
+    ],
+  ])("keeps an actionable failure for %s as error", (eventName, details) => {
+    expect(inferMiradorEventSeverity(eventName, details)).toBe("error");
+  });
 });

--- a/src/lib/mirador/eventSeverity.ts
+++ b/src/lib/mirador/eventSeverity.ts
@@ -15,6 +15,8 @@ const USER_CANCELLATION_MESSAGE_PATTERNS = [
   "denied message signature",
   "rejected the request",
   "rejected signature",
+  "scan cancelled",
+  "scan canceled",
   "exited_link_flow",
   "exited_update_flow",
 ];
@@ -27,6 +29,27 @@ const WALLET_TRANSPORT_ERROR_PATTERNS = [
   "failed to publish payload",
   "rpc endpoint returned http client error",
   "details: invalid id",
+];
+
+const SIWE_WALLET_OUTCOME_PATTERNS = [
+  "cannot read properties of undefined (reading 'includes')",
+  "request expired. please try again",
+];
+
+const GOVERNANCE_WALLET_OUTCOME_PATTERNS = [
+  "connect your wallet before submitting this transaction",
+  "wallet connection is still reconnecting",
+  "wallet connection is still initializing",
+  "rpc endpoint returned too many errors",
+  "the device must be opened first",
+  "extension context invalidated",
+];
+
+const STANDARD_VOTE_OUTCOME_PATTERNS = [
+  "nonce too low",
+  "vote already cast",
+  "voter already voted",
+  "insufficient funds for gas",
 ];
 
 function collectDetailValues(value: unknown, values: string[], depth = 0) {
@@ -124,6 +147,40 @@ export function isWalletTransportError(details?: unknown): boolean {
   });
 }
 
+function hasDetailPattern(details: unknown, patterns: string[]) {
+  const values: string[] = [];
+  collectDetailValues(details, values);
+  return values.some((value) => {
+    const normalized = value.trim().toLowerCase();
+    return patterns.some((pattern) => normalized.includes(pattern));
+  });
+}
+
+function isExpectedWalletOutcome(eventName: string, details?: unknown) {
+  if (eventName === "siwe_login_failed") {
+    return hasDetailPattern(details, SIWE_WALLET_OUTCOME_PATTERNS);
+  }
+
+  if (
+    eventName !== "governance_vote_failed" &&
+    eventName !== "governance_delegation_failed"
+  ) {
+    return false;
+  }
+
+  if (hasDetailPattern(details, GOVERNANCE_WALLET_OUTCOME_PATTERNS)) {
+    return true;
+  }
+
+  return (
+    eventName === "governance_vote_failed" &&
+    typeof details === "object" &&
+    details !== null &&
+    (details as Record<string, unknown>).voteKind === "standard" &&
+    hasDetailPattern(details, STANDARD_VOTE_OUTCOME_PATTERNS)
+  );
+}
+
 export function inferMiradorEventSeverity(
   eventName: string,
   details?: unknown
@@ -133,6 +190,10 @@ export function inferMiradorEventSeverity(
   }
 
   if (isWalletTransportError(details)) {
+    return "warn";
+  }
+
+  if (isExpectedWalletOutcome(eventName, details)) {
     return "warn";
   }
 


### PR DESCRIPTION
## What changed

- Retry SIWE signing once through the live connector only after an exact Wagmi connector-chain mismatch, reusing the same nonce and without switching networks.
- Classify only exact, flow-scoped wallet and user outcomes as info/warn.
- Keep relay nonce failures, generic RPC failures, unknown reverts, and confirmation timeouts as errors.
- Add regression coverage for the happy path, mismatch recovery, no-retry failures, and severity boundaries.

## Why

The Mirador synthesis mixed real SIWE failures with expected wallet outcomes. This fixes the supported Optimism SIWE mismatch while preventing known client conditions from creating error tickets, without changing successful app, UI, or transaction flows.

Uniswap and sponsored-relay recovery are intentionally out of scope.

## Checks

- `npm test -- --run src/hooks/__tests__/useEnsureSiweSession.test.tsx src/lib/mirador/__tests__/eventSeverity.test.ts` — 26 passed
- Scoped ESLint — passed
- Full typecheck could not run in the temporary shallow clone because generated/LFS assets were unavailable; CI remains authoritative.