### PR TITLE
test(civic): fix unit tests broken by import-time tenant access

### DIFF
--- a/src/app/notification-preferences/components/__tests__/NotificationPreferencesClient.test.tsx
+++ b/src/app/notification-preferences/components/__tests__/NotificationPreferencesClient.test.tsx
@@ -23,6 +23,10 @@ import {
 import { isSafeWallet } from "@/lib/utils";
 import NotificationPreferencesClient from "../NotificationPreferencesClient";
 
+vi.mock("@/lib/tenant/tenant", () => ({
+  default: { current: () => ({ ui: { toggle: () => undefined } }) },
+}));
+
 vi.mock("wagmi", () => ({
   useAccount: vi.fn(),
   useSignMessage: () => ({ signMessageAsync: signMessageAsyncMock }),

--- a/src/components/DelegateStatement/__tests__/DelegateStatementForm.test.tsx
+++ b/src/components/DelegateStatement/__tests__/DelegateStatementForm.test.tsx
@@ -44,6 +44,10 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
+vi.mock("@/components/Dialogs/DialogProvider/DialogProvider", () => ({
+  useOpenDialog: () => vi.fn(),
+}));
+
 vi.mock("wagmi", () => ({
   useAccount: vi.fn(() => ({
     address: "0x1234567890123456789012345678901234567890",
@@ -138,6 +142,7 @@ vi.mock("@/lib/tenant/tenant", async () => {
       current: () => ({
         ui: {
           copy: getTenantCopy("dao"),
+          toggle: () => undefined,
           governanceIssues: [],
           governanceStakeholders: [],
         },

--- a/src/components/Forum/ForumSurvey.test.tsx
+++ b/src/components/Forum/ForumSurvey.test.tsx
@@ -21,6 +21,10 @@ const mocks = vi.hoisted(() => ({
   getAuthenticationData: vi.fn(),
 }));
 
+vi.mock("@/lib/tenant/tenant", () => ({
+  default: { current: () => ({}) },
+}));
+
 vi.mock("@privy-io/react-auth", () => ({
   usePrivy: () => ({
     authenticated: mocks.authenticated,

--- a/src/components/Forum/ForumSurveyBuilder.test.tsx
+++ b/src/components/Forum/ForumSurveyBuilder.test.tsx
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SurveyDefinitionInput } from "@/lib/actions/forum/surveys";
 import { validateSurveyDefinition } from "./ForumSurveyBuilder";
+
+vi.mock("@/lib/tenant/tenant", () => ({
+  default: { current: () => ({}) },
+}));
 
 describe("validateSurveyDefinition", () => {
   it("accepts a valid poll", () => {

--- a/src/lib/votingPowerUtils.test.ts
+++ b/src/lib/votingPowerUtils.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tenant/tenant", () => ({
+  default: { current: () => ({}) },
+}));
+
+vi.mock("@/app/lib/dao-node/server-client", () => ({
+  getDelegateVotingPowerFromDaoNode: vi.fn(),
+}));
 
 import { formatVotingPower, formatVotingPowerString } from "./votingPowerUtils";
 


### PR DESCRIPTION
Every Unit Tests run on `deploy/civic` has failed since 2026-08-17, including the base of #1577. Five test files die before running because the Privy login change (#1567) and the forum survey tests (efde9952) reach `Tenant.current()` at import or render time without mocking it, and the constructor throws on the missing `NEXT_PUBLIC_RPC_SECRET`. `main` is green because none of those paths exist there.

Per-file fixes, following the tenant-mock pattern the rest of the suite already uses:

- `ForumSurvey.test.tsx`, `ForumSurveyBuilder.test.tsx`, `votingPowerUtils.test.ts`: mock the tenant so `src/lib/utils.ts` can be imported. The voting power test also mocks the dao-node client, which pulls Prisma in and needs `DATABASE_URL`.
- `NotificationPreferencesClient.test.tsx`: mock the tenant with a `ui.toggle` for the new Privy check.
- `DelegateStatementForm.test.tsx`: mock `DialogProvider`, which now drags in the web3 provider module and its import-time tenant reads, and give the tenant mock a `ui.toggle` for the delete-account check.

A global env default in `setupTests.ts` was tried first and rejected: it makes the trace tests tag every span with the tenant name and breaks their exact-tag assertions.

Validation: full `vitest run` with `NEXT_PUBLIC_RPC_SECRET`, `NEXT_PUBLIC_AGORA_INSTANCE_NAME`, and `DATABASE_URL` unset and `NEXT_PUBLIC_AGORA_ENV=dev` passes 101 files, 588 tests. Prettier and ESLint pass on the changed files.

https://claude.ai/code/session_01AvZYrKNFSHLQzdsrAgJiH6
