### PR TITLE
fix(civic): paginate NFT lookup during account deletion

### DIFF
--- a/src/app/api/v1/account/burnMembershipNft.test.ts
+++ b/src/app/api/v1/account/burnMembershipNft.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  encodeErrorResult,
+  parseAbi,
+} from "viem";
+import { burnMembershipNfts } from "./burnMembershipNft";
+
+const { client, writeContract } = vi.hoisted(() => ({
+  client: {
+    getBlockNumber: vi.fn(),
+    readContract: vi.fn(),
+    getLogs: vi.fn(),
+    simulateContract: vi.fn(),
+    waitForTransactionReceipt: vi.fn(),
+  },
+  writeContract: vi.fn(),
+}));
+
+vi.mock("@/lib/viem", () => ({ getPublicClient: () => client }));
+vi.mock("@/lib/utils", () => ({ getTransportForChain: vi.fn() }));
+vi.mock("@/lib/tenant/tenant", () => ({
+  default: {
+    current: () => ({
+      contracts: {
+        token: {
+          address: "0x2d0886464a7175a6d7b10aaa6942c49232bd8d1f",
+          chain: { id: 8453 },
+          isERC721: () => true,
+        },
+      },
+    }),
+  },
+}));
+vi.mock("viem", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("viem")>()),
+  createWalletClient: () => ({ writeContract }),
+}));
+
+const OWNER = "0xedc0720e5c529ca25204363e2c51e809350ddb5c";
+const DEPLOY_BLOCK = 48_296_940n;
+const HEAD = DEPLOY_BLOCK + 25_000n;
+const HASH = `0x${"ab".repeat(32)}`;
+const errorAbi = parseAbi(["error NonexistentToken(uint256 tokenId)"]);
+let ownedIds: Set<bigint>;
+let transfers: Array<{ block: bigint; tokenId?: bigint }>;
+
+describe("burnMembershipNfts", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubEnv("MEMBERSHIP_BURNER_PK", `0x${"01".repeat(32)}`);
+    ownedIds = new Set([12n]);
+    transfers = [{ block: DEPLOY_BLOCK + 10_000n, tokenId: 12n }];
+    client.getBlockNumber.mockResolvedValue(HEAD);
+    client.readContract.mockImplementation(({ functionName, args, abi }) => {
+      if (functionName === "balanceOf") return BigInt(ownedIds.size);
+      const tokenId = args[0];
+      if (ownedIds.has(tokenId)) return OWNER;
+      throw new BaseError("Contract call failed", {
+        cause: new ContractFunctionRevertedError({
+          abi,
+          data: encodeErrorResult({
+            abi: errorAbi,
+            errorName: "NonexistentToken",
+            args: [tokenId],
+          }),
+          functionName: "ownerOf",
+        }),
+      });
+    });
+    client.getLogs.mockImplementation(
+      ({
+        fromBlock,
+        toBlock,
+      }: {
+        fromBlock: bigint;
+        toBlock: bigint | "latest";
+      }) => {
+        const end = toBlock === "latest" ? HEAD : toBlock;
+        if (end - fromBlock + 1n > 10_000n) {
+          throw new Error("getLogs request exceeded max allowed range");
+        }
+        return transfers
+          .filter(({ block }) => block >= fromBlock && block <= end)
+          .map(({ tokenId }) => ({ args: { tokenId } }));
+      }
+    );
+    client.simulateContract.mockImplementation((request) => ({ request }));
+    writeContract.mockImplementation(({ args }) => {
+      ownedIds.delete(args[0]);
+      return HASH;
+    });
+    client.waitForTransactionReceipt.mockResolvedValue({ status: "success" });
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("pages within the RPC limit and stops once every owned token is found", async () => {
+    await burnMembershipNfts(OWNER);
+
+    expect(
+      client.getLogs.mock.calls.map(([{ fromBlock, toBlock }]) => [
+        fromBlock,
+        toBlock,
+      ])
+    ).toEqual([
+      [HEAD - 9_999n, HEAD],
+      [HEAD - 19_999n, HEAD - 10_000n],
+    ]);
+    expect(writeContract).toHaveBeenCalledOnce();
+    expect(writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ args: [12n] })
+    );
+    const reads = client.readContract.mock.calls.map(([request]) => request);
+    expect(
+      reads.slice(0, -1).every((request) => request.blockNumber === HEAD)
+    ).toBe(true);
+    expect(reads.at(-1)).toMatchObject({
+      functionName: "balanceOf",
+      args: [OWNER],
+    });
+    expect(reads.at(-1)).not.toHaveProperty("blockNumber");
+  });
+
+  it("covers page boundaries and the deployment block, retaining token zero and deduplicating IDs", async () => {
+    transfers = [0n, 5_000n, 5_001n, 15_000n, 15_001n, 25_000n].map(
+      (offset, index) => ({
+        block: DEPLOY_BLOCK + offset,
+        tokenId: BigInt(index),
+      })
+    );
+    ownedIds = new Set(transfers.map(({ tokenId }) => tokenId!));
+    transfers.push(transfers[4], { block: HEAD });
+
+    await burnMembershipNfts(OWNER);
+
+    expect(client.getLogs).toHaveBeenCalledTimes(3);
+    expect(client.getLogs).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fromBlock: DEPLOY_BLOCK,
+        toBlock: DEPLOY_BLOCK + 5_000n,
+      })
+    );
+    expect(
+      writeContract.mock.calls.map(([{ args }]) => args[0]).sort()
+    ).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+  });
+
+  it("skips the decoded NonexistentToken error for a previously burned token", async () => {
+    transfers.push({ block: HEAD, tokenId: 99n });
+
+    await burnMembershipNfts(OWNER);
+
+    expect(client.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "ownerOf",
+        args: [99n],
+      })
+    );
+    expect(writeContract).toHaveBeenCalledOnce();
+  });
+
+  it.each(["logs", "ownership", "unexpected revert"])(
+    "propagates %s errors without submitting burns",
+    async (failure) => {
+      const error =
+        failure === "unexpected revert"
+          ? new ContractFunctionRevertedError({
+              abi: errorAbi,
+              functionName: "ownerOf",
+              message: "execution reverted",
+            })
+          : new Error("RPC unavailable");
+      if (failure === "logs") client.getLogs.mockRejectedValue(error);
+      else
+        client.readContract.mockImplementation(({ functionName }) => {
+          if (functionName === "balanceOf") return 1n;
+          throw error;
+        });
+
+      await expect(burnMembershipNfts(OWNER)).rejects.toBe(error);
+      expect(writeContract).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([false, true])(
+    "rejects incomplete discovery before burning (partial: %s)",
+    async (partial) => {
+      if (partial) ownedIds.add(13n);
+      else transfers = [];
+
+      await expect(burnMembershipNfts(OWNER)).rejects.toThrow(
+        "Could not find all membership NFTs"
+      );
+      expect(writeContract).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects a failed burn receipt", async () => {
+    client.waitForTransactionReceipt.mockResolvedValue({ status: "reverted" });
+
+    await expect(burnMembershipNfts(OWNER)).rejects.toThrow(
+      "Membership NFT burn reverted"
+    );
+  });
+
+  it("rejects deletion when the post-burn balance remains positive", async () => {
+    writeContract.mockResolvedValue(HASH);
+
+    await expect(burnMembershipNfts(OWNER)).rejects.toThrow(
+      "Membership NFT balance is not zero after burning"
+    );
+  });
+
+  it("skips discovery and signing for a zero-balance retry", async () => {
+    ownedIds.clear();
+    vi.stubEnv("MEMBERSHIP_BURNER_PK", "");
+
+    await burnMembershipNfts(OWNER);
+
+    expect(client.getLogs).not.toHaveBeenCalled();
+    expect(writeContract).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/account/burnMembershipNft.ts
+++ b/src/app/api/v1/account/burnMembershipNft.ts
@@ -2,6 +2,8 @@ import Tenant from "@/lib/tenant/tenant";
 import { getTransportForChain } from "@/lib/utils";
 import { getPublicClient } from "@/lib/viem";
 import {
+  BaseError,
+  ContractFunctionRevertedError,
   createWalletClient,
   isAddressEqual,
   isHex,
@@ -18,11 +20,15 @@ const membershipAbi = parseAbi([
   "function balanceOf(address owner) view returns (uint256)",
   "function ownerOf(uint256 tokenId) view returns (address)",
   "function burn(uint256 tokenId)",
+  "error NonexistentToken(uint256 tokenId)",
 ]);
 
 const transferEvent = parseAbiItem(
   "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
 );
+
+const DEPLOYMENT_BLOCK = 48_296_940n; // Civic membership token on Base
+const LOG_BLOCK_RANGE = 10_000n; // Goldsky's supported query range
 
 export async function burnMembershipNfts(owner: `0x${string}`) {
   const { contracts } = Tenant.current();
@@ -33,12 +39,14 @@ export async function burnMembershipNfts(owner: `0x${string}`) {
 
   const tokenAddress = token.address as `0x${string}`;
   const publicClient = getPublicClient();
+  const blockNumber = await publicClient.getBlockNumber();
 
   const balance = await publicClient.readContract({
     address: tokenAddress,
     abi: membershipAbi,
     functionName: "balanceOf",
     args: [owner],
+    blockNumber,
   });
   if (balance === 0n) {
     return;
@@ -51,42 +59,62 @@ export async function burnMembershipNfts(owner: `0x${string}`) {
     );
   }
 
-  // The contract is not enumerable, so token ids are recovered from mint
-  // transfers and confirmed with ownerOf (which reverts for burned ids).
-  const logs = await publicClient.getLogs({
-    address: tokenAddress,
-    event: transferEvent,
-    args: { to: owner },
-    // Civic token deploy block on Base; anchoring here keeps the scan
-    // window small. Chunk the range if the RPC ever caps it.
-    fromBlock: 48297405n,
-    toBlock: "latest",
-  });
-  const candidateIds = [
-    ...new Set(logs.map((log) => log.args.tokenId).filter(Boolean)),
-  ] as bigint[];
-
+  // The token is not enumerable. Search recent transfers first and confirm
+  // ownership at the same block as the balance, skipping previously burned ids.
+  // ponytail: history scans grow with token age; use indexed ids if they outgrow the request timeout.
   const ownedIds: bigint[] = [];
-  for (const tokenId of candidateIds) {
-    try {
-      const currentOwner = await publicClient.readContract({
-        address: tokenAddress,
-        abi: membershipAbi,
-        functionName: "ownerOf",
-        args: [tokenId],
-      });
-      if (isAddressEqual(currentOwner, owner)) {
-        ownedIds.push(tokenId);
+  const seenIds = new Set<bigint>();
+  let toBlock = blockNumber;
+  while (toBlock >= DEPLOYMENT_BLOCK && BigInt(ownedIds.length) < balance) {
+    const start = toBlock - LOG_BLOCK_RANGE + 1n;
+    const fromBlock = start < DEPLOYMENT_BLOCK ? DEPLOYMENT_BLOCK : start;
+    const logs = await publicClient.getLogs({
+      address: tokenAddress,
+      event: transferEvent,
+      args: { to: owner },
+      fromBlock,
+      toBlock,
+    });
+
+    for (const {
+      args: { tokenId },
+    } of logs) {
+      if (tokenId === undefined || seenIds.has(tokenId)) continue;
+      seenIds.add(tokenId);
+      try {
+        const currentOwner = await publicClient.readContract({
+          address: tokenAddress,
+          abi: membershipAbi,
+          functionName: "ownerOf",
+          args: [tokenId],
+          blockNumber,
+        });
+        if (isAddressEqual(currentOwner, owner)) {
+          ownedIds.push(tokenId);
+        }
+      } catch (error) {
+        if (
+          error instanceof BaseError &&
+          error.walk(
+            (cause) =>
+              cause instanceof ContractFunctionRevertedError &&
+              cause.data?.errorName === "NonexistentToken"
+          )
+        ) {
+          continue;
+        }
+        throw error;
       }
-    } catch {
-      // burned or invalid id
+      if (BigInt(ownedIds.length) === balance) {
+        break;
+      }
     }
-    if (BigInt(ownedIds.length) === balance) {
-      break;
-    }
+    toBlock = fromBlock - 1n;
   }
-  if (ownedIds.length === 0) {
-    return;
+  if (BigInt(ownedIds.length) !== balance) {
+    throw new Error(
+      `Could not find all membership NFTs (found ${ownedIds.length}, expected ${balance})`
+    );
   }
 
   const account = privateKeyToAccount(burnerKey);
@@ -111,5 +139,15 @@ export async function burnMembershipNfts(owner: `0x${string}`) {
         `Membership NFT burn reverted (tokenId ${tokenId}, tx ${hash})`
       );
     }
+  }
+
+  const remainingBalance = await publicClient.readContract({
+    address: tokenAddress,
+    abi: membershipAbi,
+    functionName: "balanceOf",
+    args: [owner],
+  });
+  if (remainingBalance !== 0n) {
+    throw new Error("Membership NFT balance is not zero after burning");
   }
 }

--- a/src/app/api/v1/account/burnMembershipNft.ts
+++ b/src/app/api/v1/account/burnMembershipNft.ts
@@ -1,6 +1,3 @@
-import Tenant from "@/lib/tenant/tenant";
-import { getTransportForChain } from "@/lib/utils";
-import { getPublicClient } from "@/lib/viem";
 import {
   BaseError,
   ContractFunctionRevertedError,
@@ -12,6 +9,9 @@ import {
   zeroAddress,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import Tenant from "@/lib/tenant/tenant";
+import { getTransportForChain } from "@/lib/utils";
+import { getPublicClient } from "@/lib/viem";
 
 // The generated Membership__factory ABI is stale vs. the deployed contract
 // (it has safeMint(address); the chain has mint(address[])), so the calls we
@@ -59,8 +59,8 @@ export async function burnMembershipNfts(owner: `0x${string}`) {
     );
   }
 
-  // The token is not enumerable. Search recent transfers first and confirm
-  // ownership at the same block as the balance, skipping previously burned ids.
+  // Not enumerable: ids only exist in Transfer logs. Reads share one block so
+  // the balance and the ownership checks cannot disagree.
   // ponytail: history scans grow with token age; use indexed ids if they outgrow the request timeout.
   const ownedIds: bigint[] = [];
   const seenIds = new Set<bigint>();

--- a/src/app/api/v1/account/route.ts
+++ b/src/app/api/v1/account/route.ts
@@ -1,5 +1,6 @@
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+export const maxDuration = 300;
 
 import { NextResponse, type NextRequest } from "next/server";
 import { createRemoteJWKSet, jwtVerify } from "jose";


### PR DESCRIPTION
Civic account deletion fails before burning its membership NFT because a single transfer-log query spans roughly 2.8 million blocks. Goldsky rejects it with `getLogs request exceeded max allowed range`, which the API reports as `Failed to burn membership NFT`.

Query logs backward in 10,000-block pages and stop once every owned NFT is found. Pin discovery reads to one block, include the token's earliest mints and token ID zero, and abort on RPC failures or incomplete discovery. Only skip the contract's decoded `NonexistentToken` error, and require a zero balance after confirmed burns before deleting account data. Set the route timeout to 300 seconds for discovery and transaction confirmation.

Validation:
- All 18 helper and account-route tests pass, including oversized RPC ranges, page boundaries, token zero, burned tokens, incomplete discovery, failed receipts, and zero-balance retries.
- Full TypeScript check, lint on changed files, and formatting checks pass.
- Read-only checks using the implemented helper against Civic's Goldsky endpoint found token 12 in 99 requests (~49 seconds) and token 2 in 251 requests (~66 seconds). Both burn simulations succeeded; no transactions were submitted.

Discovery time still grows with token age. The production signer configuration and the original request's server log could not be checked because the saved Vercel login has expired.
